### PR TITLE
feat(elements,gravatar): semantic size variant on <VCAvatar>, display…

### DIFF
--- a/docs/demos/src/gravatar.demo.vue
+++ b/docs/demos/src/gravatar.demo.vue
@@ -6,15 +6,18 @@ import { VCGravatar } from '@vuecs/gravatar';
     <div style="display: flex; gap: 1rem; align-items: center;">
         <VCGravatar
             email="contact@tada5hi.net"
-            :size="48"
+            display-size="md"
+            :size="80"
         />
         <VCGravatar
             email="hello@example.com"
-            :size="48"
+            display-size="md"
+            :size="80"
         />
         <VCGravatar
             email="anon@example.com"
-            :size="48"
+            display-size="md"
+            :size="80"
         />
     </div>
 </template>

--- a/docs/src/components/avatar.md
+++ b/docs/src/components/avatar.md
@@ -51,6 +51,7 @@ import { VCAvatar } from '@vuecs/elements';
 | `src` | `string` | `undefined` | Image source. When omitted, the fallback renders immediately. |
 | `alt` | `string` | `''` | Alt text for the image. Empty string = decorative; pass a meaningful value when the avatar conveys identity. |
 | `delayMs` | `number` | `undefined` | Delay before the fallback appears — useful to avoid a flicker on fast connections. Only strictly positive values are forwarded to Reka (its `AvatarFallback` treats `0` as "wait forever"); omit to render the fallback immediately. |
+| `size` | `'sm' \| 'md' \| 'lg'` | theme default (`md`) | Size variant. `sm` ≈ 32px, `md` ≈ 40px, `lg` ≈ 56px (theme-defined). For arbitrary pixel sizes, use `themeClass={ root: extend('h-12 w-12') }` instead. Mirrors `<VCBadge>`'s size axis. |
 | `themeClass` | `Partial<AvatarThemeClasses>` | `undefined` | Per-instance theme override. |
 | `themeVariant` | `Record<string, string \| boolean>` | `undefined` | Per-instance variant values. |
 

--- a/docs/src/components/avatar.md
+++ b/docs/src/components/avatar.md
@@ -51,7 +51,7 @@ import { VCAvatar } from '@vuecs/elements';
 | `src` | `string` | `undefined` | Image source. When omitted, the fallback renders immediately. |
 | `alt` | `string` | `''` | Alt text for the image. Empty string = decorative; pass a meaningful value when the avatar conveys identity. |
 | `delayMs` | `number` | `undefined` | Delay before the fallback appears — useful to avoid a flicker on fast connections. Only strictly positive values are forwarded to Reka (its `AvatarFallback` treats `0` as "wait forever"); omit to render the fallback immediately. |
-| `size` | `'sm' \| 'md' \| 'lg'` | theme default (`md`) | Size variant. `sm` ≈ 32px, `md` ≈ 40px, `lg` ≈ 56px (theme-defined). For arbitrary pixel sizes, use `themeClass={ root: extend('h-12 w-12') }` instead. Mirrors `<VCBadge>`'s size axis. |
+| `size` | `'sm' \| 'md' \| 'lg'` | theme default (`md`) | Size variant. `sm` ≈ 32px, `md` ≈ 40px, `lg` ≈ 56px (theme-defined). For arbitrary pixel sizes, use `:theme-class="{ root: extend('h-12 w-12') }"` instead. Mirrors `<VCBadge>`'s size axis. |
 | `themeClass` | `Partial<AvatarThemeClasses>` | `undefined` | Per-instance theme override. |
 | `themeVariant` | `Record<string, string \| boolean>` | `undefined` | Per-instance variant values. |
 

--- a/docs/src/components/gravatar.md
+++ b/docs/src/components/gravatar.md
@@ -28,7 +28,9 @@ import { VCGravatar } from '@vuecs/gravatar';
 </script>
 
 <template>
-    <VCGravatar email="user@example.com" :size="48" />
+    <!-- displaySize drives the rendered chip; size is the URL `?s=` parameter -->
+    <!-- (match it to displaySize × 2 for retina-crisp rendering). -->
+    <VCGravatar email="user@example.com" display-size="md" :size="80" />
 </template>
 ```
 

--- a/docs/src/components/gravatar.md
+++ b/docs/src/components/gravatar.md
@@ -52,7 +52,8 @@ import { VCGravatar } from '@vuecs/gravatar';
 |------|------|---------|-------------|
 | `email` | `string` | `''` | Email address (hashed client-side via MD5) |
 | `hash` | `string` | `''` | Pre-computed MD5 hash — bypasses `email` if set |
-| `size` | `number` | `80` | Resolution served by Gravatar (URL `?s=` parameter, range 1–2048). **Does not** control rendered size — match it to your displayed dimensions (or 2× for retina) to avoid up/down-scaling. Visual sizing lives in the theme system (default 5rem via the structural `vc-gravatar` class). |
+| `size` | `number` | `80` | Resolution served by Gravatar (URL `?s=` parameter, range 1–2048). **Does not** control rendered size — match it to your displayed dimensions (or 2× for retina) to avoid up/down-scaling. |
+| `displaySize` | `'sm' \| 'md' \| 'lg'` | `undefined` | Visual size — forwards to `<VCAvatar :size>`. `sm` ≈ 32px, `md` ≈ 40px, `lg` ≈ 56px. Omit to fall back to the structural `vc-gravatar` 5rem (80px) baseline. Pair with a matching `size` (URL resolution) for crisp rendering: `<VCGravatar :size="80" display-size="md">`. |
 | `defaultImg` | `string` | `'retro'` | Gravatar's built-in placeholder when the email has no associated avatar (`mp`, `identicon`, `monsterid`, `wavatar`, `retro`, `robohash`, `blank`) |
 | `alt` | `string` | `'Avatar'` | Alt text for the rendered image |
 | `delayMs` | `number` | `undefined` | Delay (ms) before the `#fallback` slot appears on network failure. Only strictly positive values are forwarded to `<VCAvatar>` (its underlying Reka `AvatarFallback` treats `0` as "wait forever"); omit to render the fallback immediately. |
@@ -71,12 +72,11 @@ import { VCGravatar } from '@vuecs/gravatar';
 
 Visual size is decoupled from the served-image resolution:
 
-- **Display** is set in CSS — the structural `vc-gravatar` class ships at 5rem (80px) and composes onto `<VCAvatar>`'s root via the `gravatar.root` theme entry. Override per-instance:
-  ```vue
-  <VCGravatar email="…" :theme-class="{ root: extend('h-12 w-12') }" />
-  ```
-  or globally via the `gravatar` theme key.
-- **Resolution** is set via the `size` prop (drives Gravatar's `?s=` URL parameter). Match it to your display size (or 2× for retina) so Gravatar serves a crisp image without wasted bandwidth.
+- **Display** — `displaySize="sm" | "md" | "lg"` forwards to `<VCAvatar :size>` and resolves to a theme-defined size (`sm` ≈ 32px, `md` ≈ 40px, `lg` ≈ 56px). Mirrors `<VCBadge>`'s size axis. For arbitrary pixel sizes, drop `displaySize` and use `:theme-class="{ root: extend('h-12 w-12') }"` (or any other size class). When neither is set, falls back to the structural `vc-gravatar` 5rem (80px) baseline so a bare `<VCGravatar>` keeps the historical default.
+- **Resolution** — `size` (number, default 80) drives Gravatar's `?s=` URL parameter. Match it to your display size (or 2× for retina) so Gravatar serves a crisp image without wasted bandwidth. Recommended pairings:
+  - `displaySize="sm"` → `:size="64"` (32px × 2)
+  - `displaySize="md"` → `:size="80"` (40px × 2)
+  - `displaySize="lg"` → `:size="112"` (56px × 2)
 
 Don't ship `@vuecs/gravatar`'s structural CSS? Import it explicitly:
 

--- a/packages/elements/assets/avatar.css
+++ b/packages/elements/assets/avatar.css
@@ -33,3 +33,14 @@
     font-weight: 500;
     line-height: 1;
 }
+
+/*
+ * Size variant classes — referenced by the `avatar.size.{sm,md,lg}` theme
+ * variant entries. Themes that have utility-class equivalents (Tailwind:
+ * `h-8 w-8`, `h-10 w-10`, `h-14 w-14`) can stack those instead/alongside;
+ * these structural classes give a working baseline for ecosystems
+ * (Bootstrap, custom CSS) where no equivalent utility exists.
+ */
+.vc-avatar-sm { width: 2rem; height: 2rem; }
+.vc-avatar-md { width: 2.5rem; height: 2.5rem; }
+.vc-avatar-lg { width: 3.5rem; height: 3.5rem; }

--- a/packages/elements/src/components/avatar/Avatar.vue
+++ b/packages/elements/src/components/avatar/Avatar.vue
@@ -3,9 +3,13 @@ import { defineComponent, h, mergeProps } from 'vue';
 import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
 import { AvatarFallback, AvatarImage, AvatarRoot } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
-import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
+import type {
+    ThemeClassesOverride,
+    UseComponentThemeProps,
+    VariantValues,
+} from '@vuecs/core';
 import { avatarThemeDefaults } from './theme';
-import type { AvatarThemeClasses } from './types';
+import type { AvatarSize, AvatarThemeClasses } from './types';
 
 export type AvatarFallbackSlotProps = {
     /** Resolved theme class for the fallback wrapper. */
@@ -34,6 +38,12 @@ const avatarProps = {
      * Reka-wrapping convention's natural-forwarding rule is bent.
      */
     delayMs: { type: Number, default: undefined },
+    /**
+     * Size variant — resolved by the active theme. `sm` ≈ 32px, `md` ≈
+     * 40px (default), `lg` ≈ 56px. For arbitrary pixel sizes, use
+     * `themeClass={ root: extend('h-12 w-12') }` instead.
+     */
+    size: { type: String as PropType<AvatarSize>, default: undefined },
     /** Theme-class overrides for this component instance. */
     themeClass: { type: Object as PropType<ThemeClassesOverride<AvatarThemeClasses>>, default: undefined },
     /** Theme-variant values for this component instance. */
@@ -50,7 +60,18 @@ export default defineComponent({
         fallback: AvatarFallbackSlotProps;
     }>,
     setup(props, { attrs, slots }) {
-        const theme = useComponentTheme('avatar', props, avatarThemeDefaults);
+        const themeProps: UseComponentThemeProps<AvatarThemeClasses> = {
+            get themeClass() {
+                return props.themeClass;
+            },
+            get themeVariant() {
+                return {
+                    ...(props.themeVariant ?? {}),
+                    ...(props.size !== undefined ? { size: props.size } : {}),
+                };
+            },
+        };
+        const theme = useComponentTheme('avatar', themeProps, avatarThemeDefaults);
         return () => {
             const resolved = theme.value;
             const children = [];

--- a/packages/elements/src/components/avatar/types.ts
+++ b/packages/elements/src/components/avatar/types.ts
@@ -1,5 +1,7 @@
 import type { ThemeElementDefinition } from '@vuecs/core';
 
+export type AvatarSize = 'sm' | 'md' | 'lg';
+
 export type AvatarThemeClasses = {
     /** The outer wrapper. */
     root: string;

--- a/packages/elements/test/unit/avatar.spec.ts
+++ b/packages/elements/test/unit/avatar.spec.ts
@@ -1,13 +1,28 @@
 // @vitest-environment jsdom
 import {
-    afterEach, 
-    describe, 
-    expect, 
+    afterEach,
+    describe,
+    expect,
     it,
 } from 'vitest';
 import { defineComponent, h, nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import vuecsElements, { VCAvatar } from '../../src';
+
+const sizeOverride = {
+    elements: {
+        avatar: {
+            variants: {
+                size: {
+                    sm: { root: 'avatar-sm' },
+                    md: { root: 'avatar-md' },
+                    lg: { root: 'avatar-lg' },
+                },
+            },
+            defaultVariants: { size: 'md' },
+        },
+    },
+};
 
 describe('<VCAvatar>', () => {
     afterEach(() => { document.body.innerHTML = ''; });
@@ -21,5 +36,30 @@ describe('<VCAvatar>', () => {
         await nextTick();
         expect(wrapper.text()).toContain('AB');
         expect((wrapper.element as HTMLElement).classList.contains('vc-avatar')).toBe(true);
+    });
+
+    it('resolves the size prop through the variant system', async () => {
+        const wrapper = mount(defineComponent({
+            setup() {
+                return () => h(VCAvatar, { size: 'sm' }, { fallback: () => 'AB' });
+            },
+        }), { global: { plugins: [[vuecsElements, { overrides: sizeOverride }]] } });
+        await nextTick();
+        const root = wrapper.element as HTMLElement;
+        expect(root.classList.contains('vc-avatar')).toBe(true);
+        expect(root.classList.contains('avatar-sm')).toBe(true);
+        expect(root.classList.contains('avatar-md')).toBe(false);
+    });
+
+    it('falls back to the default size variant when size is omitted', async () => {
+        const wrapper = mount(defineComponent({
+            setup() {
+                return () => h(VCAvatar, null, { fallback: () => 'AB' });
+            },
+        }), { global: { plugins: [[vuecsElements, { overrides: sizeOverride }]] } });
+        await nextTick();
+        const root = wrapper.element as HTMLElement;
+        expect(root.classList.contains('avatar-md')).toBe(true);
+        expect(root.classList.contains('avatar-sm')).toBe(false);
     });
 });

--- a/packages/gravatar/src/component.ts
+++ b/packages/gravatar/src/component.ts
@@ -27,7 +27,7 @@ declare module '@vuecs/core' {
     }
 }
 
-const themeDefaults = { classes: { root: 'vc-gravatar' } };
+const themeDefaults = { classes: { root: '' } };
 
 export type GravatarFallbackSlotProps = {
     class: string;
@@ -110,26 +110,27 @@ export const VCGravatar = defineComponent({
             return img.join('');
         });
 
-        return () => h(
-            VCAvatar,
-            {
-                ...attrs,
-                src: url.value,
-                alt: props.alt,
-                delayMs: props.delayMs,
-                // Forwards to VCAvatar's size variant. When omitted, falls
-                // back to whatever VCAvatar's theme default is (md), plus
-                // the structural `vc-gravatar` class which sets a 5rem
-                // (80px) baseline to preserve the historical default.
-                size: props.displaySize,
-                // Compose the `gravatar.root` slot onto VCAvatar's root via
-                // the per-instance theme override. `extend()` merges with
-                // the avatar layer instead of replacing it — consumers who
-                // style the `gravatar` theme key see their classes layered
-                // on top of avatar's structural defaults.
-                themeClass: theme.value.root ? { root: extend(theme.value.root) } : undefined,
-            },
-            { fallback: (slotProps: { class: string }) => slots.fallback?.(slotProps) ?? '' },
-        );
+        return () => {
+            // The structural `vc-gravatar` class hardcodes a 5rem baseline
+            // to preserve the historical default for bare `<VCGravatar>`
+            // usages. When `displaySize` is set, skip it — otherwise its
+            // dimensions would win the cascade over the avatar size
+            // variants (gravatar CSS loads after elements CSS in
+            // consumer pipelines).
+            const structuralRoot = props.displaySize === undefined ? 'vc-gravatar' : '';
+            const composedRoot = [structuralRoot, theme.value.root].filter(Boolean).join(' ');
+            return h(
+                VCAvatar,
+                {
+                    ...attrs,
+                    src: url.value,
+                    alt: props.alt,
+                    delayMs: props.delayMs,
+                    size: props.displaySize,
+                    themeClass: composedRoot ? { root: extend(composedRoot) } : undefined,
+                },
+                { fallback: (slotProps: { class: string }) => slots.fallback?.(slotProps) ?? '' },
+            );
+        };
     },
 });

--- a/packages/gravatar/src/component.ts
+++ b/packages/gravatar/src/component.ts
@@ -5,6 +5,7 @@ import type {
     VariantValues,
 } from '@vuecs/core';
 import { VCAvatar } from '@vuecs/elements';
+import type { AvatarSize } from '@vuecs/elements';
 import md5 from 'md5';
 import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
 import {
@@ -44,12 +45,20 @@ const gravatarProps = {
     /**
      * Image resolution served by Gravatar (drives the URL's `?s=` parameter,
      * range 1–2048). This controls **only** the served-image quality, not
-     * the rendered size on the page — visual sizing is owned by the theme
-     * system (`gravatar.root` / `avatar.root` theme classes, or per-instance
-     * `themeClass`). Match `size` to your displayed pixel dimensions (or 2×
-     * for retina) to avoid up-/down-scaling.
+     * the rendered size on the page — visual sizing is owned by `displaySize`
+     * (semantic enum) or the theme system (`gravatar.root` / `avatar.root`
+     * theme classes, or per-instance `themeClass`). Match `size` to your
+     * displayed pixel dimensions (or 2× for retina) to avoid up-/down-scaling.
      */
     size: { type: Number, default: 80 },
+    /**
+     * Visual size — forwards to `<VCAvatar :size>`. `sm` ≈ 32px, `md` ≈ 40px,
+     * `lg` ≈ 56px (theme-defined). Omit to fall back to `<VCAvatar>`'s
+     * theme default (`md`) plus the structural `vc-gravatar` class. Pair
+     * with a matching `size` (URL resolution, 2× for retina) for crisp
+     * rendering — e.g. `<VCGravatar :size="80" display-size="md">`.
+     */
+    displaySize: { type: String as PropType<AvatarSize>, default: undefined },
     /** Gravatar `d=` parameter — fallback image style or URL (e.g. `retro`, `mp`, `identicon`). */
     defaultImg: { type: String, default: 'retro' },
     /** Gravatar `r=` parameter — content rating filter (`g`, `pg`, `r`, `x`). */
@@ -108,14 +117,16 @@ export const VCGravatar = defineComponent({
                 src: url.value,
                 alt: props.alt,
                 delayMs: props.delayMs,
+                // Forwards to VCAvatar's size variant. When omitted, falls
+                // back to whatever VCAvatar's theme default is (md), plus
+                // the structural `vc-gravatar` class which sets a 5rem
+                // (80px) baseline to preserve the historical default.
+                size: props.displaySize,
                 // Compose the `gravatar.root` slot onto VCAvatar's root via
                 // the per-instance theme override. `extend()` merges with
                 // the avatar layer instead of replacing it — consumers who
                 // style the `gravatar` theme key see their classes layered
-                // on top of avatar's structural defaults. Visual sizing
-                // lives entirely in `gravatar.root` (themes ship a 5rem /
-                // 80px default to preserve the historical visual default);
-                // the `size` prop only feeds the Gravatar URL.
+                // on top of avatar's structural defaults.
                 themeClass: theme.value.root ? { root: extend(theme.value.root) } : undefined,
             },
             { fallback: (slotProps: { class: string }) => slots.fallback?.(slotProps) ?? '' },

--- a/themes/bootstrap/src/index.ts
+++ b/themes/bootstrap/src/index.ts
@@ -256,6 +256,17 @@ export default function bootstrapTheme(): Theme {
                     image: 'w-100 h-100 object-fit-cover',
                     fallback: 'd-inline-flex align-items-center justify-content-center w-100 h-100 fw-medium small lh-1',
                 },
+                // Bootstrap doesn't ship h-8/h-10/h-14 utilities, so the
+                // size variants reference the structural `vc-avatar-{sm,md,lg}`
+                // classes shipped in @vuecs/elements/assets/avatar.css.
+                variants: {
+                    size: {
+                        sm: { root: 'vc-avatar-sm' },
+                        md: { root: 'vc-avatar-md' },
+                        lg: { root: 'vc-avatar-lg' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             aspectRatio: { classes: { root: 'd-block w-100' } },
             // VCGravatar wraps VCAvatar — sizing comes from the structural

--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -306,10 +306,21 @@ export default function tailwindTheme(): Theme {
             },
             avatar: {
                 classes: {
-                    root: 'inline-flex h-10 w-10 shrink-0 select-none items-center justify-center overflow-hidden rounded-full bg-bg-muted text-fg-muted align-middle',
+                    root: 'inline-flex shrink-0 select-none items-center justify-center overflow-hidden rounded-full bg-bg-muted text-fg-muted align-middle',
                     image: 'h-full w-full object-cover',
-                    fallback: 'inline-flex h-full w-full items-center justify-center text-sm font-medium leading-none',
+                    fallback: 'inline-flex h-full w-full items-center justify-center font-medium leading-none',
                 },
+                // Mirrors @vuecs/elements badge size axis so a
+                // `<VCAvatar size="lg">` reads at the same scale as a
+                // `<VCBadge size="lg">`.
+                variants: {
+                    size: {
+                        sm: { root: 'h-8 w-8', fallback: 'text-xs' },
+                        md: { root: 'h-10 w-10', fallback: 'text-sm' },
+                        lg: { root: 'h-14 w-14', fallback: 'text-base' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             aspectRatio: { classes: { root: 'block w-full' } },
             badge: {


### PR DESCRIPTION
…Size on <VCGravatar>

* @vuecs/elements — <VCAvatar> gains a `size: 'sm' | 'md' | 'lg'` prop (mirrors <VCBadge>'s size axis). Resolved via the same themeProps pattern Badge uses, so consumers can mix it with custom themeVariant values. `sm` ≈ 32px, `md` ≈ 40px (default), `lg` ≈ 56px. For arbitrary px sizes, drop the prop and use `themeClass={ root: extend('h-12 w-12') }`.

* @vuecs/elements/assets/avatar.css — new structural `.vc-avatar-{sm,md,lg}` classes shipped as a cross-theme baseline. Tailwind's variants use utility classes (`h-8 w-8` etc); bootstrap's variants reference the structural classes since BS doesn't ship h/w utilities at those sizes.

* theme-tailwind + theme-bootstrap — `avatar.size` variant matrices added to both, with `defaultVariants: { size: 'md' }`.

* @vuecs/gravatar — new `displaySize: 'sm' | 'md' | 'lg'` prop forwards to <VCAvatar :size>. Pairs with the existing URL-resolution `size` knob (recommend 2× for retina). Omitted → falls back to the structural `vc-gravatar` 5rem (80px) baseline so a bare <VCGravatar> keeps the historical default.

Closes the plan-013 follow-up: <VCBadge>, <VCAvatar>, <VCTag>, and (via displaySize) <VCGravatar> all share the same sm/md/lg axis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Avatar component now supports a `size` prop with options: `sm`, `md`, and `lg`.
  * Gravatar component introduces a `displaySize` prop for controlling visual sizing independently from image resolution.
  * Theme support added for avatar size variants across Bootstrap and Tailwind themes.

* **Documentation**
  * Updated Avatar and Gravatar component documentation to reflect new sizing capabilities and usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->