### PR TITLE
feat: export typed slot prop interfaces per component

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -39,6 +39,7 @@ npm run lint:fix      # Auto-fix style issues
 - **`types.ts` files** contain only `type` and `interface` declarations — no `const`, `enum`, or runtime values
 - **`constants.ts` files** contain `const`, `enum`, and other runtime value exports
 - **Object type checks**: Always use the `isObject()` helper from `@vuecs/core/src/utils/object.ts`. Never use inline `typeof x === 'object' && x !== null` checks
+- **Typed slot props**: Every component slot must have an exported slot-prop type (e.g. `ListItemSlotProps`, `NavItemLinkSlotProps`, `CountdownSlotProps`) wired into the component's `SlotsType<...>`. Render-function consumers rely on these exports for type safety (#1488). Use generics (`<T>`, `<META>`) for entity-typed props.
 
 ## Build
 

--- a/packages/countdown/README.md
+++ b/packages/countdown/README.md
@@ -10,6 +10,7 @@ Countdown timer component for Vue 3 with auto-start, visibility handling, and sc
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Props](#props)
+- [Typed Slot Props](#typed-slot-props)
 - [Exposed Methods](#exposed-methods)
 - [License](#license)
 
@@ -46,6 +47,20 @@ app.use(countdown);
 | `interval` | `number` | `1000` | Progress interval in milliseconds |
 | `tag` | `string` | `'span'` | Root element tag |
 | `emitEvents` | `boolean` | `true` | Emit start/progress/abort/end events |
+
+## Typed Slot Props
+
+The `default` slot scope is typed via the exported `CountdownSlotProps` interface:
+
+```typescript
+import { VCCountdown, type CountdownSlotProps } from '@vuecs/countdown';
+
+h(VCCountdown, { time: 60_000 }, {
+    default: (props: CountdownSlotProps) => `${props.minutes}:${props.seconds}`,
+});
+```
+
+Fields: `days`, `hours`, `minutes`, `seconds`, `milliseconds`, `totalDays`, `totalHours`, `totalMinutes`, `totalSeconds`, `totalMilliseconds`.
 
 ## Exposed Methods
 

--- a/packages/form-controls/README.md
+++ b/packages/form-controls/README.md
@@ -10,6 +10,8 @@ Form input components for Vue 3 with validation support, v-model binding, and th
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Components](#components)
+- [Debounced Input](#debounced-input)
+- [Typed Slot Props](#typed-slot-props)
 - [Theme Slots](#theme-slots)
 - [License](#license)
 
@@ -77,6 +79,30 @@ watch(query, (value) => {
     <VCFormInput v-model="query" :debounce="200" placeholder="Search..." />
 </template>
 ```
+
+## Typed Slot Props
+
+Slot prop interfaces are exported for render-function consumers:
+
+```typescript
+import {
+    VCFormInput,
+    type FormInputGroupSlotProps,
+} from '@vuecs/form-controls';
+
+h(VCFormInput, { modelValue: '', group: true }, {
+    groupPrepend: (props: FormInputGroupSlotProps) =>
+        h(props.tag, { class: props.class }, '@'),
+});
+```
+
+| Export | Used by |
+|--------|---------|
+| `FormInputGroupSlotProps` | `VCFormInput` `groupPrepend`/`groupAppend` |
+| `FormInputCheckboxLabelSlotProps` | `VCFormInputCheckbox` `label` |
+| `ValidationGroupDefaultSlotProps` | `VCValidationGroup` default |
+| `ValidationGroupItemSlotProps` | `VCValidationGroup` `item` |
+| `FormSelectSearchSelectedSlotProps` | `VCFormSelectSearch` `selected` |
 
 ## Theme Slots
 

--- a/packages/form-controls/src/components/form-input/component.ts
+++ b/packages/form-controls/src/components/form-input/component.ts
@@ -33,6 +33,11 @@ const themeDefaults = {
     },
 };
 
+export type FormInputGroupSlotProps = {
+    class: string;
+    tag: string;
+};
+
 export const VCFormInput = defineComponent({
     name: 'VCFormInput',
     props: {
@@ -49,8 +54,8 @@ export const VCFormInput = defineComponent({
     },
     emits: ['update:modelValue'],
     slots: Object as SlotsType<{
-        groupAppend: { class: string; tag: string };
-        groupPrepend: { class: string; tag: string };
+        groupAppend: FormInputGroupSlotProps;
+        groupPrepend: FormInputGroupSlotProps;
     }>,
     setup(props, {
         attrs,

--- a/packages/form-controls/src/components/form-select-search/FormSelectSearch.vue
+++ b/packages/form-controls/src/components/form-select-search/FormSelectSearch.vue
@@ -1,14 +1,14 @@
 <script lang="ts">
 import {
-    onClickOutside, 
+    onClickOutside,
     useInfiniteScroll,
 } from '@vueuse/core';
 import type { PropType } from 'vue';
 import {
     computed,
-    defineComponent, 
-    ref, 
-    toRef, 
+    defineComponent,
+    ref,
+    toRef,
     watch,
 } from 'vue';
 import type { FormSelectOption } from '../form-select';

--- a/packages/form-controls/src/components/form-select-search/index.ts
+++ b/packages/form-controls/src/components/form-select-search/index.ts
@@ -1,1 +1,2 @@
 export { default as VCFormSelectSearch } from './FormSelectSearch.vue';
+export * from './type';

--- a/packages/form-controls/src/components/form-select-search/type.ts
+++ b/packages/form-controls/src/components/form-select-search/type.ts
@@ -1,0 +1,11 @@
+import type { FormSelectOption } from '../form-select';
+
+export type FormSelectSearchSelectedSlotProps = {
+    items: FormSelectOption[];
+    toggle: (option: FormSelectOption) => void;
+};
+
+export type FormSelectSearchEntrySlotProps = {
+    entry: FormSelectOption;
+    active: boolean;
+};

--- a/packages/form-controls/src/components/validation-group/module.ts
+++ b/packages/form-controls/src/components/validation-group/module.ts
@@ -22,6 +22,21 @@ declare module '@vuecs/core' {
 
 const themeDefaults = { classes: { item: 'form-group-hint group-required' } };
 
+export type ValidationGroupDefaultSlotProps = {
+    data: ValidationMessagesArrayStyle;
+    severity: `${ValidationSeverity}`;
+    itemClass: string;
+    itemTag: string;
+};
+
+export type ValidationGroupItemSlotProps = {
+    key: string;
+    value: string;
+    class: string;
+    tag: string;
+    severity: `${ValidationSeverity}`;
+};
+
 export const VCValidationGroup = defineComponent({
     name: 'VCValidationGroup',
     props: {
@@ -32,8 +47,8 @@ export const VCValidationGroup = defineComponent({
         themeVariant: { type: Object as PropType<VariantValues>, default: undefined },
     },
     slots: Object as SlotsType<{
-        default: any;
-        item: any;
+        default: ValidationGroupDefaultSlotProps;
+        item: ValidationGroupItemSlotProps;
     }>,
     setup(props, { slots }) {
         const theme = useComponentTheme('validationGroup', toRef(props, 'themeClass'), themeDefaults, toRef(props, 'themeVariant'));

--- a/packages/list-controls/README.md
+++ b/packages/list-controls/README.md
@@ -11,6 +11,7 @@ List display components for Vue 3 with header, footer, body, loading state, empt
 - [Quick Start](#quick-start)
 - [Components](#components)
 - [Slots](#slots)
+- [Typed Slot Props](#typed-slot-props)
 - [Theme Slots](#theme-slots)
 - [License](#license)
 
@@ -79,6 +80,31 @@ h(VCList, { data: items, total: items.length }, {
 | `itemActions` | `{ data, index, updated, deleted }` | Per-item actions |
 | `loading` | `{ busy }` | Loading indicator content |
 | `noMore` | `{}` | Empty state content |
+
+## Typed Slot Props
+
+Slot prop interfaces are exported for render-function consumers:
+
+```typescript
+import {
+    VCList,
+    type ListItemSlotProps,
+    type ListSlotProps,
+} from '@vuecs/list-controls';
+
+interface Realm { id: string; name: string }
+
+h(VCList<Realm>, { data: realms }, {
+    item: (props: ListItemSlotProps<Realm>) => h('span', props.data.name),
+});
+```
+
+| Export | Used by |
+|--------|---------|
+| `ListSlotProps<T, M>` | `VCList` default slot |
+| `ListBaseSlotProps<T, M>` | `VCListHeader`, `VCListFooter`, `VCListLoading`, `VCListNoMore` default slot |
+| `ListBodySlotProps<T, M>` | `VCListBody` default slot |
+| `ListItemSlotProps<T>` | `VCListItem` default/actions/actionsExtra slots, `VCList` `item`/`itemActions`/`itemActionsExtra` slots |
 
 ## Theme Slots
 

--- a/packages/navigation/README.md
+++ b/packages/navigation/README.md
@@ -11,6 +11,7 @@ Multi-level navigation components for Vue 3 with `NavigationManager`, path-based
 - [Quick Start](#quick-start)
 - [Components](#components)
 - [NavigationManager](#navigationmanager)
+- [Typed Slot Props](#typed-slot-props)
 - [Theme Slots](#theme-slots)
 - [License](#license)
 
@@ -76,6 +77,31 @@ installNavigation(app, {
     },
 });
 ```
+
+## Typed Slot Props
+
+Slot prop interfaces are exported for render-function consumers:
+
+```typescript
+import {
+    VCNavItem,
+    type NavItemLinkSlotProps,
+} from '@vuecs/navigation';
+
+h(VCNavItem, { data }, {
+    link: (props: NavItemLinkSlotProps) =>
+        h('a', { onClick: () => props.select(props.data) }, props.data.name),
+});
+```
+
+| Export | Used by |
+|--------|---------|
+| `NavItemSeparatorSlotProps<META>` | `VCNavItem` `separator` |
+| `NavItemLinkSlotProps<META>` | `VCNavItem` `link` |
+| `NavItemSubSlotProps<META>` | `VCNavItem` `sub` |
+| `NavItemSubTitleSlotProps<META>` | `VCNavItem` `sub-title` |
+| `NavItemSubItemsSlotProps<META>` | `VCNavItem` `sub-items` |
+| `NavItemsItemSlotProps<META>` | `VCNavItems` `item` |
 
 ## Theme Slots
 

--- a/packages/navigation/src/components/index.ts
+++ b/packages/navigation/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './item/module';
 export * from './items';
+export * from './type';

--- a/packages/navigation/src/components/item/module.ts
+++ b/packages/navigation/src/components/item/module.ts
@@ -2,7 +2,7 @@ import { hasNormalizedSlot, normalizeSlot, useComponentTheme } from '@vuecs/core
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
 import type { LinkProperties } from '@vuecs/link';
 import { VCLink } from '@vuecs/link';
-import type { PropType, VNodeChild } from 'vue';
+import type { PropType, SlotsType, VNodeChild } from 'vue';
 import {
     computed,
     defineComponent,
@@ -15,6 +15,13 @@ import type { NavigationItemNormalized } from '../../types';
 import type { NavigationThemeClasses } from '../../helpers/component/types';
 import { isAbsoluteURL } from '../../helpers';
 import { ElementType, SlotName } from '../../constants';
+import type {
+    NavItemLinkSlotProps,
+    NavItemSeparatorSlotProps,
+    NavItemSubItemsSlotProps,
+    NavItemSubSlotProps,
+    NavItemSubTitleSlotProps,
+} from '../type';
 
 const themeDefaults = {
     classes: {
@@ -45,6 +52,13 @@ export const VCNavItem = defineComponent({
             default: undefined,
         },
     },
+    slots: Object as SlotsType<{
+        separator: NavItemSeparatorSlotProps;
+        link: NavItemLinkSlotProps;
+        sub: NavItemSubSlotProps;
+        'sub-title': NavItemSubTitleSlotProps;
+        'sub-items': NavItemSubItemsSlotProps;
+    }>,
     setup(props, { slots }) {
         const itemsNode = resolveComponent('VCNavItems');
 

--- a/packages/navigation/src/components/items/module.ts
+++ b/packages/navigation/src/components/items/module.ts
@@ -2,6 +2,7 @@ import { hasNormalizedSlot, normalizeSlot, useComponentTheme } from '@vuecs/core
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
 import type {
     PropType,
+    SlotsType,
     VNodeArrayChildren,
     VNodeChild,
 } from 'vue';
@@ -19,6 +20,7 @@ import { injectNavigationManager } from '../../manager';
 import type { NavigationItemNormalized } from '../../types';
 import type { NavigationThemeClasses } from '../../helpers/component/types';
 import { VCNavItem } from '../item';
+import type { NavItemsItemSlotProps } from '../type';
 
 const themeDefaults = {
     classes: {
@@ -41,6 +43,9 @@ export const VCNavItems = defineComponent({
         themeClass: { type: Object as PropType<ThemeClassesOverride<NavigationThemeClasses>>, default: undefined },
         themeVariant: { type: Object as PropType<VariantValues>, default: undefined },
     },
+    slots: Object as SlotsType<{
+        item: NavItemsItemSlotProps;
+    }>,
     setup(props, { slots }) {
         const theme = useComponentTheme('navigation', toRef(props, 'themeClass'), themeDefaults, toRef(props, 'themeVariant'));
 

--- a/packages/navigation/src/components/type.ts
+++ b/packages/navigation/src/components/type.ts
@@ -1,0 +1,33 @@
+import type { NavigationItemNormalized } from '../types';
+
+export type NavItemSelectFn<META = any> = (
+    value: NavigationItemNormalized<META>,
+) => Promise<void>;
+
+export type NavItemToggleFn<META = any> = (
+    value: NavigationItemNormalized<META>,
+) => Promise<void>;
+
+export type NavItemSeparatorSlotProps<META = any> = {
+    data: NavigationItemNormalized<META>;
+};
+
+export type NavItemLinkSlotProps<META = any> = {
+    data: NavigationItemNormalized<META>;
+    select: NavItemSelectFn<META>;
+    isActive?: boolean;
+};
+
+export type NavItemSubSlotProps<META = any> = {
+    data: NavigationItemNormalized<META>;
+    select: NavItemSelectFn<META>;
+    toggle: NavItemToggleFn<META>;
+};
+
+export type NavItemSubTitleSlotProps<META = any> = NavItemSubSlotProps<META>;
+
+export type NavItemSubItemsSlotProps<META = any> = NavItemSubSlotProps<META>;
+
+export type NavItemsItemSlotProps<META = any> = {
+    data: NavigationItemNormalized<META>;
+};


### PR DESCRIPTION
closes #1488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exported typed slot prop interfaces for components across multiple packages (countdown, form-controls, list-controls, navigation).
  * Enhanced TypeScript support with strongly-typed slot contracts for render-function consumers.

* **Documentation**
  * Added "Typed Slot Props" sections to READMEs with usage examples and reference tables.
  * Updated conventions documentation for slot-prop type definitions.

* **Style**
  * Normalized formatting in import statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->