### PR TITLE
feat!: migrate VCFormSelect to Reka Select primitives, theme VCFormSelectSearch

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -844,7 +844,7 @@ matching `*Portal` so consumers don't have to compose them manually
         ModalContent.vue    <- DialogPortal + DialogOverlay + DialogContent
         ModalTitle.vue
         ModalDescription.vue
-        ModalClose.vue        <- close trigger; `icon` prop selects theme `close` (neutral) vs `closeIcon` (corner-X)
+        ModalClose.vue        <- close trigger; slotless OR `icon` prop → theme `closeIcon` (corner-X); otherwise neutral `close`
         theme.ts            <- shared modalThemeDefaults (single source for all parts)
         types.ts            <- ModalThemeClasses + ThemeElements augmentation
         use-modal.ts        <- useModal() view-stack composable (issue #1480)

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -844,12 +844,12 @@ matching `*Portal` so consumers don't have to compose them manually
         ModalContent.vue    <- DialogPortal + DialogOverlay + DialogContent
         ModalTitle.vue
         ModalDescription.vue
-        ModalClose.vue
+        ModalClose.vue        <- close trigger; `icon` prop selects theme `close` (neutral) vs `closeIcon` (corner-X)
         theme.ts            <- shared modalThemeDefaults (single source for all parts)
         types.ts            <- ModalThemeClasses + ThemeElements augmentation
         use-modal.ts        <- useModal() view-stack composable (issue #1480)
         index.ts
-      popover/                <- Popover / Trigger / Content / Arrow / Close
+      popover/                <- Popover / Trigger / Content / Arrow / Close (with `icon` prop)
       tooltip/                <- TooltipProvider / Tooltip / Trigger / Content / Arrow
       dropdown-menu/          <- DropdownMenu / Trigger / Content / Item / Label / Separator / Group / Arrow
       context-menu/           <- ContextMenu / Trigger / Content / Item / Label / Separator / Group

--- a/docs/src/.vitepress/theme/components/SettingsModal.vue
+++ b/docs/src/.vitepress/theme/components/SettingsModal.vue
@@ -69,7 +69,7 @@ const cogIconPath = 'M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 
             </svg>
         </VCModalTrigger>
         <VCModalContent>
-            <VCModalClose icon />
+            <VCModalClose />
             <VCModalTitle>Appearance</VCModalTitle>
             <VCModalDescription>
                 Customise the docs preview palette and color mode.

--- a/docs/src/.vitepress/theme/components/SettingsModal.vue
+++ b/docs/src/.vitepress/theme/components/SettingsModal.vue
@@ -69,7 +69,7 @@ const cogIconPath = 'M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 
             </svg>
         </VCModalTrigger>
         <VCModalContent>
-            <VCModalClose />
+            <VCModalClose icon />
             <VCModalTitle>Appearance</VCModalTitle>
             <VCModalDescription>
                 Customise the docs preview palette and color mode.

--- a/docs/src/components/form-select-search.md
+++ b/docs/src/components/form-select-search.md
@@ -120,6 +120,7 @@ Filtering matches the `label` field with a case-insensitive `RegExp`. The option
 | `maxItems` | `number` | `10` | Max items rendered before infinite-scroll kicks in |
 | `scrollDistance` | `number` | `10` | Scroll distance threshold for the next page |
 | `disabled` | `boolean` | `false` | Disable the input |
+| `closeOnSelect` | `boolean \| undefined` | `undefined` (mode-default) | Close the dropdown after a pick. Default: single closes, multi stays open. Set explicitly to override. |
 
 ## Events
 

--- a/docs/src/components/form-select.md
+++ b/docs/src/components/form-select.md
@@ -107,7 +107,7 @@ const id = ref<number | undefined>(undefined);
 
 ## Placeholder
 
-`placeholder` renders a leading `<option disabled selected>` whenever `modelValue` is `undefined` or `''`. Falls back to the global `formSelect.placeholder` default; when both are empty no placeholder renders.
+`placeholder` is rendered inside the trigger via Reka's `SelectValue` whenever `modelValue` is unset (no native `<option>` element). The trigger gets a `data-placeholder` attribute so themes can style the empty state (e.g. muted color). Falls back to the global `formSelect.placeholder` default; when both are empty the trigger renders no text.
 
 ```vue
 <VCFormSelect
@@ -133,7 +133,7 @@ app.use(vuecs, {
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `placeholder` | `''` | Leading disabled option text. Empty disables the placeholder. |
+| `placeholder` | `''` | Trigger text shown while no option is selected. Empty hides the placeholder. |
 
 See [Behavioral Defaults](/guide/behavioral-defaults) for the resolution rules.
 

--- a/docs/src/components/form-select.md
+++ b/docs/src/components/form-select.md
@@ -1,6 +1,8 @@
 # FormSelect
 
-Dropdown select with `v-model` binding. Accepts a flat `FormOption[]` or a mixed array of options and `FormOptionGroup`s (rendered as HTML `<optgroup>`). Supports a `placeholder` prop that renders a leading disabled option.
+Dropdown select with `v-model` binding. Accepts a flat `FormOption[]` or a mixed array of options and `FormOptionGroup`s. Supports a `placeholder` prop shown in the trigger when no value is selected.
+
+Built on Reka UI's `Select` compound primitive — renders a real `<button role="combobox">` trigger plus a portal-mounted dropdown panel with full keyboard navigation, type-ahead, and `data-state` hooks. Note: this replaces the native `<select>` element from earlier `@vuecs/forms` versions, so the OS-native mobile picker is no longer used.
 
 ```bash
 npm install @vuecs/forms
@@ -141,9 +143,29 @@ See [Behavioral Defaults](/guide/behavioral-defaults) for the resolution rules.
 |------|------|---------|-------------|
 | `modelValue` | `T \| undefined` | `undefined` | Bound value (matches an option's `value`) |
 | `options` | `FormOptionItems<T>` | — | Flat options, groups, or a mix |
-| `placeholder` | `string` | (defaults system) | Leading disabled option text |
+| `placeholder` | `string` | (defaults system) | Trigger placeholder text when no option selected |
+| `disabled` | `boolean` | `false` | Block user interaction with the trigger |
+| `name` | `string` | `undefined` | Native form field name — submitted via Reka's hidden input |
+| `required` | `boolean` | `false` | Native form `required` semantics |
 | `themeClass` | `Partial<FormSelectThemeClasses>` | `undefined` | Per-instance theme override |
 | `themeVariant` | `Record<string, string \| boolean>` | `undefined` | Per-instance variant values |
+
+## Theme keys
+
+The compound DOM exposes ten theme slots — target `[data-state=open]`, `[data-highlighted]`, `[data-disabled]`, `[data-placeholder]` for state-driven styling.
+
+| Key | Element |
+|-----|---------|
+| `trigger` | The `<button role="combobox">` |
+| `value` | Inner span showing the selected label or placeholder |
+| `icon` | Chevron icon inside the trigger |
+| `content` | Portal-mounted popover panel |
+| `viewport` | Scrollable container inside content |
+| `item` | A single option row |
+| `itemIndicator` | Checkmark on the currently-selected item |
+| `group` | An option-group wrapper |
+| `groupLabel` | Group heading |
+| `separator` | Optional divider (reserved for future use) |
 
 ## Events
 

--- a/docs/src/components/form-select.md
+++ b/docs/src/components/form-select.md
@@ -152,6 +152,19 @@ See [Behavioral Defaults](/guide/behavioral-defaults) for the resolution rules.
 
 ## Theme keys
 
+::: warning Renamed in this release
+The single `root` slot has been **renamed to `trigger`** to reflect the new compound DOM. Per-instance overrides need to migrate:
+
+```vue
+<!-- before -->
+<VCFormSelect :theme-class="{ root: 'my-custom-styles' }" :options="..." />
+<!-- after -->
+<VCFormSelect :theme-class="{ trigger: 'my-custom-styles' }" :options="..." />
+```
+
+Same renaming applies to the `formSelect` entry in `app.use(vuecs, { overrides: { elements: { formSelect: { classes: { ... } } } } })` and to theme packages.
+:::
+
 The compound DOM exposes ten theme slots — target `[data-state=open]`, `[data-highlighted]`, `[data-disabled]`, `[data-placeholder]` for state-driven styling.
 
 | Key | Element |

--- a/docs/src/components/modal.md
+++ b/docs/src/components/modal.md
@@ -17,7 +17,7 @@ npm install @vuecs/overlays
 | `VCModalContent` | `DialogPortal` + `DialogOverlay` + `DialogContent` | Backdrop + focused panel. Use `inline` to skip the portal, `hideOverlay` to skip the backdrop. |
 | `VCModalTitle` | `DialogTitle` | aria-labelledby target. |
 | `VCModalDescription` | `DialogDescription` | aria-describedby target. |
-| `VCModalClose` | `DialogClose` | Button that closes. Default content is `×` (auto `aria-label="Close"` when no slot). |
+| `VCModalClose` | `DialogClose` | Button that closes. Neutral by default (composes with consumer classes for Cancel-style buttons); pass `icon` for the pre-styled corner-X. Default content is `×` (auto `aria-label="Close"` when no slot). |
 
 <Demo name="modal" component="VCModal">
   <template #code>
@@ -43,16 +43,21 @@ const open = ref(false);
     <VCModal v-model:open="open">
         <VCModalTrigger>Open dialog</VCModalTrigger>
         <VCModalContent>
-            <!-- Renders the default × in the top-right (the position
-                 styled by the theme-tailwind `close` slot). -->
-            <VCModalClose />
+            <!-- `icon` selects the pre-styled corner-X (absolute right-3
+                 top-3 from the theme's `closeIcon` slot). -->
+            <VCModalClose icon />
             <VCModalTitle>Confirm action</VCModalTitle>
             <VCModalDescription>
                 This will permanently delete the record.
             </VCModalDescription>
             <div class="flex justify-end gap-2">
-                <button @click="open = false">Cancel</button>
-                <button @click="open = false">Confirm</button>
+                <!-- Without `icon`, <VCModalClose> uses the neutral `close`
+                     theme slot, so consumer classes compose cleanly. -->
+                <VCModalClose
+                    class="rounded-md border border-border bg-bg px-3 py-1.5 text-sm font-medium hover:bg-bg-muted"
+                >
+                    Cancel
+                </VCModalClose>
             </div>
         </VCModalContent>
     </VCModal>
@@ -71,15 +76,11 @@ const open = ref(false);
   </template>
 </Demo>
 
-::: tip When to use `<VCModalClose>` vs a plain `<button>`
-The theme-tailwind `close` slot is styled for the **top-right corner ×**
-(`absolute right-3 top-3 h-7 w-7`). Use `<VCModalClose />` (no children) for
-that position. For Cancel/Confirm-style buttons elsewhere in the dialog,
-use plain `<button @click="open = false">` — Vue's `class` attribute merges
-with the theme's classes rather than replacing them, so the corner-positioning
-leaks if you reuse `<VCModalClose>` in the footer. To use `<VCModalClose>`
-outside the corner (e.g. for a labelled Cancel button), pass a full theme
-override via `:theme-class="{ close: 'rounded-md border ...' }"`.
+::: tip Two presentations, one component
+`<VCModalClose>` has two presets selected by the `icon` boolean prop:
+
+- `<VCModalClose icon />` — pre-styled top-right **corner ×**. Reads the theme's `closeIcon` slot (absolute positioning + sizing — `absolute right-3 top-3 h-7 w-7` in theme-tailwind, `btn-close` in theme-bootstrap). Drop one inside `<VCModalContent>` for the standard dismiss affordance.
+- `<VCModalClose>` (default) — neutral close trigger that reads the `close` slot. Consumer classes via `class=` or `:theme-class` compose cleanly, so this is the right choice for Cancel/Confirm-style buttons in the footer, or anywhere you want a labelled close button. Behaves like `<button @click="open = false">` but inherits Reka's focus management.
 :::
 
 ## `useModal()` composable
@@ -206,7 +207,8 @@ const showItem = (id: number) => {
 | `body` | `vc-modal-body` | Body layout container (consumer-composed). |
 | `footer` | `vc-modal-footer` | Footer layout container (consumer-composed). |
 | `trigger` | `vc-modal-trigger` | Trigger button. |
-| `close` | `vc-modal-close` | Close button. |
+| `close` | `vc-modal-close` | Generic close trigger (`<VCModalClose>`). Neutral baseline so consumer classes compose cleanly. |
+| `closeIcon` | `vc-modal-close-icon` | Corner-X positioning + sizing for `<VCModalCloseIcon>`. |
 | `back` | `vc-modal-back` | Optional view-stack back button. |
 
 `@vuecs/theme-tailwind` ships pre-built styling for every key with light/dark mode and `data-state="open|closed"` animation hooks.
@@ -301,14 +303,15 @@ Accessible description, linked via `aria-describedby`. Wraps `DialogDescription`
 
 ### `<VCModalClose>`
 
-Button that dismisses the modal. Wraps `DialogClose`. Default slot content is `×` when no children are provided.
+Button that dismisses the modal. Wraps `DialogClose`. Reads either the `close` slot (default — neutral so consumer classes compose cleanly) or the `closeIcon` slot (pre-styled corner-X) depending on the `icon` prop.
 
-When no slot content is supplied, `<VCModalClose>` auto-applies `aria-label="Close"` so screen readers don't announce the bare `×` glyph as "multiplication sign". Pass an explicit `aria-label` via attrs to override, or supply visible text content (e.g. `<VCModalClose>Close</VCModalClose>`) — visible text takes precedence and the auto-label is dropped.
+Default slot content is `×` when no children are provided. Auto-applies `aria-label="Close"` so screen readers don't announce the bare `×` glyph as "multiplication sign". Pass an explicit `aria-label` via attrs to override, or supply visible text content (e.g. `<VCModalClose>Close</VCModalClose>`) — visible text takes precedence and the auto-label is dropped.
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `as` | `string` | `'button'` | HTML tag to render. |
 | `asChild` | `boolean` | `false` | Render via the default slot's child element. |
+| `icon` | `boolean` | `false` | When true, reads the theme's `closeIcon` slot (corner-X). When false, reads the neutral `close` slot. |
 | `themeClass` | `Partial<ModalThemeClasses>` | `undefined` | Per-instance theme override. |
 | `themeVariant` | `Record<string, string \| boolean>` | `undefined` | Per-instance variant values. |
 

--- a/docs/src/components/modal.md
+++ b/docs/src/components/modal.md
@@ -17,7 +17,7 @@ npm install @vuecs/overlays
 | `VCModalContent` | `DialogPortal` + `DialogOverlay` + `DialogContent` | Backdrop + focused panel. Use `inline` to skip the portal, `hideOverlay` to skip the backdrop. |
 | `VCModalTitle` | `DialogTitle` | aria-labelledby target. |
 | `VCModalDescription` | `DialogDescription` | aria-describedby target. |
-| `VCModalClose` | `DialogClose` | Button that closes. Neutral by default (composes with consumer classes for Cancel-style buttons); pass `icon` for the pre-styled corner-X. Default content is `×` (auto `aria-label="Close"` when no slot). |
+| `VCModalClose` | `DialogClose` | Button that closes. Slotless `<VCModalClose />` renders the corner-X (default `×` glyph + `closeIcon` theme slot). With slot content (e.g. "Cancel") it renders neutrally so consumer classes compose. Pass `icon` to force the corner-X even with custom content. Auto `aria-label="Close"` when slotless. |
 
 <Demo name="modal" component="VCModal">
   <template #code>
@@ -43,16 +43,16 @@ const open = ref(false);
     <VCModal v-model:open="open">
         <VCModalTrigger>Open dialog</VCModalTrigger>
         <VCModalContent>
-            <!-- `icon` selects the pre-styled corner-X (absolute right-3
-                 top-3 from the theme's `closeIcon` slot). -->
-            <VCModalClose icon />
+            <!-- Slotless = corner-X (theme `closeIcon` slot, absolute
+                 right-3 top-3). -->
+            <VCModalClose />
             <VCModalTitle>Confirm action</VCModalTitle>
             <VCModalDescription>
                 This will permanently delete the record.
             </VCModalDescription>
             <div class="flex justify-end gap-2">
-                <!-- Without `icon`, <VCModalClose> uses the neutral `close`
-                     theme slot, so consumer classes compose cleanly. -->
+                <!-- With slot content, <VCModalClose> uses the neutral
+                     `close` theme slot so consumer classes compose. -->
                 <VCModalClose
                     class="rounded-md border border-border bg-bg px-3 py-1.5 text-sm font-medium hover:bg-bg-muted"
                 >
@@ -77,10 +77,11 @@ const open = ref(false);
 </Demo>
 
 ::: tip Two presentations, one component
-`<VCModalClose>` has two presets selected by the `icon` boolean prop:
+`<VCModalClose>` picks between two theme slots based on slot content and the `icon` prop:
 
-- `<VCModalClose icon />` — pre-styled top-right **corner ×**. Reads the theme's `closeIcon` slot (absolute positioning + sizing — `absolute right-3 top-3 h-7 w-7` in theme-tailwind, `btn-close` in theme-bootstrap). Drop one inside `<VCModalContent>` for the standard dismiss affordance.
-- `<VCModalClose>` (default) — neutral close trigger that reads the `close` slot. Consumer classes via `class=` or `:theme-class` compose cleanly, so this is the right choice for Cancel/Confirm-style buttons in the footer, or anywhere you want a labelled close button. Behaves like `<button @click="open = false">` but inherits Reka's focus management.
+- `<VCModalClose />` (no slot, no `icon`) — pre-styled top-right **corner ×**. Reads the theme's `closeIcon` slot (`absolute right-3 top-3 h-7 w-7` in theme-tailwind, `btn-close` in theme-bootstrap). Drop one inside `<VCModalContent>` for the standard dismiss affordance.
+- `<VCModalClose>Cancel</VCModalClose>` (with slot content) — neutral close trigger that reads the `close` slot. Consumer classes via `class=` or `:theme-class` compose cleanly. Right choice for Cancel/Confirm rows or any labelled close button.
+- `<VCModalClose icon>...</VCModalClose>` — explicit `icon` forces the corner-X presentation even when you supply custom slot content (e.g. a custom icon).
 :::
 
 ## `useModal()` composable
@@ -303,15 +304,19 @@ Accessible description, linked via `aria-describedby`. Wraps `DialogDescription`
 
 ### `<VCModalClose>`
 
-Button that dismisses the modal. Wraps `DialogClose`. Reads either the `close` slot (default — neutral so consumer classes compose cleanly) or the `closeIcon` slot (pre-styled corner-X) depending on the `icon` prop.
+Button that dismisses the modal. Wraps `DialogClose`. Picks between the `closeIcon` slot (pre-styled corner-X) and the `close` slot (neutral) based on slot content + the `icon` prop:
 
-Default slot content is `×` when no children are provided. Auto-applies `aria-label="Close"` so screen readers don't announce the bare `×` glyph as "multiplication sign". Pass an explicit `aria-label` via attrs to override, or supply visible text content (e.g. `<VCModalClose>Close</VCModalClose>`) — visible text takes precedence and the auto-label is dropped.
+- **Slotless** (`<VCModalClose />`) — corner-X via `closeIcon`. Renders the default `×` glyph.
+- **With slot content** (`<VCModalClose>Cancel</VCModalClose>`) — neutral `close` slot, so consumer classes via `class=` or `:theme-class` compose cleanly.
+- **Explicit `icon` prop** — always reads the `closeIcon` slot, regardless of slot content.
+
+Auto-applies `aria-label="Close"` when slotless so screen readers don't announce the bare `×` glyph as "multiplication sign". Pass an explicit `aria-label` via attrs to override, or supply visible text content (which takes precedence and drops the auto-label).
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `as` | `string` | `'button'` | HTML tag to render. |
 | `asChild` | `boolean` | `false` | Render via the default slot's child element. |
-| `icon` | `boolean` | `false` | When true, reads the theme's `closeIcon` slot (corner-X). When false, reads the neutral `close` slot. |
+| `icon` | `boolean` | `false` | Force the `closeIcon` (corner-X) slot even when slot content is provided. Not needed for slotless usage — bare `<VCModalClose />` already picks `closeIcon`. |
 | `themeClass` | `Partial<ModalThemeClasses>` | `undefined` | Per-instance theme override. |
 | `themeVariant` | `Record<string, string \| boolean>` | `undefined` | Per-instance variant values. |
 

--- a/docs/src/components/popover.md
+++ b/docs/src/components/popover.md
@@ -34,7 +34,7 @@ import {
                 floating-ui flips and shifts to stay on-screen.
             </p>
             <VCPopoverArrow />
-            <VCPopoverClose icon />
+            <VCPopoverClose />
         </VCPopoverContent>
     </VCPopover>
 </template>
@@ -60,7 +60,7 @@ import {
 | `VCPopoverTrigger` | `PopoverTrigger` | Toggles open. |
 | `VCPopoverContent` | `PopoverPortal` + `PopoverContent` | Floating panel. `inline` skips the portal. Position via `side` / `sideOffset` / `align` / `alignOffset` / `avoidCollisions`. |
 | `VCPopoverArrow` | `PopoverArrow` | Optional pointer arrow. |
-| `VCPopoverClose` | `PopoverClose` | Close button. Neutral by default; pass `icon` for the pre-styled corner-X. |
+| `VCPopoverClose` | `PopoverClose` | Close button. Slotless `<VCPopoverClose />` renders the corner-X; with slot content it renders neutrally. Pass `icon` to force the corner-X with custom content. |
 
 ```vue
 <script setup lang="ts">
@@ -79,7 +79,7 @@ import {
         <VCPopoverContent side="bottom" :side-offset="8">
             <p class="text-sm">Hello from a popover</p>
             <VCPopoverArrow />
-            <VCPopoverClose icon />
+            <VCPopoverClose />
         </VCPopoverContent>
     </VCPopover>
 </template>
@@ -164,14 +164,18 @@ Optional pointer arrow that follows the panel's position. Wraps `PopoverArrow`.
 
 ### `<VCPopoverClose>`
 
-Button that dismisses the popover. Wraps `PopoverClose`. Reads either the `close` slot (default — neutral so consumer classes compose cleanly) or the `closeIcon` slot (pre-styled corner-X) depending on the `icon` prop.
+Button that dismisses the popover. Wraps `PopoverClose`. Picks between the `closeIcon` slot (pre-styled corner-X) and the `close` slot (neutral) based on slot content + the `icon` prop:
 
-Default slot content is `×` when no children are provided. Auto-applies `aria-label="Close"` so screen readers don't announce the bare `×` glyph as "multiplication sign". Pass an explicit `aria-label` via attrs to override, or supply visible text content to drop the auto-label.
+- **Slotless** (`<VCPopoverClose />`) — corner-X via `closeIcon`. Renders the default `×` glyph.
+- **With slot content** — neutral `close` slot, so consumer classes via `class=` or `:theme-class` compose cleanly.
+- **Explicit `icon` prop** — always reads the `closeIcon` slot, regardless of slot content.
+
+Auto-applies `aria-label="Close"` when slotless so screen readers don't announce the bare `×` glyph as "multiplication sign". Pass an explicit `aria-label` via attrs to override, or supply visible text content to drop the auto-label.
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `as` | `string` | `'button'` | HTML tag to render. |
 | `asChild` | `boolean` | `false` | Render via the default slot's child element. |
-| `icon` | `boolean` | `false` | When true, reads the theme's `closeIcon` slot (corner-X). When false, reads the neutral `close` slot. |
+| `icon` | `boolean` | `false` | Force the `closeIcon` (corner-X) slot even when slot content is provided. Not needed for slotless usage. |
 | `themeClass` | `Partial<PopoverThemeClasses>` | `undefined` | Per-instance theme override. |
 | `themeVariant` | `Record<string, string \| boolean>` | `undefined` | Per-instance variant values. |

--- a/docs/src/components/popover.md
+++ b/docs/src/components/popover.md
@@ -34,7 +34,7 @@ import {
                 floating-ui flips and shifts to stay on-screen.
             </p>
             <VCPopoverArrow />
-            <VCPopoverClose />
+            <VCPopoverClose icon />
         </VCPopoverContent>
     </VCPopover>
 </template>
@@ -60,7 +60,7 @@ import {
 | `VCPopoverTrigger` | `PopoverTrigger` | Toggles open. |
 | `VCPopoverContent` | `PopoverPortal` + `PopoverContent` | Floating panel. `inline` skips the portal. Position via `side` / `sideOffset` / `align` / `alignOffset` / `avoidCollisions`. |
 | `VCPopoverArrow` | `PopoverArrow` | Optional pointer arrow. |
-| `VCPopoverClose` | `PopoverClose` | Close button. |
+| `VCPopoverClose` | `PopoverClose` | Close button. Neutral by default; pass `icon` for the pre-styled corner-X. |
 
 ```vue
 <script setup lang="ts">
@@ -79,7 +79,7 @@ import {
         <VCPopoverContent side="bottom" :side-offset="8">
             <p class="text-sm">Hello from a popover</p>
             <VCPopoverArrow />
-            <VCPopoverClose />
+            <VCPopoverClose icon />
         </VCPopoverContent>
     </VCPopover>
 </template>
@@ -92,7 +92,8 @@ import {
 | `trigger` | `vc-popover-trigger` | |
 | `content` | `vc-popover-content` | Floating panel; supports `data-state="open\|closed"` for animation. |
 | `arrow` | `vc-popover-arrow` | |
-| `close` | `vc-popover-close` | |
+| `close` | `vc-popover-close` | Neutral baseline for `<VCPopoverClose>` — composes with consumer classes. |
+| `closeIcon` | `vc-popover-close-icon` | Corner-X positioning + sizing for `<VCPopoverCloseIcon>`. |
 
 ## Accessibility
 
@@ -163,13 +164,14 @@ Optional pointer arrow that follows the panel's position. Wraps `PopoverArrow`.
 
 ### `<VCPopoverClose>`
 
-Button that dismisses the popover. Wraps `PopoverClose`. Default content is `×`.
+Button that dismisses the popover. Wraps `PopoverClose`. Reads either the `close` slot (default — neutral so consumer classes compose cleanly) or the `closeIcon` slot (pre-styled corner-X) depending on the `icon` prop.
 
-When no slot content is supplied, `<VCPopoverClose>` auto-applies `aria-label="Close"` so screen readers don't announce the bare `×` glyph as "multiplication sign". Pass an explicit `aria-label` via attrs to override, or supply visible text content to drop the auto-label.
+Default slot content is `×` when no children are provided. Auto-applies `aria-label="Close"` so screen readers don't announce the bare `×` glyph as "multiplication sign". Pass an explicit `aria-label` via attrs to override, or supply visible text content to drop the auto-label.
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `as` | `string` | `'button'` | HTML tag to render. |
 | `asChild` | `boolean` | `false` | Render via the default slot's child element. |
+| `icon` | `boolean` | `false` | When true, reads the theme's `closeIcon` slot (corner-X). When false, reads the neutral `close` slot. |
 | `themeClass` | `Partial<PopoverThemeClasses>` | `undefined` | Per-instance theme override. |
 | `themeVariant` | `Record<string, string \| boolean>` | `undefined` | Per-instance variant values. |

--- a/examples/nuxt/components/form-input-text/FormInputTextBasic.vue
+++ b/examples/nuxt/components/form-input-text/FormInputTextBasic.vue
@@ -60,7 +60,7 @@ export default defineComponent({
                                 'hover:bg-bg-elevated',
                             ]"
                         >
-                            <i class="fa fa-plus" />
+                            <VCIcon name="fa6-solid:plus" />
                         </button>
                     </template>
                 </VCFormInput>

--- a/examples/nuxt/components/header.vue
+++ b/examples/nuxt/components/header.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { extend } from '@vuecs/core';
 import { VCGravatar } from '@vuecs/gravatar';
 import { VCNavItems } from '@vuecs/navigation';
 import { ref } from 'vue';
@@ -17,11 +18,17 @@ export default defineNuxtComponent({
             displayNav.value = !displayNav.value;
         };
 
+        // extend() so the per-instance sizing merges with the theme's
+        // `inline-block overflow-hidden rounded-full` instead of replacing it
+        // (themeClass is layer 4 and replaces by default — see architecture.md).
+        const gravatarThemeClass = { root: extend('h-8 w-8') };
+
         return {
             toggleNav,
             displayNav,
             colorMode: resolved,
             toggleColorMode,
+            gravatarThemeClass,
         };
     },
 });
@@ -39,7 +46,7 @@ export default defineNuxtComponent({
                 @click="toggleNav"
             >
                 <span class="sr-only">Toggle navigation</span>
-                <i class="fa fa-bars" />
+                <VCIcon name="fa6-solid:bars" />
             </button>
 
             <div class="text-lg font-semibold tracking-tight text-fg">
@@ -61,7 +68,7 @@ export default defineNuxtComponent({
                 :aria-label="colorMode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'"
                 @click="toggleColorMode"
             >
-                <i :class="colorMode === 'dark' ? 'fa-regular fa-sun' : 'fa-regular fa-moon'" />
+                <VCIcon :name="colorMode === 'dark' ? 'fa6-solid:sun' : 'fa6-solid:moon'" />
             </button>
 
             <a
@@ -70,7 +77,7 @@ export default defineNuxtComponent({
             >
                 <VCGravatar
                     email="peter.placzek1996@gmail.com"
-                    :theme-class="{ root: 'h-8 w-8' }"
+                    :theme-class="gravatarThemeClass"
                 />
             </a>
         </div>

--- a/examples/nuxt/config/layout/module.ts
+++ b/examples/nuxt/config/layout/module.ts
@@ -5,13 +5,13 @@ import type {
 
 const primaryItems : NavigationItem[] = [
     {
-        name: 'Home', 
-        icon: 'fa fa-home', 
+        name: 'Home',
+        icon: 'fa6-solid:house',
         url: '/',
     },
     {
-        name: 'Admin', 
-        icon: 'fas fa-cog', 
+        name: 'Admin',
+        icon: 'fa6-solid:gear',
         activeMatch: '/admin/',
     },
 ];
@@ -20,7 +20,7 @@ const secondaryDefaultItems : NavigationItem[] = [
     {
         name: 'Home',
         type: 'link',
-        icon: 'fas fa-home',
+        icon: 'fa6-solid:house',
         url: '/',
     },
 
@@ -31,7 +31,7 @@ const secondaryDefaultItems : NavigationItem[] = [
     {
         name: 'Form Controls',
         type: 'link',
-        icon: 'fa-solid fa-bars',
+        icon: 'fa6-solid:bars',
         children: [
             { name: 'Input Checkbox', url: '/form-controls/input-checkbox' },
             { name: 'Input Text', url: '/form-controls/input-text' },
@@ -45,7 +45,7 @@ const secondaryDefaultItems : NavigationItem[] = [
     {
         name: 'List',
         type: 'link',
-        icon: 'fa-solid fa-bars',
+        icon: 'fa6-solid:list',
         children: [
             { name: 'default', url: '/list/list' },
             { name: 'Slot', url: '/list/list-slot' },
@@ -56,27 +56,27 @@ const secondaryDefaultItems : NavigationItem[] = [
         type: 'separator',
     },
     {
-        name: 'Countdown', 
-        type: 'link', 
-        icon: 'fa-solid fa-clock', 
+        name: 'Countdown',
+        type: 'link',
+        icon: 'fa6-solid:clock',
         url: '/countdown',
     },
     {
-        name: 'Pagination', 
-        type: 'link', 
-        icon: 'fa-solid fa-road', 
+        name: 'Pagination',
+        type: 'link',
+        icon: 'fa6-solid:road',
         url: '/pagination',
     },
     {
         name: 'Overlays',
         type: 'link',
-        icon: 'fa-solid fa-window-restore',
+        icon: 'fa6-solid:window-restore',
         url: '/overlays',
     },
     {
         name: 'Timeago',
         type: 'link',
-        icon: 'fa-solid fa-clock',
+        icon: 'fa6-solid:clock',
         url: '/timeago',
     },
 ];
@@ -86,10 +86,10 @@ const secondaryAdminItems : NavigationItem[] = [
         name: 'Auth',
         children: [
             {
-                name: 'Realms', 
-                type: 'link', 
-                url: '/admin/realms', 
-                icon: 'fas fa-university',
+                name: 'Realms',
+                type: 'link',
+                url: '/admin/realms',
+                icon: 'fa6-solid:university',
             },
         ],
     },

--- a/examples/nuxt/pages/about.vue
+++ b/examples/nuxt/pages/about.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="mx-auto max-w-5xl">
         <h3 class="flex items-center gap-2 text-2xl font-semibold">
-            <i class="fa fa-info text-blue-500" /> About
+            <VCIcon name="fa6-solid:info" class="text-blue-500" /> About
         </h3>
     </div>
 </template>

--- a/examples/nuxt/pages/admin/realms.vue
+++ b/examples/nuxt/pages/admin/realms.vue
@@ -8,7 +8,7 @@
 <template>
     <div class="mx-auto max-w-5xl space-y-4">
         <h3 class="flex items-center gap-2 text-2xl font-semibold">
-            <i class="fas fa-university text-blue-500" /> Realms
+            <VCIcon name="fa6-solid:university" class="text-blue-500" /> Realms
         </h3>
         <p class="text-fg">
             Admin realms placeholder page.

--- a/examples/nuxt/pages/countdown.vue
+++ b/examples/nuxt/pages/countdown.vue
@@ -13,7 +13,7 @@ export default defineNuxtComponent({
 <template>
     <div class="mx-auto max-w-5xl space-y-4">
         <h3 class="flex items-center gap-2 text-2xl font-semibold">
-            <i class="fa fa-solid fa-clock text-blue-500" /> Countdown
+            <VCIcon name="fa6-solid:clock" class="text-blue-500" /> Countdown
         </h3>
         <VCCountdown :time="time">
             <template #default="props">

--- a/examples/nuxt/pages/index.vue
+++ b/examples/nuxt/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="mx-auto max-w-5xl space-y-4">
         <h3 class="flex items-center gap-2 text-2xl font-semibold">
-            <i class="fa-solid fa-heart text-red-500" /> vuecs
+            <VCIcon name="fa6-solid:heart" class="text-red-500" /> vuecs
             <span class="text-sm font-normal text-fg-muted">Examples</span>
         </h3>
         <p class="text-fg">

--- a/examples/nuxt/pages/list/list-slot.vue
+++ b/examples/nuxt/pages/list/list-slot.vue
@@ -28,7 +28,7 @@ export default defineComponent({
                         class="inline-flex items-center justify-center rounded-md bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-700"
                         @click.prevent="update({ id: data.id, name: 'foo' })"
                     >
-                        <i class="fa fa-refresh" />
+                        <VCIcon name="fa6-solid:arrows-rotate" />
                     </button>
                     <button
                         type="button"
@@ -37,7 +37,7 @@ export default defineComponent({
                         class="inline-flex items-center justify-center rounded-md bg-neutral-800 px-2 py-1 text-xs text-white"
                         @click.prevent="del(data)"
                     >
-                        <i class="fa fa-trash" />
+                        <VCIcon name="fa6-solid:trash" />
                     </button>
                 </VCListItemActions>
             </VCListItem>
@@ -51,7 +51,7 @@ export default defineComponent({
                     name: 'Max'
                 })"
             >
-                Create <i class="fa fa-plus" />
+                Create <VCIcon name="fa6-solid:plus" />
             </button>
         </template>
     </ExampleList>

--- a/examples/nuxt/pages/overlays.vue
+++ b/examples/nuxt/pages/overlays.vue
@@ -146,7 +146,7 @@ export default defineNuxtComponent({
                         Open dialog
                     </VCModalTrigger>
                     <VCModalContent>
-                        <VCModalClose icon />
+                        <VCModalClose />
                         <VCModalTitle>Confirm action</VCModalTitle>
                         <VCModalDescription>
                             This will permanently delete the record.

--- a/examples/nuxt/pages/overlays.vue
+++ b/examples/nuxt/pages/overlays.vue
@@ -127,7 +127,7 @@ export default defineNuxtComponent({
 <template>
     <div class="mx-auto max-w-5xl space-y-8">
         <h3 class="flex items-center gap-2 text-2xl font-semibold">
-            <i class="fa fa-window-restore text-blue-500" /> Overlays
+            <VCIcon name="fa6-solid:window-restore" class="text-blue-500" /> Overlays
         </h3>
 
         <section class="space-y-2">

--- a/examples/nuxt/pages/overlays.vue
+++ b/examples/nuxt/pages/overlays.vue
@@ -127,7 +127,10 @@ export default defineNuxtComponent({
 <template>
     <div class="mx-auto max-w-5xl space-y-8">
         <h3 class="flex items-center gap-2 text-2xl font-semibold">
-            <VCIcon name="fa6-solid:window-restore" class="text-blue-500" /> Overlays
+            <VCIcon
+                name="fa6-solid:window-restore"
+                class="text-blue-500"
+            /> Overlays
         </h3>
 
         <section class="space-y-2">
@@ -143,6 +146,7 @@ export default defineNuxtComponent({
                         Open dialog
                     </VCModalTrigger>
                     <VCModalContent>
+                        <VCModalClose icon />
                         <VCModalTitle>Confirm action</VCModalTitle>
                         <VCModalDescription>
                             This will permanently delete the record.

--- a/examples/nuxt/pages/pagination.vue
+++ b/examples/nuxt/pages/pagination.vue
@@ -37,7 +37,7 @@ export default defineNuxtComponent({
 <template>
     <div class="mx-auto max-w-5xl space-y-4">
         <h3 class="flex items-center gap-2 text-2xl font-semibold">
-            <i class="fa fa-solid fa-road text-blue-500" /> Pagination
+            <VCIcon name="fa6-solid:road" class="text-blue-500" /> Pagination
         </h3>
         <ul class="list-disc space-y-1 pl-6">
             <li

--- a/examples/nuxt/pages/timeago.vue
+++ b/examples/nuxt/pages/timeago.vue
@@ -19,7 +19,7 @@ export default defineNuxtComponent({
 <template>
     <div class="mx-auto max-w-5xl space-y-4">
         <h3 class="flex items-center gap-2 text-2xl font-semibold">
-            <i class="fa fa-solid fa-clock text-blue-500" /> Timeago
+            <VCIcon name="fa6-solid:clock" class="text-blue-500" /> Timeago
         </h3>
         <VCTimeago :datetime="dateTime" />
     </div>

--- a/packages/forms/assets/form-select-search.css
+++ b/packages/forms/assets/form-select-search.css
@@ -88,3 +88,28 @@
     flex-wrap: wrap;
     gap: 0.25rem;
 }
+
+.vc-form-select-search .vc-form-select-search-selected-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+    color: var(--vc-color-fg, #111827);
+    background-color: var(--vc-color-bg-muted, #f3f4f6);
+    border: 1px solid var(--vc-color-border, #d1d5db);
+    border-radius: var(--vc-radius-sm, 0.125rem);
+    cursor: pointer;
+    appearance: none;
+}
+
+.vc-form-select-search .vc-form-select-search-selected-item:hover {
+    background-color: var(--vc-color-bg-elevated, #e5e7eb);
+}
+
+.vc-form-select-search .vc-form-select-search-selected-item-remove {
+    color: var(--vc-color-fg-muted, #6b7280);
+    font-weight: 600;
+    line-height: 1;
+}

--- a/packages/forms/assets/form-select.css
+++ b/packages/forms/assets/form-select.css
@@ -42,6 +42,17 @@
     color: var(--vc-color-fg-muted, #6b7280);
 }
 
+/* The value sits between the trigger's value-area and the chevron in a flex
+   row. `min-width: 0` allows it to shrink below its intrinsic width so
+   `text-overflow: ellipsis` (driven by theme classes like Bootstrap's
+   `.text-truncate` or Tailwind's `truncate`) actually triggers; without it
+   long labels push the chevron out of view. */
+.vc-form-select-value {
+    flex: 1 1 0%;
+    min-width: 0;
+    overflow: hidden;
+}
+
 .vc-form-select-icon {
     display: inline-flex;
     align-items: center;

--- a/packages/forms/assets/form-select.css
+++ b/packages/forms/assets/form-select.css
@@ -1,0 +1,118 @@
+/*
+ * Structural defaults for VCFormSelect (Reka Select compound).
+ *
+ * Reka renders a real <button> trigger plus a portal-mounted dropdown panel
+ * with `data-state="open|closed"`. Items expose `data-state="checked|unchecked"`
+ * + `data-highlighted` (keyboard/hover) + `data-disabled`. Theme packages can
+ * target any of these via attribute selectors. Structural CSS below keeps the
+ * widget visible and usable out-of-the-box; theme packages add color / hover
+ * polish on top.
+ */
+.vc-form-select-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.375rem 0.625rem;
+    border: 1px solid var(--vc-color-border, #d1d5db);
+    border-radius: var(--vc-radius-md, 0.375rem);
+    background-color: var(--vc-color-bg, #fff);
+    color: var(--vc-color-fg, #111827);
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    cursor: pointer;
+    text-align: left;
+    appearance: none;
+    -webkit-appearance: none;
+}
+
+.vc-form-select-trigger:focus-visible {
+    outline: 2px solid var(--vc-color-primary-500, #3b82f6);
+    outline-offset: 1px;
+}
+
+.vc-form-select-trigger[data-disabled] {
+    cursor: not-allowed;
+    opacity: 0.5;
+}
+
+.vc-form-select-trigger[data-placeholder] .vc-form-select-value {
+    color: var(--vc-color-fg-muted, #6b7280);
+}
+
+.vc-form-select-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: var(--vc-color-fg-muted, #6b7280);
+}
+
+.vc-form-select-content {
+    z-index: 50;
+    overflow: hidden;
+    min-width: var(--reka-select-trigger-width);
+    max-height: var(--reka-select-content-available-height, 18rem);
+    border: 1px solid var(--vc-color-border, #d1d5db);
+    border-radius: var(--vc-radius-md, 0.375rem);
+    background-color: var(--vc-color-bg, #fff);
+    color: var(--vc-color-fg, #111827);
+    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+}
+
+.vc-form-select-viewport {
+    padding: 0.25rem;
+}
+
+.vc-form-select-item {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.375rem 0.625rem 0.375rem 1.75rem;
+    border-radius: var(--vc-radius-sm, 0.125rem);
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    cursor: pointer;
+    user-select: none;
+    outline: none;
+}
+
+.vc-form-select-item[data-highlighted] {
+    background-color: var(--vc-color-bg-muted, #f3f4f6);
+}
+
+.vc-form-select-item[data-disabled] {
+    cursor: not-allowed;
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.vc-form-select-item-indicator {
+    position: absolute;
+    left: 0.375rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1rem;
+    height: 1rem;
+    color: var(--vc-color-primary-600, #2563eb);
+}
+
+.vc-form-select-group-label {
+    display: block;
+    padding: 0.375rem 0.625rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--vc-color-fg-muted, #6b7280);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.vc-form-select-separator {
+    height: 1px;
+    margin: 0.25rem 0;
+    background-color: var(--vc-color-border, #d1d5db);
+}

--- a/packages/forms/src/components/form-select-search/FormSelectSearch.vue
+++ b/packages/forms/src/components/form-select-search/FormSelectSearch.vue
@@ -212,6 +212,15 @@ export default defineComponent({
         );
 
         const toggle = (option: FormOption) => {
+            // Disabled-form semantics: a disabled control must not mutate
+            // its bound value or emit change events. Mouse picks on dropdown
+            // items are gated by `display()` (which short-circuits when
+            // disabled), but the multi-select chip-remove buttons render
+            // outside the dropdown and were still callable.
+            if (props.disabled) {
+                return;
+            }
+
             if (isMulti.value) {
                 const index = selected.value.findIndex((el) => el.value === option.value);
                 if (index === -1) {
@@ -430,6 +439,7 @@ export default defineComponent({
                     :key="String(item.value)"
                     type="button"
                     :class="theme.selectedItem"
+                    :disabled="disabled"
                     @click="toggle(item)"
                 >
                     {{ item.label }}

--- a/packages/forms/src/components/form-select-search/FormSelectSearch.vue
+++ b/packages/forms/src/components/form-select-search/FormSelectSearch.vue
@@ -277,11 +277,6 @@ export default defineComponent({
             isDisplayed.value = false;
         };
 
-        const toggleHide = (option: FormOption) => {
-            isDisplayed.value = false;
-            toggle(option);
-        };
-
         onClickOutside(listElement, () => {
             hide();
         }, { ignore: [inputElement] });
@@ -320,7 +315,7 @@ export default defineComponent({
                 }
 
                 if (itemsDisplayed.value.length === 1) {
-                    toggleHide(itemsDisplayed.value[0]);
+                    toggle(itemsDisplayed.value[0]);
                     return;
                 }
 
@@ -328,14 +323,14 @@ export default defineComponent({
                     currentIndex.value >= 0 &&
                     itemsDisplayed.value[currentIndex.value]
                 ) {
-                    toggleHide(itemsDisplayed.value[currentIndex.value]);
+                    toggle(itemsDisplayed.value[currentIndex.value]);
 
                     return;
                 }
 
                 if (selected.value.length === 0) {
                     if (itemsDisplayed.value[0]) {
-                        toggleHide(itemsDisplayed.value[0]);
+                        toggle(itemsDisplayed.value[0]);
                     }
 
                     return;
@@ -358,7 +353,6 @@ export default defineComponent({
 
             isMulti,
             toggle,
-            toggleHide,
             currentIndex,
             q,
             items: itemsDisplayed,

--- a/packages/forms/src/components/form-select-search/FormSelectSearch.vue
+++ b/packages/forms/src/components/form-select-search/FormSelectSearch.vue
@@ -170,14 +170,21 @@ export default defineComponent({
             return props.options.filter((option) => option.label.match(pattern));
         });
 
+        // Clamp pagination knobs to a sane minimum: a 0/negative `maxItems`
+        // would render nothing on open, and a 0/negative `scrollDistance`
+        // would stall infinite-scroll because each load step would advance
+        // by zero (or rewind).
+        const pageSize = computed(() => Math.max(1, props.maxItems));
+        const pageStep = computed(() => Math.max(1, props.scrollDistance));
+
         const itemsDisplayed = ref<FormOption[]>([]);
         const setItemsDisplayed = () => {
-            itemsDisplayed.value = items.value.slice(0, props.maxItems);
+            itemsDisplayed.value = items.value.slice(0, pageSize.value);
         };
 
         const showMoreItemsDisplayed = () => {
             const startIndex = itemsDisplayed.value.length;
-            const endIndex = Math.min(startIndex + props.scrollDistance, items.value.length);
+            const endIndex = Math.min(startIndex + pageStep.value, items.value.length);
             if (startIndex >= endIndex) {
                 return;
             }

--- a/packages/forms/src/components/form-select-search/FormSelectSearch.vue
+++ b/packages/forms/src/components/form-select-search/FormSelectSearch.vue
@@ -1,4 +1,10 @@
 <script lang="ts">
+import { useComponentTheme } from '@vuecs/core';
+import type {
+    ThemeClassesOverride,
+    ThemeElementDefinition,
+    VariantValues,
+} from '@vuecs/core';
 import {
     onClickOutside,
     useInfiniteScroll,
@@ -14,6 +20,40 @@ import {
 } from 'vue';
 import type { FormOption } from '../../types/option';
 import FormSelectSearchEntry from './FormSelectSearchEntry.vue';
+
+export type FormSelectSearchThemeClasses = {
+    root: string;
+    input: string;
+    content: string;
+    item: string;
+    itemActive: string;
+    itemCurrent: string;
+    itemDescription: string;
+    selected: string;
+    selectedItem: string;
+    selectedItemRemove: string;
+};
+
+declare module '@vuecs/core' {
+    interface ThemeElements {
+        formSelectSearch?: ThemeElementDefinition<FormSelectSearchThemeClasses>;
+    }
+}
+
+const themeDefaults = {
+    classes: {
+        root: 'vc-form-select-search',
+        input: 'vc-form-select-search-input',
+        content: 'vc-form-select-search-content',
+        item: 'vc-form-select-search-item',
+        itemActive: 'active',
+        itemCurrent: 'current',
+        itemDescription: 'vc-form-select-search-item-description',
+        selected: 'vc-form-select-search-selected',
+        selectedItem: 'vc-form-select-search-selected-item',
+        selectedItemRemove: 'vc-form-select-search-selected-item-remove',
+    },
+};
 
 const formSelectSearchProps = {
     modelValue: {
@@ -46,6 +86,25 @@ const formSelectSearchProps = {
         required: false,
         default: 10,
     },
+    /**
+     * Whether to close the dropdown after a pick. When unset:
+     * - single-select closes (matches the native `<select>` mental model)
+     * - multi-select stays open (so the user can pick several without re-opening)
+     *
+     * Set explicitly (`true` / `false`) to override the mode-default.
+     */
+    closeOnSelect: {
+        type: Boolean as PropType<boolean | undefined>,
+        default: undefined,
+    },
+    themeClass: {
+        type: Object as PropType<ThemeClassesOverride<FormSelectSearchThemeClasses>>,
+        default: undefined,
+    },
+    themeVariant: {
+        type: Object as PropType<VariantValues>,
+        default: undefined,
+    },
 };
 
 export type FormSelectSearchProps = ExtractPublicPropTypes<typeof formSelectSearchProps>;
@@ -55,6 +114,8 @@ export default defineComponent({
     props: formSelectSearchProps,
     emits: ['update:modelValue', 'change'],
     setup(props, { emit }) {
+        const theme = useComponentTheme('formSelectSearch', props, themeDefaults);
+
         const listElement = ref<globalThis.HTMLElement | null>(null);
         const inputElement = ref<globalThis.HTMLElement | null>(null);
 
@@ -113,13 +174,13 @@ export default defineComponent({
 
         const itemsDisplayed = ref<FormOption[]>([]);
         const setItemsDisplayed = () => {
-            itemsDisplayed.value = items.value.slice(0, props.maxItems - 1);
+            itemsDisplayed.value = items.value.slice(0, props.maxItems);
         };
 
         const showMoreItemsDisplayed = () => {
-            const startIndex = itemsDisplayed.value.length - 1;
+            const startIndex = itemsDisplayed.value.length;
             const endIndex = Math.min(startIndex + props.scrollDistance, items.value.length);
-            if (startIndex === endIndex) {
+            if (startIndex >= endIndex) {
                 return;
             }
             itemsDisplayed.value.push(...items.value.slice(startIndex, endIndex));
@@ -144,6 +205,12 @@ export default defineComponent({
 
         const isDisplayed = ref(false);
 
+        // `closeOnSelect === undefined` falls back to the mode-default:
+        // single-select closes, multi stays open.
+        const shouldCloseOnSelect = () => (
+            typeof props.closeOnSelect === 'boolean' ? props.closeOnSelect : !isMulti.value
+        );
+
         const toggle = (option: FormOption) => {
             if (isMulti.value) {
                 const index = selected.value.findIndex((el) => el.value === option.value);
@@ -156,6 +223,10 @@ export default defineComponent({
                 const values = selected.value.map((el) => el.value);
                 emit('update:modelValue', values);
                 emit('change', values);
+
+                if (shouldCloseOnSelect()) {
+                    isDisplayed.value = false;
+                }
                 return;
             }
 
@@ -175,7 +246,9 @@ export default defineComponent({
                 selected.value = [option];
             }
 
-            isDisplayed.value = false;
+            if (shouldCloseOnSelect()) {
+                isDisplayed.value = false;
+            }
 
             if (isBlank) {
                 emit('update:modelValue', null);
@@ -279,6 +352,7 @@ export default defineComponent({
         };
 
         return {
+            theme,
             listElement,
             inputElement,
 
@@ -299,11 +373,11 @@ export default defineComponent({
 });
 </script>
 <template>
-    <div class="vc-form-select-search">
+    <div :class="theme.root">
         <input
             ref="inputElement"
             v-model="q"
-            class="vc-form-select-search-input"
+            :class="theme.input"
             :disabled="disabled"
             :placeholder="placeholder"
             @focus="onFocus"
@@ -314,7 +388,7 @@ export default defineComponent({
         <div
             v-show="isDisplayed"
             ref="listElement"
-            class="vc-form-select-search-content"
+            :class="theme.content"
         >
             <template
                 v-for="(option, index) in items"
@@ -326,17 +400,19 @@ export default defineComponent({
                 >
                     <template #default="{ entry, active }">
                         <div
-                            class="vc-form-select-search-item"
-                            :class="{
-                                'active': active,
-                                'current': index === currentIndex || (index === 0 && currentIndex === -1)
-                            }"
+                            :class="[
+                                theme.item,
+                                {
+                                    [theme.itemActive]: active,
+                                    [theme.itemCurrent]: index === currentIndex || (index === 0 && currentIndex === -1),
+                                },
+                            ]"
                             @mousedown="toggle(entry)"
                         >
                             {{ entry.label }}
                             <span
                                 v-if="entry.description"
-                                class="vc-form-select-search-item-description"
+                                :class="theme.itemDescription"
                             >
                                 {{ entry.description }}
                             </span>
@@ -348,19 +424,26 @@ export default defineComponent({
 
         <div
             v-if="isMulti"
-            class="vc-form-select-search-selected"
+            :class="theme.selected"
         >
             <slot
                 name="selected"
                 :items="selected"
                 :toggle="toggle"
             >
-                <template
+                <button
                     v-for="item in selected"
                     :key="String(item.value)"
+                    type="button"
+                    :class="theme.selectedItem"
+                    @click="toggle(item)"
                 >
                     {{ item.label }}
-                </template>
+                    <span
+                        :class="theme.selectedItemRemove"
+                        aria-hidden="true"
+                    >&times;</span>
+                </button>
             </slot>
         </div>
     </div>

--- a/packages/forms/src/components/form-select-search/FormSelectSearch.vue
+++ b/packages/forms/src/components/form-select-search/FormSelectSearch.vue
@@ -170,8 +170,6 @@ export default defineComponent({
             return props.options.filter((option) => option.label.match(pattern));
         });
 
-        const itemsLength = computed(() => items.value.length);
-
         const itemsDisplayed = ref<FormOption[]>([]);
         const setItemsDisplayed = () => {
             itemsDisplayed.value = items.value.slice(0, props.maxItems);
@@ -188,11 +186,13 @@ export default defineComponent({
 
         setItemsDisplayed();
 
-        watch(itemsLength, (val, oldValue) => {
-            if (val !== oldValue) {
-                currentIndex.value = 0;
-                setItemsDisplayed();
-            }
+        // Watch the filtered set itself, not just its length — two queries can
+        // return the same number of matches but different items, and the
+        // length-only watcher would miss the content swap, leaving the
+        // dropdown showing the previous query's results.
+        watch(items, () => {
+            currentIndex.value = 0;
+            setItemsDisplayed();
         });
 
         useInfiniteScroll(listElement, () => {

--- a/packages/forms/src/components/form-select-search/index.ts
+++ b/packages/forms/src/components/form-select-search/index.ts
@@ -1,4 +1,4 @@
 export { default as VCFormSelectSearch } from './FormSelectSearch.vue';
-export type { FormSelectSearchProps } from './FormSelectSearch.vue';
+export type { FormSelectSearchProps, FormSelectSearchThemeClasses } from './FormSelectSearch.vue';
 export type { FormSelectSearchEntryProps } from './FormSelectSearchEntry.vue';
 export * from './type';

--- a/packages/forms/src/components/form-select/FormSelect.vue
+++ b/packages/forms/src/components/form-select/FormSelect.vue
@@ -30,6 +30,7 @@ import type {
 import {
     defineComponent,
     h,
+    mergeProps,
 } from 'vue';
 import {
     type FormOption,
@@ -84,12 +85,16 @@ const themeDefaults = {
 
 const behavioralDefaults: FormSelectDefaults = { placeholder: '' };
 
-const renderItem = (option: FormOption, classes: FormSelectThemeClasses): VNode => h(
+const renderItem = (
+    option: FormOption,
+    classes: FormSelectThemeClasses,
+    groupDisabled = false,
+): VNode => h(
     SelectItem,
     {
         key: String(option.value),
         value: option.value,
-        disabled: option.disabled,
+        disabled: groupDisabled || option.disabled,
         class: classes.item,
     },
     {
@@ -106,7 +111,7 @@ const renderGroup = (group: FormOptionGroup, classes: FormSelectThemeClasses): V
     {
         default: () => [
             h(SelectLabel, { class: classes.groupLabel }, () => [group.label]),
-            ...group.options.map((option) => renderItem(option, classes)),
+            ...group.options.map((option) => renderItem(option, classes, !!group.disabled)),
         ],
     },
 );
@@ -169,7 +174,7 @@ export default defineComponent({
                 },
             }, {
                 default: () => [
-                    h(SelectTrigger, { class: resolved.trigger || undefined, ...attrs }, () => [
+                    h(SelectTrigger, mergeProps({ class: resolved.trigger || undefined }, attrs), () => [
                         h(SelectValue, { class: resolved.value || undefined, placeholder }),
                         h(SelectIcon, { class: resolved.icon || undefined }, () => '▾'),
                     ]),

--- a/packages/forms/src/components/form-select/FormSelect.vue
+++ b/packages/forms/src/components/form-select/FormSelect.vue
@@ -6,6 +6,20 @@ import type {
     ThemeElementDefinition,
     VariantValues,
 } from '@vuecs/core';
+import {
+    SelectContent,
+    SelectGroup,
+    SelectIcon,
+    SelectItem,
+    SelectItemIndicator,
+    SelectItemText,
+    SelectLabel,
+    SelectPortal,
+    SelectRoot,
+    SelectTrigger,
+    SelectValue,
+    SelectViewport,
+} from 'reka-ui';
 import type { AcceptableValue } from 'reka-ui';
 import type {
     ExtractPublicPropTypes,
@@ -16,7 +30,6 @@ import type {
 import {
     defineComponent,
     h,
-    mergeProps,
 } from 'vue';
 import {
     type FormOption,
@@ -26,13 +39,21 @@ import {
 } from '../../types/option';
 
 export type FormSelectThemeClasses = {
-    root: string;
+    trigger: string;
+    value: string;
+    icon: string;
+    content: string;
+    viewport: string;
+    item: string;
+    itemIndicator: string;
+    group: string;
+    groupLabel: string;
+    separator: string;
 };
 
 export type FormSelectDefaults = {
     /**
-     * Placeholder text rendered as a leading disabled `<option>`. When unset,
-     * no placeholder option is rendered.
+     * Placeholder text rendered inside the trigger when no option is selected.
      */
     placeholder: string;
 };
@@ -46,33 +67,48 @@ declare module '@vuecs/core' {
     }
 }
 
-const themeDefaults = { classes: { root: '' } };
+const themeDefaults = {
+    classes: {
+        trigger: 'vc-form-select-trigger',
+        value: 'vc-form-select-value',
+        icon: 'vc-form-select-icon',
+        content: 'vc-form-select-content',
+        viewport: 'vc-form-select-viewport',
+        item: 'vc-form-select-item',
+        itemIndicator: 'vc-form-select-item-indicator',
+        group: 'vc-form-select-group',
+        groupLabel: 'vc-form-select-group-label',
+        separator: 'vc-form-select-separator',
+    },
+};
 
 const behavioralDefaults: FormSelectDefaults = { placeholder: '' };
 
-const renderOption = (option: FormOption, modelValue: AcceptableValue | undefined): VNode => h(
-    'option',
+const renderItem = (option: FormOption, classes: FormSelectThemeClasses): VNode => h(
+    SelectItem,
     {
         key: String(option.value),
-        // Pass `option.value` through unchanged — Vue's `<option>._value`
-        // patching preserves identity for non-string primitives (boolean,
-        // bigint, object). Casting to `string | number | undefined` would
-        // drop those cases and break the round-trip in `onChange`.
         value: option.value,
-        selected: option.value === modelValue,
         disabled: option.disabled,
+        class: classes.item,
     },
-    [option.label],
+    {
+        default: () => [
+            h(SelectItemText, null, () => [option.label]),
+            h(SelectItemIndicator, { class: classes.itemIndicator }, () => '✓'),
+        ],
+    },
 );
 
-const renderGroup = (group: FormOptionGroup, modelValue: AcceptableValue | undefined): VNode => h(
-    'optgroup',
+const renderGroup = (group: FormOptionGroup, classes: FormSelectThemeClasses): VNode => h(
+    SelectGroup,
+    { key: group.label, class: classes.group },
     {
-        key: group.label,
-        label: group.label,
-        disabled: group.disabled,
+        default: () => [
+            h(SelectLabel, { class: classes.groupLabel }, () => [group.label]),
+            ...group.options.map((option) => renderItem(option, classes)),
+        ],
     },
-    group.options.map((option) => renderOption(option, modelValue)),
 );
 
 const formSelectProps = {
@@ -85,11 +121,16 @@ const formSelectProps = {
         required: true,
     },
     /**
-     * Placeholder text rendered as a leading disabled option. Falls back
-     * to the global `formSelect.placeholder` default; when both are empty
-     * no placeholder is rendered.
+     * Placeholder text rendered inside the trigger when no option is selected.
+     * Falls back to the global `formSelect.placeholder` default.
      */
     placeholder: { type: String, default: undefined },
+    /** When `true`, blocks user interaction with the trigger. */
+    disabled: { type: Boolean, default: false },
+    /** `name` attribute submitted with the owning form. */
+    name: { type: String, default: undefined },
+    /** When `true`, the field must be set before the owning form can submit. */
+    required: { type: Boolean, default: false },
     themeClass: { type: Object as PropType<ThemeClassesOverride<FormSelectThemeClasses>>, default: undefined },
     themeVariant: { type: Object as PropType<VariantValues>, default: undefined },
 };
@@ -98,6 +139,7 @@ export type FormSelectProps = ExtractPublicPropTypes<typeof formSelectProps>;
 
 export default defineComponent({
     name: 'VCFormSelect',
+    inheritAttrs: false,
     props: formSelectProps,
     emits: ['update:modelValue'],
     setup(props, { attrs, emit }) {
@@ -107,49 +149,37 @@ export default defineComponent({
         return () => {
             const resolved = theme.value;
             const { placeholder } = defaults.value;
-            const children: VNodeChild[] = [];
 
-            if (placeholder) {
-                children.push(h(
-                    'option',
-                    {
-                        key: '__placeholder',
-                        value: '',
-                        disabled: true,
-                        selected: props.modelValue === undefined || props.modelValue === '',
-                    },
-                    [placeholder],
-                ));
-            }
-
+            const items: VNodeChild[] = [];
             for (const item of props.options) {
                 if (isFormOptionGroup(item)) {
-                    children.push(renderGroup(item, props.modelValue));
+                    items.push(renderGroup(item, resolved));
                 } else {
-                    children.push(renderOption(item, props.modelValue));
+                    items.push(renderItem(item, resolved));
                 }
             }
 
-            return h('select', mergeProps({
-                class: resolved.root || undefined,
-                onChange($event: Event) {
-                    const target = $event.target as globalThis.HTMLSelectElement;
-                    const selectedRaw = Array.prototype.filter.call(
-                        target.options,
-                        (option: globalThis.HTMLOptionElement) => option.selected,
-                    ).map((option: globalThis.HTMLOptionElement) => {
-                        // Vue patches `_value` onto <option> when `:value`
-                        // resolves to a non-string primitive — preserves the
-                        // original boolean / number / object identity.
-                        const node = option as globalThis.HTMLOptionElement & { _value?: unknown };
-                        return '_value' in node ? node._value : option.value;
-                    });
-
-                    const value = target.multiple ? selectedRaw : selectedRaw[0];
+            return h(SelectRoot, {
+                modelValue: props.modelValue,
+                disabled: props.disabled,
+                name: props.name,
+                required: props.required,
+                'onUpdate:modelValue'(value: AcceptableValue) {
                     emit('update:modelValue', value);
                 },
-                ...(typeof props.modelValue !== 'undefined' ? { value: props.modelValue } : {}),
-            }, attrs), children);
+            }, {
+                default: () => [
+                    h(SelectTrigger, { class: resolved.trigger || undefined, ...attrs }, () => [
+                        h(SelectValue, { class: resolved.value || undefined, placeholder }),
+                        h(SelectIcon, { class: resolved.icon || undefined }, () => '▾'),
+                    ]),
+                    h(SelectPortal, null, () => [
+                        h(SelectContent, { class: resolved.content || undefined, position: 'popper' }, () => [
+                            h(SelectViewport, { class: resolved.viewport || undefined }, () => items),
+                        ]),
+                    ]),
+                ],
+            });
         };
     },
 });

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -7,6 +7,7 @@ import '../assets/form-input.css';
 import '../assets/form-number.css';
 import '../assets/form-pin.css';
 import '../assets/form-radio.css';
+import '../assets/form-select.css';
 import '../assets/form-select-search.css';
 import '../assets/form-slider.css';
 import '../assets/form-switch.css';

--- a/packages/forms/test/unit/components.spec.ts
+++ b/packages/forms/test/unit/components.spec.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import {
+    afterEach,
     beforeAll,
     describe,
     expect,
@@ -25,7 +26,10 @@ import { default as VCFormTextarea } from '../../src/components/form-textarea/Fo
 import { default as VCValidationGroup } from '../../src/components/validation-group/ValidationGroup.vue';
 
 // Reka's `useSize` (used by Slider) constructs a `ResizeObserver`. jsdom does
-// not implement it, so install a no-op stub before any component mounts.
+// not implement it. Reka's `SelectTrigger` calls `target.hasPointerCapture`
+// inside its `pointerdown` handler — also missing from jsdom. Both stubs are
+// no-ops; their presence is what matters so the call doesn't throw and abort
+// Reka's open flow.
 beforeAll(() => {
     if (typeof globalThis.ResizeObserver === 'undefined') {
         globalThis.ResizeObserver = class {
@@ -33,6 +37,12 @@ beforeAll(() => {
             unobserve() {}
             disconnect() {}
         } as unknown as typeof globalThis.ResizeObserver;
+    }
+    if (typeof Element !== 'undefined' && !Element.prototype.hasPointerCapture) {
+        Element.prototype.hasPointerCapture = () => false;
+        Element.prototype.setPointerCapture = () => {};
+        Element.prototype.releasePointerCapture = () => {};
+        Element.prototype.scrollIntoView = () => {};
     }
 });
 
@@ -384,16 +394,37 @@ describe('VCFormSwitch', () => {
 });
 
 describe('VCFormSelect', () => {
-    // Reka's Select renders a <button role="combobox"> trigger; the dropdown
-    // mounts in a portal only when open. jsdom can't drive Reka's open flow
-    // reliably (focus/positioning APIs missing), so these tests assert the
-    // trigger surface only — the structurally interesting bits (item rendering,
-    // selection emit, group <optgroup>-equivalent layout) are exercised in
-    // the docs-site demos and the nuxt example, not here.
+    // Reka's Select mounts dropdown contents in a portal under document.body
+    // only after open. We `attachTo: document.body` and click the trigger to
+    // drive the open flow, then query `document.body` for the portal contents.
     const options = [
         { value: '1', label: 'Option 1' },
         { value: '2', label: 'Option 2' },
     ];
+
+    let activeWrapper: ReturnType<typeof mount> | null = null;
+    afterEach(async () => {
+        // Reka schedules microtasks (e.g. closing the dropdown after a pick)
+        // that try to insertBefore on the teleport target. Unmount + flush
+        // before nuking the body so those updates resolve cleanly.
+        if (activeWrapper) {
+            activeWrapper.unmount();
+            activeWrapper = null;
+        }
+        await nextTick();
+        document.body.innerHTML = '';
+    });
+
+    const openSelect = async (wrapper: ReturnType<typeof mount>) => {
+        activeWrapper = wrapper;
+        // Reka's SelectTrigger opens on `pointerdown` (not `click`). Triggering
+        // a synthetic `click` doesn't dispatch the pointer events jsdom needs.
+        const trigger = wrapper.find('button[role="combobox"]');
+        await trigger.trigger('pointerdown');
+        await trigger.trigger('pointerup');
+        await nextTick();
+        await nextTick();
+    };
 
     it('should render a button trigger with role="combobox"', () => {
         const wrapper = mount(VCFormSelect, {
@@ -429,6 +460,113 @@ describe('VCFormSelect', () => {
         });
         const trigger = wrapper.find('button[role="combobox"]');
         expect(trigger.attributes('disabled')).toBeDefined();
+    });
+
+    it('should render every option as a SelectItem when opened', async () => {
+        const wrapper = mount(VCFormSelect, {
+            props: { options },
+            global: { plugins: [themePlugin] },
+            attachTo: document.body,
+        });
+        await openSelect(wrapper);
+        const items = document.body.querySelectorAll('[role="option"]');
+        expect(items.length).toBe(2);
+        expect(items[0].textContent).toContain('Option 1');
+        expect(items[1].textContent).toContain('Option 2');
+    });
+
+    it('should render groups with their label and options', async () => {
+        const grouped = [
+            {
+                label: 'Americas',
+                options: [
+                    { value: 'us', label: 'United States' },
+                    { value: 'br', label: 'Brazil' },
+                ],
+            },
+            {
+                label: 'Europe',
+                options: [
+                    { value: 'de', label: 'Germany' },
+                ],
+            },
+        ];
+        const wrapper = mount(VCFormSelect, {
+            props: { options: grouped },
+            global: { plugins: [themePlugin] },
+            attachTo: document.body,
+        });
+        await openSelect(wrapper);
+        const text = document.body.textContent || '';
+        expect(text).toContain('Americas');
+        expect(text).toContain('Europe');
+        const items = document.body.querySelectorAll('[role="option"]');
+        expect(items.length).toBe(3);
+    });
+
+    it('should mark options inside a disabled group as disabled', async () => {
+        const grouped = [
+            {
+                label: 'Disabled',
+                disabled: true,
+                options: [
+                    { value: 'a', label: 'A' },
+                    { value: 'b', label: 'B' },
+                ],
+            },
+        ];
+        const wrapper = mount(VCFormSelect, {
+            props: { options: grouped },
+            global: { plugins: [themePlugin] },
+            attachTo: document.body,
+        });
+        await openSelect(wrapper);
+        const items = document.body.querySelectorAll('[role="option"]');
+        expect(items.length).toBe(2);
+        items.forEach((item) => {
+            expect(item.getAttribute('data-disabled')).not.toBeNull();
+        });
+    });
+
+    it('should respect the disabled flag on individual options', async () => {
+        const wrapper = mount(VCFormSelect, {
+            props: {
+                options: [
+                    { value: 'a', label: 'A' },
+                    {
+                        value: 'b', 
+                        label: 'B', 
+                        disabled: true, 
+                    },
+                ],
+            },
+            global: { plugins: [themePlugin] },
+            attachTo: document.body,
+        });
+        await openSelect(wrapper);
+        const items = document.body.querySelectorAll('[role="option"]');
+        expect(items[0].getAttribute('data-disabled')).toBeNull();
+        expect(items[1].getAttribute('data-disabled')).not.toBeNull();
+    });
+
+    it('should emit update:modelValue when an option is picked', async () => {
+        const wrapper = mount(VCFormSelect, {
+            props: { options },
+            global: { plugins: [themePlugin] },
+            attachTo: document.body,
+        });
+        await openSelect(wrapper);
+        const items = document.body.querySelectorAll<HTMLElement>('[role="option"]');
+        // Reka SelectItem selects on `pointerup` (not `click`). Dispatch a real
+        // PointerEvent so Reka's handler accepts it; selection runs in a
+        // microtask so we need to await a few ticks.
+        items[1].dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+        items[1].dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+        await nextTick();
+        await nextTick();
+        const emitted = wrapper.emitted('update:modelValue');
+        expect(emitted).toBeTruthy();
+        expect(emitted![0]).toEqual(['2']);
     });
 });
 

--- a/packages/forms/test/unit/components.spec.ts
+++ b/packages/forms/test/unit/components.spec.ts
@@ -6,7 +6,7 @@ import {
     it,
     vi,
 } from 'vitest';
-import { h } from 'vue';
+import { h, nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { installDefaultsManager, installThemeManager } from '@vuecs/core';
 import { default as VCFormCheckbox } from '../../src/components/form-checkbox/FormCheckbox.vue';
@@ -384,102 +384,51 @@ describe('VCFormSwitch', () => {
 });
 
 describe('VCFormSelect', () => {
+    // Reka's Select renders a <button role="combobox"> trigger; the dropdown
+    // mounts in a portal only when open. jsdom can't drive Reka's open flow
+    // reliably (focus/positioning APIs missing), so these tests assert the
+    // trigger surface only — the structurally interesting bits (item rendering,
+    // selection emit, group <optgroup>-equivalent layout) are exercised in
+    // the docs-site demos and the nuxt example, not here.
     const options = [
         { value: '1', label: 'Option 1' },
         { value: '2', label: 'Option 2' },
     ];
 
-    it('should render a select element', () => {
+    it('should render a button trigger with role="combobox"', () => {
         const wrapper = mount(VCFormSelect, {
             props: { options },
             global: { plugins: [themePlugin] },
         });
-        expect(wrapper.find('select').exists()).toBe(true);
+        expect(wrapper.find('button[role="combobox"]').exists()).toBe(true);
     });
 
-    it('should render placeholder option when placeholder is set', () => {
+    it('should show placeholder text in the trigger when no value is selected', () => {
         const wrapper = mount(VCFormSelect, {
             props: { options, placeholder: 'Pick one' },
             global: { plugins: [themePlugin] },
         });
-        const opts = wrapper.findAll('option');
-        expect(opts).toHaveLength(3); // placeholder + 2
-        expect(opts[0].text()).toBe('Pick one');
-        expect(opts[0].attributes('disabled')).toBeDefined();
+        expect(wrapper.find('button[role="combobox"]').text()).toContain('Pick one');
     });
 
-    it('should not render placeholder option when placeholder is empty', () => {
-        const wrapper = mount(VCFormSelect, {
-            props: { options },
-            global: { plugins: [themePlugin] },
-        });
-        expect(wrapper.findAll('option')).toHaveLength(2);
-    });
-
-    it('should render all options with their labels', () => {
-        const wrapper = mount(VCFormSelect, {
-            props: { options },
-            global: { plugins: [themePlugin] },
-        });
-        const opts = wrapper.findAll('option');
-        expect(opts[0].text()).toBe('Option 1');
-        expect(opts[1].text()).toBe('Option 2');
-    });
-
-    it('should render groups as <optgroup>', () => {
-        const grouped = [
-            {
-                label: 'Americas',
-                options: [
-                    { value: 'us', label: 'United States' },
-                    { value: 'br', label: 'Brazil' },
-                ],
-            },
-            {
-                label: 'Europe',
-                options: [
-                    { value: 'de', label: 'Germany' },
-                ],
-            },
-        ];
-        const wrapper = mount(VCFormSelect, {
-            props: { options: grouped },
-            global: { plugins: [themePlugin] },
-        });
-        const groups = wrapper.findAll('optgroup');
-        expect(groups).toHaveLength(2);
-        expect(groups[0].attributes('label')).toBe('Americas');
-        expect(groups[1].attributes('label')).toBe('Europe');
-        // Three options under the two groups.
-        const opts = wrapper.findAll('option');
-        expect(opts).toHaveLength(3);
-    });
-
-    it('should mark the matching option as selected from modelValue', () => {
+    it('should show the matching option label in the trigger when modelValue is set', async () => {
         const wrapper = mount(VCFormSelect, {
             props: { options, modelValue: '2' },
             global: { plugins: [themePlugin] },
         });
-        const opts = wrapper.findAll('option');
-        expect((opts[1].element as HTMLOptionElement).selected).toBe(true);
+        // SelectValue resolves the displayed label asynchronously after
+        // SelectItem registers its text — wait one tick.
+        await nextTick();
+        expect(wrapper.find('button[role="combobox"]').text()).toContain('Option 2');
     });
 
-    it('should respect disabled flag on individual options', () => {
+    it('should respect the disabled prop on the trigger', () => {
         const wrapper = mount(VCFormSelect, {
-            props: {
-                options: [
-                    { value: 'a', label: 'A' },
-                    {
-                        value: 'b', 
-                        label: 'B', 
-                        disabled: true, 
-                    },
-                ],
-            },
+            props: { options, disabled: true },
             global: { plugins: [themePlugin] },
         });
-        const opts = wrapper.findAll('option');
-        expect(opts[1].attributes('disabled')).toBeDefined();
+        const trigger = wrapper.find('button[role="combobox"]');
+        expect(trigger.attributes('disabled')).toBeDefined();
     });
 });
 

--- a/packages/link/src/component.ts
+++ b/packages/link/src/component.ts
@@ -183,6 +183,8 @@ export const VCLink = defineComponent({
                     active: props.active,
                     disabled: props.disabled,
                 },
+                'data-active': props.active ? '' : undefined,
+                'data-disabled': props.disabled ? '' : undefined,
                 ...computedAttrs.value,
                 ...computedProps.value,
                 onClick,

--- a/packages/navigation/src/components/item/module.ts
+++ b/packages/navigation/src/components/item/module.ts
@@ -84,6 +84,18 @@ export const VCNavItem = defineComponent({
             await manager.select(data.value.level, value);
         };
 
+        // Iconify-style icon strings (e.g. `fa6-solid:home`, `lucide:plus`)
+        // contain a colon. Render via the globally-registered <VCIcon> so
+        // they resolve through the Iconify pipeline rather than landing as
+        // raw CSS classes on a literal <i>. Legacy class-string icons
+        // (`fa fa-home`, `material-icons home`) keep their <i class> rendering.
+        const renderIcon = (icon: string): VNodeChild => {
+            if (icon.includes(':')) {
+                return h(resolveComponent('VCIcon'), { name: icon });
+            }
+            return h('i', { class: icon });
+        };
+
         const toggle = async (
             value: NavigationItemNormalized,
         ) => {
@@ -152,7 +164,7 @@ export const VCNavItem = defineComponent({
                         default: () => [
                             ...(data.value.icon ?
                                 [h('div', { class: resolved.linkIcon || undefined }, [
-                                    h('i', { class: data.value.icon }),
+                                    renderIcon(data.value.icon),
                                 ])] :
                                 []),
                             h('div', { class: resolved.linkText || undefined }, [
@@ -201,7 +213,7 @@ export const VCNavItem = defineComponent({
                     }, [
                         ...(data.value.icon ?
                             [h('div', { class: resolved.linkIcon || undefined }, [
-                                h('i', { class: data.value.icon }),
+                                renderIcon(data.value.icon),
                             ])] :
                             []),
                         h('div', { class: resolved.linkText || undefined }, [

--- a/packages/navigation/src/components/item/module.ts
+++ b/packages/navigation/src/components/item/module.ts
@@ -182,6 +182,8 @@ export const VCNavItem = defineComponent({
                     title = h('div', {
                         class: resolved.link,
                         'data-vc-collection-item': '',
+                        'data-state': data.value.displayChildren ? 'open' : 'closed',
+                        'data-active': data.value.active ? '' : undefined,
                         tabindex: 0,
                         role: 'button',
                         'aria-expanded': data.value.displayChildren ? 'true' : 'false',
@@ -235,6 +237,8 @@ export const VCNavItem = defineComponent({
                     ...(hasChildren.value ? [resolved.itemNested] : []),
                     { active: data.value.active || data.value.displayChildren },
                 ],
+                'data-active': data.value.active || data.value.displayChildren ? '' : undefined,
+                ...(hasChildren.value ? { 'data-state': data.value.displayChildren ? 'open' : 'closed' } : {}),
             }, [buildItem()]);
         };
     },

--- a/packages/overlays/src/components/modal/ModalClose.vue
+++ b/packages/overlays/src/components/modal/ModalClose.vue
@@ -37,7 +37,12 @@ export default defineComponent({
             const hasSlot = !!slots.default;
             const ariaLabel = (attrs['aria-label'] as string | undefined) ??
                 (hasSlot ? undefined : 'Close');
-            const slotKey = props.icon ? 'closeIcon' : 'close';
+            // Slot-presence heuristic: a bare `<VCModalClose />` means
+            // the consumer wants the default `×` glyph in the corner — they
+            // didn't provide content because they want the icon presentation.
+            // Explicit `icon` always wins; a slot with content (e.g. "Cancel")
+            // implies the labelled-button presentation.
+            const slotKey = props.icon || !hasSlot ? 'closeIcon' : 'close';
             return h(
                 DialogClose,
                 {

--- a/packages/overlays/src/components/modal/ModalClose.vue
+++ b/packages/overlays/src/components/modal/ModalClose.vue
@@ -10,6 +10,13 @@ import type { ModalThemeClasses } from './types';
 const modalCloseProps = {
     as: { type: String, default: 'button' },
     asChild: { type: Boolean, default: false },
+    /**
+     * When true, renders as a pre-styled corner-X (reads the theme's
+     * `closeIcon` slot — absolute positioning + sizing). When false
+     * (default), renders neutrally so consumer classes via `class=` /
+     * `:theme-class` compose cleanly — use this for Cancel-style buttons.
+     */
+    icon: { type: Boolean, default: false },
     themeClass: { type: Object as PropType<ThemeClassesOverride<ModalThemeClasses>>, default: undefined },
     themeVariant: { type: Object as PropType<VariantValues>, default: undefined },
 };
@@ -30,12 +37,13 @@ export default defineComponent({
             const hasSlot = !!slots.default;
             const ariaLabel = (attrs['aria-label'] as string | undefined) ??
                 (hasSlot ? undefined : 'Close');
+            const slotKey = props.icon ? 'closeIcon' : 'close';
             return h(
                 DialogClose,
                 {
                     as: props.as,
                     asChild: props.asChild,
-                    class: theme.value.close || undefined,
+                    class: theme.value[slotKey] || undefined,
                     'aria-label': ariaLabel,
                 },
                 { default: () => slots.default?.() ?? '×' },

--- a/packages/overlays/src/components/modal/theme.ts
+++ b/packages/overlays/src/components/modal/theme.ts
@@ -21,6 +21,7 @@ export const modalThemeDefaults: ComponentThemeDefinition<ModalThemeClasses> = {
         footer: 'vc-modal-footer',
         trigger: 'vc-modal-trigger',
         close: 'vc-modal-close',
+        closeIcon: 'vc-modal-close-icon',
         back: 'vc-modal-back',
     },
 };

--- a/packages/overlays/src/components/modal/types.ts
+++ b/packages/overlays/src/components/modal/types.ts
@@ -17,8 +17,17 @@ export type ModalThemeClasses = {
     footer: string;
     /** Trigger button element. */
     trigger: string;
-    /** Close button element. */
+    /**
+     * Generic close-trigger button. Neutral by design (just focus-ring +
+     * button affordances) so consumer classes layered via `class=` compose
+     * cleanly. Used by `<VCModalClose>`.
+     */
     close: string;
+    /**
+     * Corner-X close button. Carries absolute positioning + sizing so it
+     * docks into the dialog's top-right corner. Used by `<VCModalCloseIcon>`.
+     */
+    closeIcon: string;
     /** "Back" button shown when the view stack has history. */
     back: string;
 };

--- a/packages/overlays/src/components/popover/PopoverClose.vue
+++ b/packages/overlays/src/components/popover/PopoverClose.vue
@@ -10,6 +10,13 @@ import type { PopoverThemeClasses } from './types';
 const popoverCloseProps = {
     as: { type: String, default: 'button' },
     asChild: { type: Boolean, default: false },
+    /**
+     * When true, renders as a pre-styled corner-X (reads the theme's
+     * `closeIcon` slot — absolute positioning + sizing). When false
+     * (default), renders neutrally so consumer classes via `class=` /
+     * `:theme-class` compose cleanly.
+     */
+    icon: { type: Boolean, default: false },
     themeClass: { type: Object as PropType<ThemeClassesOverride<PopoverThemeClasses>>, default: undefined },
     themeVariant: { type: Object as PropType<VariantValues>, default: undefined },
 };
@@ -30,12 +37,13 @@ export default defineComponent({
             const hasSlot = !!slots.default;
             const ariaLabel = (attrs['aria-label'] as string | undefined) ??
                 (hasSlot ? undefined : 'Close');
+            const slotKey = props.icon ? 'closeIcon' : 'close';
             return h(
                 PopoverClose,
                 {
                     as: props.as,
                     asChild: props.asChild,
-                    class: theme.value.close || undefined,
+                    class: theme.value[slotKey] || undefined,
                     'aria-label': ariaLabel,
                 },
                 { default: () => slots.default?.() ?? '×' },

--- a/packages/overlays/src/components/popover/PopoverClose.vue
+++ b/packages/overlays/src/components/popover/PopoverClose.vue
@@ -37,7 +37,12 @@ export default defineComponent({
             const hasSlot = !!slots.default;
             const ariaLabel = (attrs['aria-label'] as string | undefined) ??
                 (hasSlot ? undefined : 'Close');
-            const slotKey = props.icon ? 'closeIcon' : 'close';
+            // Slot-presence heuristic: a bare `<VCPopoverClose />` means
+            // the consumer wants the default `×` glyph in the corner — they
+            // didn't provide content because they want the icon presentation.
+            // Explicit `icon` always wins; a slot with content implies the
+            // labelled-button presentation.
+            const slotKey = props.icon || !hasSlot ? 'closeIcon' : 'close';
             return h(
                 PopoverClose,
                 {

--- a/packages/overlays/src/components/popover/theme.ts
+++ b/packages/overlays/src/components/popover/theme.ts
@@ -7,5 +7,6 @@ export const popoverThemeDefaults: ComponentThemeDefinition<PopoverThemeClasses>
         trigger: 'vc-popover-trigger',
         arrow: 'vc-popover-arrow',
         close: 'vc-popover-close',
+        closeIcon: 'vc-popover-close-icon',
     },
 };

--- a/packages/overlays/src/components/popover/types.ts
+++ b/packages/overlays/src/components/popover/types.ts
@@ -7,8 +7,16 @@ export type PopoverThemeClasses = {
     trigger: string;
     /** Arrow / pointer element. */
     arrow: string;
-    /** Close button (optional). */
+    /**
+     * Generic close-trigger button. Neutral by design so consumer classes
+     * layered via `class=` compose cleanly. Used by `<VCPopoverClose>`.
+     */
     close: string;
+    /**
+     * Corner-X close button. Carries absolute positioning + sizing so it
+     * docks into the popover's top-right corner. Used by `<VCPopoverCloseIcon>`.
+     */
+    closeIcon: string;
 };
 
 declare module '@vuecs/core' {

--- a/themes/bootstrap/src/index.ts
+++ b/themes/bootstrap/src/index.ts
@@ -280,7 +280,11 @@ export default function bootstrapTheme(): Theme {
                     body: 'modal-body',
                     footer: 'modal-footer',
                     trigger: '',
-                    close: 'btn-close position-absolute top-0 end-0 m-2',
+                    // Generic close trigger — neutral baseline so consumer
+                    // classes (`<VCModalClose class="...">`) compose cleanly.
+                    // The corner-X pattern lives in `closeIcon` below.
+                    close: '',
+                    closeIcon: 'btn-close position-absolute top-0 end-0 m-2',
                     back: 'btn btn-sm btn-link p-1',
                 },
             },
@@ -289,7 +293,10 @@ export default function bootstrapTheme(): Theme {
                     trigger: '',
                     content: 'popover bs-popover-auto show vc-overlay-anim',
                     arrow: 'popover-arrow',
-                    close: 'btn-close position-absolute top-0 end-0 m-1',
+                    // Generic close trigger — neutral baseline so consumer
+                    // classes compose cleanly. Corner-X lives in `closeIcon`.
+                    close: '',
+                    closeIcon: 'btn-close position-absolute top-0 end-0 m-1',
                 },
             },
             tooltip: {

--- a/themes/bootstrap/src/index.ts
+++ b/themes/bootstrap/src/index.ts
@@ -46,7 +46,42 @@ export default function bootstrapTheme(): Theme {
                     group: '',
                 },
             },
-            formSelect: { classes: { root: 'form-select' } },
+            formSelect: {
+                classes: {
+                    // Bootstrap's `.form-select` ships the chevron via background-image —
+                    // it works for native <select> but not for our compound trigger.
+                    // We use `.form-control` for the input chrome plus `d-flex` to lay
+                    // out the value and our own chevron <span> (rendered by SelectIcon).
+                    trigger: 'form-control d-flex align-items-center justify-content-between gap-2 text-start',
+                    value: 'text-truncate',
+                    icon: 'text-muted',
+                    content: 'dropdown-menu show vc-overlay-anim',
+                    viewport: '',
+                    item: 'dropdown-item ps-4 position-relative',
+                    itemIndicator: 'position-absolute start-0 ms-2',
+                    group: '',
+                    groupLabel: 'dropdown-header',
+                    separator: 'dropdown-divider',
+                },
+            },
+            formSelectSearch: {
+                classes: {
+                    root: 'position-relative',
+                    input: 'form-control',
+                    // .show flips Bootstrap's dropdown-menu visibility. The component
+                    // toggles its own v-show, so .show is redundant for visibility,
+                    // but ensures the menu picks up `display: block` if a consumer
+                    // upgrades to a custom toggle that relies on the bootstrap class.
+                    content: 'dropdown-menu show w-100 mt-1 overflow-auto',
+                    item: 'dropdown-item d-flex flex-column gap-1',
+                    itemActive: 'active',
+                    itemCurrent: 'bg-secondary-subtle',
+                    itemDescription: 'small text-muted',
+                    selected: 'd-flex flex-wrap gap-1 mt-2',
+                    selectedItem: 'badge bg-secondary-subtle text-body border d-inline-flex align-items-center gap-1',
+                    selectedItemRemove: 'fw-bold',
+                },
+            },
             formRadio: {
                 classes: {
                     root: 'bg-white shadow-sm',

--- a/themes/bootstrap/src/index.ts
+++ b/themes/bootstrap/src/index.ts
@@ -230,7 +230,12 @@ export default function bootstrapTheme(): Theme {
                     // Bootstrap's own `.active.page-link` rules; we merge
                     // `active` into linkActive below.
                     item: 'page-item',
-                    link: 'page-link',
+                    // `d-inline-flex align-items-center gap-1` layers on top of
+                    // Bootstrap's `.page-link` so the icon + label pair (e.g.
+                    // <chevron> "Previous") sits on a single baseline with
+                    // breathing room between them. `.page-link` is `display: block`
+                    // by default, which would otherwise stack them.
+                    link: 'page-link d-inline-flex align-items-center gap-1',
                     linkActive: 'active',
                     // Wrapper composes `link + ellipsis` onto PaginationEllipsis
                     // so it inherits the page-link box. Disable interactivity.

--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -238,7 +238,7 @@ export default function tailwindTheme(): Theme {
                     // `size` variant, bg/border/colors come from the `variant`
                     // variant. Keeping concerns split lets consumers pick a
                     // size and a visual treatment independently.
-                    link: 'inline-flex items-center justify-center rounded-md leading-none focus:outline-none focus:ring-1 focus:ring-ring',
+                    link: 'inline-flex items-center justify-center gap-1.5 rounded-md leading-none focus:outline-none focus:ring-1 focus:ring-ring',
                     linkActive: '!border-primary-600 !bg-primary-600 !text-on-primary hover:!bg-primary-700',
                     // The component composes `link + ellipsis` onto
                     // PaginationEllipsis so it inherits the box styling

--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -272,7 +272,7 @@ export default function tailwindTheme(): Theme {
             modal: {
                 classes: {
                     overlay: 'fixed inset-0 z-50 bg-neutral-950/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-                    content: 'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border border-border bg-bg p-6 shadow-lg outline-none focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+                    content: 'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border border-border bg-bg p-6 text-fg shadow-lg outline-none focus:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
                     header: 'flex flex-col gap-1.5',
                     title: 'text-lg font-semibold text-fg',
                     description: 'text-sm text-fg-muted',

--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -57,7 +57,34 @@ export default function tailwindTheme(): Theme {
                     group: 'inline-flex items-center gap-2',
                 },
             },
-            formSelect: { classes: { root: 'block w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:bg-bg-muted' } },
+            formSelect: {
+                classes: {
+                    trigger: 'flex w-full items-center justify-between gap-2 rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-ring data-[disabled]:cursor-not-allowed data-[disabled]:bg-bg-muted data-[placeholder]:text-fg-muted',
+                    value: 'truncate',
+                    icon: 'inline-flex h-4 w-4 shrink-0 items-center justify-center text-fg-muted',
+                    content: 'z-50 overflow-hidden rounded-md border border-border bg-bg text-sm text-fg shadow-md min-w-[var(--reka-select-trigger-width)] max-h-[var(--reka-select-content-available-height)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+                    viewport: 'p-1',
+                    item: 'relative flex cursor-pointer select-none items-center gap-2 rounded-sm py-1.5 pl-7 pr-2 outline-none data-[highlighted]:bg-bg-muted data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+                    itemIndicator: 'absolute left-2 inline-flex h-3.5 w-3.5 items-center justify-center text-primary-600',
+                    group: '',
+                    groupLabel: 'px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-fg-muted',
+                    separator: '-mx-1 my-1 h-px bg-border',
+                },
+            },
+            formSelectSearch: {
+                classes: {
+                    root: 'relative block',
+                    input: 'block w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:bg-bg-muted',
+                    content: 'absolute inset-x-0 top-[calc(100%+0.25rem)] z-50 max-h-60 overflow-y-auto rounded-md border border-border bg-bg shadow-md',
+                    item: 'flex cursor-pointer select-none flex-col gap-0.5 px-3 py-2 text-sm text-fg outline-none hover:bg-bg-muted',
+                    itemActive: '!bg-bg-elevated font-semibold',
+                    itemCurrent: 'bg-bg-muted',
+                    itemDescription: 'text-xs text-fg-muted',
+                    selected: 'mt-2 flex flex-wrap gap-1',
+                    selectedItem: 'inline-flex items-center gap-1 rounded-sm border border-border bg-bg-muted px-2 py-0.5 text-xs text-fg hover:bg-bg-elevated',
+                    selectedItemRemove: 'font-semibold leading-none text-fg-muted',
+                },
+            },
             formRadio: {
                 classes: {
                     root: 'inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-border bg-bg shadow-sm transition-colors hover:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 data-[state=checked]:border-primary-600 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',

--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -77,7 +77,7 @@ export default function tailwindTheme(): Theme {
                     input: 'block w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:bg-bg-muted',
                     content: 'absolute inset-x-0 top-[calc(100%+0.25rem)] z-50 max-h-60 overflow-y-auto rounded-md border border-border bg-bg shadow-md',
                     item: 'flex cursor-pointer select-none flex-col gap-0.5 px-3 py-2 text-sm text-fg outline-none hover:bg-bg-muted',
-                    itemActive: '!bg-bg-elevated font-semibold',
+                    itemActive: 'bg-bg-elevated! font-semibold',
                     itemCurrent: 'bg-bg-muted',
                     itemDescription: 'text-xs text-fg-muted',
                     selected: 'mt-2 flex flex-wrap gap-1',

--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -279,7 +279,11 @@ export default function tailwindTheme(): Theme {
                     body: 'flex flex-col gap-2 text-sm text-fg',
                     footer: 'flex flex-row items-center justify-end gap-2',
                     trigger: '',
-                    close: 'absolute right-3 top-3 inline-flex h-7 w-7 items-center justify-center rounded-md text-fg-muted hover:bg-bg-muted hover:text-fg focus:outline-none focus:ring-2 focus:ring-ring',
+                    // Generic close trigger — neutral baseline so consumer
+                    // classes (`<VCModalClose class="...">`) compose cleanly.
+                    // The corner-X pattern lives in `closeIcon` below.
+                    close: 'focus:outline-none focus:ring-2 focus:ring-ring',
+                    closeIcon: 'absolute right-3 top-3 inline-flex h-7 w-7 items-center justify-center rounded-md text-fg-muted hover:bg-bg-muted hover:text-fg focus:outline-none focus:ring-2 focus:ring-ring',
                     back: 'inline-flex h-7 w-7 items-center justify-center rounded-md text-fg-muted hover:bg-bg-muted hover:text-fg focus:outline-none focus:ring-2 focus:ring-ring',
                 },
             },
@@ -288,7 +292,10 @@ export default function tailwindTheme(): Theme {
                     trigger: '',
                     content: 'z-50 w-72 rounded-md border border-border bg-bg p-4 text-sm text-fg shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
                     arrow: 'fill-bg',
-                    close: 'absolute right-2 top-2 inline-flex h-6 w-6 items-center justify-center rounded-md text-fg-muted hover:bg-bg-muted hover:text-fg focus:outline-none focus:ring-2 focus:ring-ring',
+                    // Generic close trigger — neutral baseline so consumer
+                    // classes compose cleanly. Corner-X lives in `closeIcon`.
+                    close: 'focus:outline-none focus:ring-2 focus:ring-ring',
+                    closeIcon: 'absolute right-2 top-2 inline-flex h-6 w-6 items-center justify-center rounded-md text-fg-muted hover:bg-bg-muted hover:text-fg focus:outline-none focus:ring-2 focus:ring-ring',
                 },
             },
             tooltip: {


### PR DESCRIPTION
## Summary

Closes plan 009 (Reka UI adoption roadmap) Phase 4. Centerpiece is the `<VCFormSelect>` migration from a native `<select>` to Reka's `Select` compound while keeping the flat `:options` / `:placeholder` / `v-model` public API frozen. Riders: `<VCFormSelectSearch>` is now wired into the theme system, gets a configurable `closeOnSelect` prop, and the infinite-scroll boundary off-by-one is fixed. `<VCNavItem>` + `<VCLink>` get `data-active` / `data-disabled` attributes (Lesson #2 retrofit); `<VCNavItem>`'s expandable group title also gets `data-state="open|closed"`.

### `<VCFormSelect>` Reka migration (BREAKING)

- Internals replaced with `SelectRoot` / `SelectTrigger` / `SelectValue` / `SelectIcon` / `SelectPortal` / `SelectContent` / `SelectViewport` / `SelectItem` / `SelectItemText` / `SelectItemIndicator` / `SelectGroup` / `SelectLabel`.
- Public API additions: `:disabled`, `:name`, `:required` props (forwarded to `SelectRoot` for form-submission semantics).
- Theme keys expand from `{ root }` to `{ trigger, value, icon, content, viewport, item, itemIndicator, group, groupLabel, separator }`.
- DOM behavior change: native `<select>` (and the OS mobile picker) replaced by a `<button role="combobox">` trigger plus a portal-mounted custom dropdown. Themes target `data-state="open|closed"` / `data-highlighted` / `data-disabled` / `data-placeholder`.
- `FormOptionGroup.disabled` now propagates to every `SelectItem` inside the group.
- New structural CSS at `packages/forms/assets/form-select.css` (includes `min-width: 0` on `.vc-form-select-value` so theme-applied truncate utilities can ellipsize inside the flex trigger).

**Breaking change:** `themeClass.root` → `themeClass.trigger`. Consumers passing `themeClass={ root: ... }` need to migrate.

### `<VCFormSelectSearch>` improvements

- Now wired through `useComponentTheme('formSelectSearch', …)` with a 10-key slot map: `root` / `input` / `content` / `item` / `itemActive` / `itemCurrent` / `itemDescription` / `selected` / `selectedItem` / `selectedItemRemove`. Theme entries shipped in both `theme-tailwind` and `theme-bootstrap`.
- New `closeOnSelect` prop (`boolean | undefined`). Default `undefined` uses mode-default (single closes, multi stays open). Set explicitly to override. The Enter-key path now honors this too (mouse and keyboard pickers behave consistently).
- Default selected-pills now render as styled chip buttons with an `×` glyph that toggles deselection (instead of bare concatenated label text).
- Fixes infinite-scroll boundary off-by-one: `startIndex = length - 1` re-included the previous page's last item at the start of each new page; corrected to `startIndex = length`.

### `<VCNavItem>` + `<VCLink>` data-state retrofit

- `<VCLink>` emits `data-active` / `data-disabled` attributes alongside the existing class toggles.
- `<VCNavItem>` group title gets `data-state="open|closed"` + `data-active`; the `<li>` gets `data-active` and `data-state` (when nested).

### Plan 009 close-out

All four phases marked ✅. The `<VCFormSelectSearch>` Reka primitive migration stays out-of-roadmap (future Combobox successor); the theming gap is closed regardless.

## Test plan

- [x] `npm run test --workspace=packages/forms` — 57/57 pass (5 new tests cover item rendering, group rendering, group-disabled propagation, item-disabled, and `update:modelValue` emit; uses `attachTo: document.body` + jsdom stubs for `hasPointerCapture` / `setPointerCapture` / `scrollIntoView` so Reka's `pointerdown` open flow runs)
- [x] `npm run build` — all 20 packages build clean (tsdown + vue-tsc, no `|| true` mask)
- [x] `npm run lint` — 0 errors
- [ ] Manual: open `<VCFormSelect>` in docs site / nuxt example, verify dropdown renders, keyboard nav (arrows/Enter/Escape), placeholder and selected-label render in trigger, Tailwind + Bootstrap themes look right, long labels ellipsize without pushing the chevron out
- [ ] Manual: open `<VCFormSelectSearch>` multi-select demo — confirm chips render, deselect works, no boundary duplicate after scrolling past `maxItems`, mouse and keyboard `closeOnSelect` behave consistently
- [ ] Manual: navigation — confirm `data-active` / `data-state` attributes appear on rendered nav items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form Select now uses a compound custom dropdown trigger with keyboard navigation/type-ahead; Form Select Search adds a closeOnSelect option. Modal/Popover close controls gain an icon variant.

* **Documentation**
  * Documented disabled/name/required props, updated placeholder behavior, and expanded "Theme keys" for multi-slot selects and closeIcon.

* **Style**
  * Added styles for select trigger, dropdown, items, and selected-item chips; updated Bootstrap/Tailwind theme mappings.

* **Tests**
  * Updated unit tests to validate the custom trigger and portal-rendered dropdown behavior.

* **Enhancements**
  * Link/nav items expose data attributes for active/disabled/state; examples switched to icon component usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->