### PR TITLE
feat: demo/playground split, stepper context, structural-CSS color is…

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -200,6 +200,39 @@ compoundVariants: [
 ]
 ```
 
+**Where variants live.** Variant definitions overwhelmingly live in
+the **theme packages** (`@vuecs/theme-tailwind` / `@vuecs/theme-bootstrap`)
+rather than in component defaults — the component declares the slot
+shape (`ThemeClasses`), the theme decides what each variant value
+adds to each slot. This keeps component code minimal and lets two
+themes ship dramatically different visuals (Tailwind utilities vs
+Bootstrap class names) for the same axis. Components that compose
+into the theme do NOT need their own `variants:` entry in defaults
+unless the variant is structural (e.g. orientation-driven layout).
+
+### Per-component variant catalog
+
+| Component | Axis | Values | Notes |
+|---|---|---|---|
+| Button | `variant` × `color` × `size` | solid/outline/soft/ghost/link × primary/neutral/success/warning/error/info × sm/md/lg | Full matrix via `compoundVariants` |
+| Badge | `variant` × `color` × `size` | solid/soft/outline × six semantic colors × sm/md/lg | Mirrors button |
+| Tag | `size` | sm/md/lg | Matches badge sizing |
+| Avatar | `size` | sm/md/lg | Theme-bootstrap uses `vc-avatar-{sm,lg}` helpers |
+| Pagination | `variant` × `size` | outline/soft/ghost × sm/md/lg | |
+| FormInput / FormTextarea / FormSelect / FormNumber / FormTags | `size` | sm/md/lg | theme-tailwind uses padding+font utilities; theme-bootstrap uses `form-control-{sm,lg}` (and input-group-{sm,lg} for groups) |
+| FormCheckbox / FormSwitch / FormRadio | `size` | sm/md/lg | theme-bootstrap uses `vc-form-{checkbox,switch,radio}-{sm,lg}` helpers from @vuecs/forms structural CSS |
+| Modal | `size` | sm/md/lg/xl | theme-tailwind uses `max-w-*`; theme-bootstrap uses `modal-{sm,lg,xl}` |
+| Popover / HoverCard | `size` | sm/md/lg | Width + padding tier |
+| Tooltip | `size` | sm/md/lg | Padding + font-size only |
+| DropdownMenu / ContextMenu | `size` | sm/md/lg | Item padding + min-width |
+| List / ListItem | `density` | compact/normal/spacious | Gap + per-row padding |
+| Navigation | `size` | sm/md/lg | Link padding + icon size |
+| Stepper | `size` | sm/md/lg | Indicator + title scale; theme-bootstrap uses `vc-stepper-indicator-{sm,lg}` |
+
+Components with NO theme variants today: VCSeparator, VCAspectRatio,
+VCVisuallyHidden, VCFormPin, VCFormSlider, VCGravatar, VCCountdown,
+VCTimeago, VCLink (Link has no theme system at all yet).
+
 ### Type-Safe Theme Slots (ThemeElements)
 
 `ThemeElements` is an empty augmentable interface with no index signature. Each component package extends it via TypeScript declaration merging to register its component name and typed slot keys. `Theme.elements` uses `Partial<ThemeElements>` so each theme only needs to provide a subset of known components. Internal runtime code casts to `Record<string, ThemeElementDefinition>` for dynamic dispatch by component name.
@@ -1004,19 +1037,37 @@ the pattern fit, not the manager. The Stepper compound does NOT use
   StepperTitle.vue
   StepperDescription.vue
   StepperSeparator.vue     <- StepperSeparator (carries data-state="completed" when prev step is done)
+  context.ts               <- provideStepperContext / useStepperContext (theme-class + theme-variant inheritance)
   theme.ts                 <- shared stepperThemeDefaults
   types.ts                 <- StepperThemeClasses + ThemeElements augmentation
   index.ts
 ```
+
+`<VCStepper>` `provideStepperContext`s its `themeClass` + `themeVariant`
+so descendant parts inherit them automatically — a single
+`<VCStepper :theme-variant="{ size: 'sm' }">` resizes every indicator /
+title / description / separator without per-part repetition. Children
+read via `useStepperContext()` and merge with their own per-instance
+props (per-instance values win). The context is optional so children
+render bare for unit tests / Storybook. `provideStepperContext` /
+`useStepperContext` / `StepperContext` are re-exported from
+`@vuecs/navigation` for consumers building custom step parts.
+
+Bootstrap theme strings can't carry `[data-state=…]` attribute
+selectors, so `themes/bootstrap/assets/index.css` ships dedicated
+`[data-state="active|completed"] .vc-stepper-…` rules with `!important`
+(Bootstrap utility classes like `.bg-light` ship `!important`; the
+attribute-selector specificity boost alone isn't enough). Both states
+use the primary color so the trail of progress reads as one
+continuous run; the Tailwind theme matches.
 
 Adding stepper made `Options.items` optional in `@vuecs/navigation`'s
 install — a stepper-only consumer can call `app.use(navigation, {})`
 without wiring any nav items. NavigationManager still constructs (with
 an empty items array) so existing nav code keeps working.
 
-Theme entries ship in both `@vuecs/theme-tailwind` (uses
+Theme entries ship in `@vuecs/theme-tailwind` (uses
 `group-data-[state=active]:` / `group-data-[state=completed]:` variant
-prefixes, scoped via the `group` utility on `<VCStepperItem>`) and
-`@vuecs/theme-bootstrap` (uses Bootstrap utility classes — the BS5
-theme is necessarily flatter since theme strings can't carry attribute
-selectors).
+prefixes, scoped via the `group` utility added by `<VCStepperItem>`) and
+`@vuecs/theme-bootstrap` (Bootstrap utility classes only, with
+data-state visualization handled by the bridge CSS as noted above).

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -170,10 +170,10 @@ in `iframe-bridge.ts`:
   `limit` / `busy` / `hideDisabled` / `themeVariant.{variant,size}`).
 
 Both APIs are additive; pick whichever matches the demo's complexity.
-The parent `Demo.vue` toolbar renders the matching control per type:
-checkbox for boolean, `<select>` for enum, range+number for number,
-text input for string. Sections (`section: 'Variant'`) group related
-controls into a single labeled row.
+The parent `Playground.vue` toolbar renders the matching control per
+type: checkbox for boolean, `<select>` for enum, range+number for
+number, text input for string. Sections (`section: 'Variant'`) group
+related controls into a single labeled row.
 
 ## Adding a New Package
 

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -132,6 +132,49 @@ After any code changes that affect architecture, APIs, or behavior:
 
 Do this as part of the same commit — documentation should never lag behind the code. The VitePress site is the user-facing reference; treating it as an afterthought breaks the "thin README → docs site" split that the package READMEs depend on.
 
+## Demo authoring (docs/demos/src/)
+
+VitePress pages embed iframe demos via two host components, picked by
+intent:
+
+- **`<Demo name="...">`** — passive showcase. Renders the iframe + the
+  static code block from the markdown's `<template #code>` slot. No
+  toolbar with controls; no `announceVariants` / `announceProps`
+  round-trip. Use for components with no meaningful interactive axis
+  (link, separator, countdown, gravatar, timeago, visually-hidden,
+  aspect-ratio, form-pin, form-slider, form-select-search,
+  modal-view-stack).
+- **`<Playground name="...">`** — interactive sandbox. Same iframe +
+  code block, plus a controls toolbar above the preview that the
+  iframe drives via `announceVariants` / `announceProps`. Use whenever
+  the demo announces a catalog.
+
+Both share the same `iframe-bridge.ts` runtime; they only differ in
+whether the parent renders the controls panel. Two announce APIs live
+in `iframe-bridge.ts`:
+
+- **`announceVariants(catalog, defaults)`** — convenience wrapper for
+  enum-only variant axes. Catalog is `{ <key>: readonly string[] }`,
+  defaults is `{ <key>: <value> }`. Updates flow into a flat
+  `variantState` ref that the demo passes as
+  `:theme-variant="variantState"`. Use this for size/density-only
+  demos (the bulk of the form / overlay / list / stepper family).
+
+- **`announceProps(catalog, defaults)`** — typed catalog supporting
+  `boolean`, `enum`, `number`, `string` per prop. Catalog values can
+  carry `section`, `min`/`max`/`step`, `options`, `placeholder`,
+  `label`. Dot-pathed keys (`themeVariant.size`) auto-build nested
+  objects on the iframe side, so a demo binds `v-bind="propState"` and
+  every announced prop becomes interactive. Use this when the demo has
+  multiple meaningful axes (e.g. `pagination` exposes `total` /
+  `limit` / `busy` / `hideDisabled` / `themeVariant.{variant,size}`).
+
+Both APIs are additive; pick whichever matches the demo's complexity.
+The parent `Demo.vue` toolbar renders the matching control per type:
+checkbox for boolean, `<select>` for enum, range+number for number,
+text input for string. Sections (`section: 'Variant'`) group related
+controls into a single labeled row.
+
 ## Adding a New Package
 
 1. Create `packages/<name>/` with `src/index.ts`, `package.json`, `tsdown.config.ts`, `LICENSE` (Apache 2.0)
@@ -151,6 +194,6 @@ Do this as part of the same commit — documentation should never lag behind the
 External project references live in .agents/references/. When looking up source code in a referenced project (e.g., tsoa), always update the corresponding reference file with:
 
 The source file path / function name in the external project
-The corresponding TRAPI file path / function name
+The corresponding vuecs file path / function name
 Any behavioral differences between the implementations
 This builds a cumulative mapping over time so future work can quickly find corresponding code without re-searching.

--- a/docs/demos/src/avatar.demo.vue
+++ b/docs/demos/src/avatar.demo.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { VCAvatar } from '@vuecs/elements';
+import { variantState } from './iframe-bridge';
 </script>
 
 <template>
@@ -7,16 +8,18 @@ import { VCAvatar } from '@vuecs/elements';
         <VCAvatar
             src="https://i.pravatar.cc/80?img=15"
             alt="Avatar 1"
+            :theme-variant="variantState"
         />
         <VCAvatar
             src="/missing-avatar.jpg"
             alt="Broken image — fallback wins"
+            :theme-variant="variantState"
         >
             <template #fallback>
                 AB
             </template>
         </VCAvatar>
-        <VCAvatar>
+        <VCAvatar :theme-variant="variantState">
             <template #fallback>
                 ?
             </template>

--- a/docs/demos/src/avatar.ts
+++ b/docs/demos/src/avatar.ts
@@ -1,6 +1,6 @@
 import elements from '@vuecs/elements';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './avatar.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(elements);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/badge.demo.vue
+++ b/docs/demos/src/badge.demo.vue
@@ -1,27 +1,42 @@
 <script setup lang="ts">
 import { VCBadge } from '@vuecs/elements';
+import { propState } from './iframe-bridge';
 
 const colors = ['primary', 'neutral', 'success', 'warning', 'error', 'info'] as const;
 const variants = ['solid', 'soft', 'outline'] as const;
 </script>
 
 <template>
-    <div style="display: flex; flex-direction: column; gap: 0.5rem;">
-        <div
-            v-for="variant in variants"
-            :key="variant"
-            style="display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;"
-        >
-            <span style="font-size: 0.75rem; color: var(--vc-color-fg-muted); width: 4rem;">
-                {{ variant }}
-            </span>
-            <VCBadge
-                v-for="color in colors"
-                :key="`${variant}-${color}`"
-                :variant="variant"
-                :color="color"
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+        <!-- Static color × variant grid — always visible so consumers see
+             the full matrix at a glance. -->
+        <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+            <div
+                v-for="variant in variants"
+                :key="variant"
+                style="display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;"
             >
-                {{ color }}
+                <span style="font-size: 0.75rem; color: var(--vc-color-fg-muted); width: 4rem;">
+                    {{ variant }}
+                </span>
+                <VCBadge
+                    v-for="color in colors"
+                    :key="`${variant}-${color}`"
+                    :variant="variant"
+                    :color="color"
+                >
+                    {{ color }}
+                </VCBadge>
+            </div>
+        </div>
+
+        <!-- Playground badge — driven by the toolbar via `propState`. -->
+        <div style="display: flex; gap: 0.5rem; align-items: center; padding-top: 0.5rem; border-top: 1px dashed var(--vc-color-border);">
+            <span style="font-size: 0.75rem; color: var(--vc-color-fg-muted); width: 4rem;">
+                playground
+            </span>
+            <VCBadge v-bind="propState">
+                {{ propState.color }}
             </VCBadge>
         </div>
     </div>

--- a/docs/demos/src/badge.ts
+++ b/docs/demos/src/badge.ts
@@ -1,6 +1,6 @@
 import elements from '@vuecs/elements';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceProps, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './badge.demo.vue';
 
@@ -8,5 +8,36 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(elements);
 app.mount('#app');
+
+// Showcase the full color × variant matrix in the static grid (always
+// visible) and let the toolbar drive the trailing "playground" badge
+// where size + variant + color flip live.
+announceProps(
+    {
+        size: {
+            type: 'enum',
+            default: 'md',
+            options: ['sm', 'md', 'lg'],
+            section: 'Variant',
+        },
+        variant: {
+            type: 'enum',
+            default: 'soft',
+            options: ['solid', 'soft', 'outline'],
+            section: 'Variant',
+        },
+        color: {
+            type: 'enum',
+            default: 'neutral',
+            options: ['primary', 'neutral', 'success', 'warning', 'error', 'info'],
+            section: 'Variant',
+        },
+    },
+    {
+        size: 'md',
+        variant: 'soft',
+        color: 'neutral',
+    },
+);
 
 installIframeBridge();

--- a/docs/demos/src/button.demo.vue
+++ b/docs/demos/src/button.demo.vue
@@ -2,6 +2,7 @@
 import { VCButton } from '@vuecs/button';
 import { useSubmitButton } from '@vuecs/forms';
 import { ref } from 'vue';
+import { variantState } from './iframe-bridge';
 
 const isEditing = ref(false);
 const submit = useSubmitButton({ isEditing: () => isEditing.value });
@@ -9,81 +10,40 @@ const submit = useSubmitButton({ isEditing: () => isEditing.value });
 
 <template>
     <div style="display: flex; flex-direction: column; gap: 1rem;">
+        <!-- Color axis. The toolbar's `size` value is forwarded via
+             `:theme-variant`, so flipping it reskins this row (and every
+             other row except the explicit size grid below). -->
         <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;">
-            <VCButton
-                color="primary"
-                label="Primary"
-            />
-            <VCButton
-                color="success"
-                label="Success"
-            />
-            <VCButton
-                color="warning"
-                label="Warning"
-            />
-            <VCButton
-                color="error"
-                label="Danger"
-            />
-            <VCButton
-                color="neutral"
-                label="Neutral"
-            />
+            <VCButton color="primary" label="Primary" :theme-variant="variantState" />
+            <VCButton color="success" label="Success" :theme-variant="variantState" />
+            <VCButton color="warning" label="Warning" :theme-variant="variantState" />
+            <VCButton color="error" label="Danger" :theme-variant="variantState" />
+            <VCButton color="neutral" label="Neutral" :theme-variant="variantState" />
         </div>
 
+        <!-- Variant axis. -->
         <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;">
-            <VCButton
-                variant="solid"
-                label="Solid"
-            />
-            <VCButton
-                variant="soft"
-                label="Soft"
-            />
-            <VCButton
-                variant="outline"
-                label="Outline"
-            />
-            <VCButton
-                variant="ghost"
-                label="Ghost"
-            />
-            <VCButton
-                variant="link"
-                label="Link"
-            />
+            <VCButton variant="solid" label="Solid" :theme-variant="variantState" />
+            <VCButton variant="soft" label="Soft" :theme-variant="variantState" />
+            <VCButton variant="outline" label="Outline" :theme-variant="variantState" />
+            <VCButton variant="ghost" label="Ghost" :theme-variant="variantState" />
+            <VCButton variant="link" label="Link" :theme-variant="variantState" />
         </div>
 
+        <!-- Explicit size grid — these buttons keep their `size` prop so
+             they remain a stable reference; the explicit prop wins over
+             themeVariant.size at the component's merge step. -->
         <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;">
-            <VCButton
-                size="sm"
-                label="Small"
-            />
-            <VCButton
-                size="md"
-                label="Medium"
-            />
-            <VCButton
-                size="lg"
-                label="Large"
-            />
-            <VCButton
-                :loading="true"
-                label="Loading…"
-            />
-            <VCButton
-                :disabled="true"
-                label="Disabled"
-            />
+            <VCButton size="sm" label="Small" />
+            <VCButton size="md" label="Medium" />
+            <VCButton size="lg" label="Large" />
+            <VCButton :loading="true" label="Loading…" :theme-variant="variantState" />
+            <VCButton :disabled="true" label="Disabled" :theme-variant="variantState" />
         </div>
 
+        <!-- useSubmitButton() returns a reactive bind-object — label /
+             icon / color all swap when `isEditing` flips. -->
         <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;">
-            <!--
-              useSubmitButton() returns a reactive bind-object — label /
-              icon / color all swap when `isEditing` flips. Demonstrates
-              the i18n-friendly DefaultsManager hook in a real bind site.
-            -->
             <button
                 type="button"
                 style="padding: 0.25rem 0.5rem; font-size: 0.75rem; border: 1px solid var(--vc-color-border); border-radius: 0.25rem;"
@@ -91,7 +51,10 @@ const submit = useSubmitButton({ isEditing: () => isEditing.value });
             >
                 Toggle isEditing ({{ isEditing ? 'on' : 'off' }})
             </button>
-            <VCButton v-bind="submit" />
+            <VCButton
+                v-bind="submit"
+                :theme-variant="variantState"
+            />
         </div>
     </div>
 </template>

--- a/docs/demos/src/button.ts
+++ b/docs/demos/src/button.ts
@@ -1,7 +1,7 @@
 import button from '@vuecs/button';
 import formControls from '@vuecs/forms';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './button.demo.vue';
 
@@ -10,5 +10,12 @@ installVuecs(app);
 app.use(button);
 app.use(formControls);
 app.mount('#app');
+
+// Drive every button in the demo via `:theme-variant="variantState"`.
+// The explicit-size row keeps its `size="sm|md|lg"` props (which win over
+// themeVariant.size at component-level merge), so toggling the toolbar
+// reskins the color / variant / state rows while the size row remains a
+// stable size reference.
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/context-menu.demo.vue
+++ b/docs/demos/src/context-menu.demo.vue
@@ -8,6 +8,7 @@ import {
     VCContextMenuTrigger,
 } from '@vuecs/overlays';
 import { ref } from 'vue';
+import { variantState } from './iframe-bridge';
 
 const lastAction = ref<string>('—');
 </script>
@@ -23,7 +24,7 @@ const lastAction = ref<string>('—');
                     Right-click anywhere in this box
                 </div>
             </VCContextMenuTrigger>
-            <VCContextMenuContent>
+            <VCContextMenuContent :theme-variant="variantState">
                 <VCContextMenuLabel>Item options</VCContextMenuLabel>
                 <VCContextMenuItem @select="lastAction = 'open'">
                     Open

--- a/docs/demos/src/context-menu.ts
+++ b/docs/demos/src/context-menu.ts
@@ -1,6 +1,6 @@
 import overlays from '@vuecs/overlays';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './context-menu.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(overlays);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/dropdown-menu.demo.vue
+++ b/docs/demos/src/dropdown-menu.demo.vue
@@ -9,6 +9,7 @@ import {
     VCDropdownMenuTrigger,
 } from '@vuecs/overlays';
 import { ref } from 'vue';
+import { variantState } from './iframe-bridge';
 
 const lastAction = ref<string>('—');
 </script>
@@ -22,7 +23,7 @@ const lastAction = ref<string>('—');
             >
                 Actions ▾
             </VCDropdownMenuTrigger>
-            <VCDropdownMenuContent>
+            <VCDropdownMenuContent :theme-variant="variantState">
                 <VCDropdownMenuLabel>Manage</VCDropdownMenuLabel>
                 <VCDropdownMenuGroup>
                     <VCDropdownMenuItem @select="lastAction = 'edit'">

--- a/docs/demos/src/dropdown-menu.ts
+++ b/docs/demos/src/dropdown-menu.ts
@@ -1,6 +1,6 @@
 import overlays from '@vuecs/overlays';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './dropdown-menu.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(overlays);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/form-checkbox.demo.vue
+++ b/docs/demos/src/form-checkbox.demo.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { VCFormCheckbox, VCFormCheckboxGroup } from '@vuecs/forms';
 import { ref } from 'vue';
+import { variantState } from './iframe-bridge';
 
 const accepted = ref(false);
 const indeterminateState = ref<boolean | 'indeterminate'>('indeterminate');
@@ -18,10 +19,12 @@ const selected = ref<string[]>(['a']);
         <VCFormCheckbox
             v-model="accepted"
             label-content="I accept the terms"
+            :theme-variant="variantState"
         />
         <VCFormCheckbox
             v-model="indeterminateState"
             label-content="Indeterminate (tri-state)"
+            :theme-variant="variantState"
         />
 
         <!--
@@ -33,14 +36,17 @@ const selected = ref<string[]>(['a']);
             <VCFormCheckbox
                 value="a"
                 label-content="Apples"
+                :theme-variant="variantState"
             />
             <VCFormCheckbox
                 value="b"
                 label-content="Bananas"
+                :theme-variant="variantState"
             />
             <VCFormCheckbox
                 value="c"
                 label-content="Cherries"
+                :theme-variant="variantState"
             />
         </VCFormCheckboxGroup>
 

--- a/docs/demos/src/form-checkbox.ts
+++ b/docs/demos/src/form-checkbox.ts
@@ -1,6 +1,6 @@
 import formControls from '@vuecs/forms';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './form-checkbox.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(formControls);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/form-input.demo.vue
+++ b/docs/demos/src/form-input.demo.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { VCFormInput } from '@vuecs/forms';
 import { ref } from 'vue';
+import { propState } from './iframe-bridge';
 
 const value = ref('');
 </script>
@@ -9,7 +10,7 @@ const value = ref('');
     <div style="display: flex; flex-direction: column; gap: 0.75rem; max-width: 24rem;">
         <VCFormInput
             v-model="value"
-            placeholder="Enter your email"
+            v-bind="propState"
         />
         <p style="font-size: 0.875rem; color: var(--vc-color-fg-muted); margin: 0;">
             Bound: <code>{{ value || '(empty)' }}</code>

--- a/docs/demos/src/form-input.ts
+++ b/docs/demos/src/form-input.ts
@@ -1,6 +1,6 @@
 import formControls from '@vuecs/forms';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceProps, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './form-input.demo.vue';
 
@@ -8,5 +8,31 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(formControls);
 app.mount('#app');
+
+announceProps(
+    {
+        'themeVariant.size': {
+            type: 'enum',
+            default: 'md',
+            options: ['sm', 'md', 'lg'],
+            section: 'Variant',
+        },
+        disabled: {
+            type: 'boolean', 
+            default: false, 
+            section: 'State', 
+        },
+        placeholder: {
+            type: 'string', 
+            default: 'Enter your email', 
+            section: 'Content', 
+        },
+    },
+    {
+        'themeVariant.size': 'md',
+        disabled: false,
+        placeholder: 'Enter your email',
+    },
+);
 
 installIframeBridge();

--- a/docs/demos/src/form-number.demo.vue
+++ b/docs/demos/src/form-number.demo.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { VCFormNumber } from '@vuecs/forms';
 import { ref } from 'vue';
+import { variantState } from './iframe-bridge';
 
 const quantity = ref<number>(1);
 const price = ref<number>(19.99);
@@ -15,6 +16,7 @@ const price = ref<number>(19.99);
                 :min="0"
                 :max="99"
                 :step="1"
+                :theme-variant="variantState"
             />
         </div>
 
@@ -25,6 +27,7 @@ const price = ref<number>(19.99);
                 :min="0"
                 :step="0.01"
                 :format-options="{ style: 'currency', currency: 'USD' }"
+                :theme-variant="variantState"
             />
         </div>
 

--- a/docs/demos/src/form-number.ts
+++ b/docs/demos/src/form-number.ts
@@ -1,6 +1,6 @@
 import forms from '@vuecs/forms';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './form-number.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(forms);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/form-radio.demo.vue
+++ b/docs/demos/src/form-radio.demo.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { VCFormRadio, VCFormRadioGroup } from '@vuecs/forms';
 import { ref } from 'vue';
+import { variantState } from './iframe-bridge';
 
 const size = ref<string>('md');
 const region = ref<string | undefined>(undefined);
@@ -14,14 +15,17 @@ const region = ref<string | undefined>(undefined);
                 <VCFormRadio
                     value="sm"
                     label-content="Small"
+                    :theme-variant="variantState"
                 />
                 <VCFormRadio
                     value="md"
                     label-content="Medium"
+                    :theme-variant="variantState"
                 />
                 <VCFormRadio
                     value="lg"
                     label-content="Large"
+                    :theme-variant="variantState"
                 />
             </VCFormRadioGroup>
         </div>

--- a/docs/demos/src/form-radio.ts
+++ b/docs/demos/src/form-radio.ts
@@ -1,6 +1,6 @@
 import forms from '@vuecs/forms';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './form-radio.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(forms);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/form-select.demo.vue
+++ b/docs/demos/src/form-select.demo.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { VCFormSelect } from '@vuecs/forms';
 import { ref } from 'vue';
+import { variantState } from './iframe-bridge';
 
 const value = ref<string | undefined>(undefined);
 const region = ref<string | undefined>(undefined);
@@ -40,11 +41,13 @@ const regions = [
             v-model="value"
             :options="sizes"
             placeholder="-- Pick a size --"
+            :theme-variant="variantState"
         />
         <VCFormSelect
             v-model="region"
             :options="regions"
             placeholder="-- Pick a region --"
+            :theme-variant="variantState"
         />
         <p style="font-size: 0.875rem; color: var(--vc-color-fg-muted); margin: 0;">
             Bound: <code>size={{ value }}, region={{ region }}</code>

--- a/docs/demos/src/form-select.ts
+++ b/docs/demos/src/form-select.ts
@@ -1,6 +1,6 @@
 import formControls from '@vuecs/forms';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './form-select.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(formControls);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/form-switch.demo.vue
+++ b/docs/demos/src/form-switch.demo.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { VCFormSwitch } from '@vuecs/forms';
 import { ref } from 'vue';
+import { variantState } from './iframe-bridge';
 
 const notifications = ref(true);
 const dnd = ref(false);
@@ -16,10 +17,12 @@ const dnd = ref(false);
         <VCFormSwitch
             v-model="notifications"
             label-content="Enable notifications"
+            :theme-variant="variantState"
         />
         <VCFormSwitch
             v-model="dnd"
             label-content="Do not disturb"
+            :theme-variant="variantState"
         />
         <p style="font-size: 0.875rem; color: var(--vc-color-fg-muted); margin: 0;">
             Bound: <code>notifications={{ notifications }}, dnd={{ dnd }}</code>

--- a/docs/demos/src/form-switch.ts
+++ b/docs/demos/src/form-switch.ts
@@ -1,6 +1,6 @@
 import forms from '@vuecs/forms';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './form-switch.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(forms);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/form-tags.demo.vue
+++ b/docs/demos/src/form-tags.demo.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { VCFormTags } from '@vuecs/forms';
 import { ref } from 'vue';
+import { variantState } from './iframe-bridge';
 
 const tags = ref<string[]>(['vue', 'reka', 'tailwind']);
 </script>
@@ -11,6 +12,7 @@ const tags = ref<string[]>(['vue', 'reka', 'tailwind']);
             v-model="tags"
             placeholder="Add a tag…"
             add-on-paste
+            :theme-variant="variantState"
         />
         <p style="font-size: 0.875rem; color: var(--vc-color-fg-muted); margin: 0;">
             Bound: <code>[{{ tags.join(', ') }}]</code>

--- a/docs/demos/src/form-tags.ts
+++ b/docs/demos/src/form-tags.ts
@@ -1,6 +1,6 @@
 import forms from '@vuecs/forms';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './form-tags.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(forms);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/form-textarea.demo.vue
+++ b/docs/demos/src/form-textarea.demo.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { VCFormTextarea } from '@vuecs/forms';
 import { ref } from 'vue';
+import { variantState } from './iframe-bridge';
 
 const value = ref('');
 </script>
@@ -11,6 +12,7 @@ const value = ref('');
             v-model="value"
             placeholder="Type a longer message..."
             rows="4"
+            :theme-variant="variantState"
         />
     </div>
 </template>

--- a/docs/demos/src/form-textarea.ts
+++ b/docs/demos/src/form-textarea.ts
@@ -1,6 +1,6 @@
 import formControls from '@vuecs/forms';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './form-textarea.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(formControls);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/hover-card.demo.vue
+++ b/docs/demos/src/hover-card.demo.vue
@@ -5,6 +5,7 @@ import {
     VCHoverCardContent,
     VCHoverCardTrigger,
 } from '@vuecs/overlays';
+import { variantState } from './iframe-bridge';
 </script>
 
 <template>
@@ -20,7 +21,10 @@ import {
             >
                 @octocat
             </VCHoverCardTrigger>
-            <VCHoverCardContent :side-offset="8">
+            <VCHoverCardContent
+                :side-offset="8"
+                :theme-variant="variantState"
+            >
                 <div style="display: flex; flex-direction: column; gap: 0.25rem;">
                     <p style="margin: 0; font-weight: 600;">
                         @octocat

--- a/docs/demos/src/hover-card.ts
+++ b/docs/demos/src/hover-card.ts
@@ -1,6 +1,6 @@
 import overlays from '@vuecs/overlays';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './hover-card.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(overlays);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/iframe-bridge.ts
+++ b/docs/demos/src/iframe-bridge.ts
@@ -16,13 +16,15 @@ import { type DemoThemeName, setDemoTheme } from './shared';
  *   iframe → parent { type: 'demo-variants', catalog, defaults }
  *   iframe → parent { type: 'demo-props',    catalog, defaults }
  *
- * The parent (`Demo.vue`) listens for `demo-resize` to size the iframe to
- * its content; for `demo-variants` to render variant dropdowns in the
- * toolbar; for `demo-props` to render rich type-aware controls. The iframe
- * listens for `set-color-mode` to flip the `.dark` class on `<html>`,
- * for `set-variants` to update `variantState`, and for `set-props` to
- * update `propState` — both of which any demo can `import` and bind to
- * its component.
+ * The parents (`Demo.vue` for passive showcases, `Playground.vue` for
+ * interactive sandboxes) both listen for `demo-resize` to size the
+ * iframe to its content. Only `Playground.vue` listens for
+ * `demo-variants` (renders variant dropdowns) and `demo-props` (renders
+ * rich type-aware controls); `Demo.vue` ignores those — passive demos
+ * have no toolbar. The iframe listens for `set-color-mode` to flip the
+ * `.dark` class on `<html>`, for `set-variants` to update
+ * `variantState`, and for `set-props` to update `propState` — both of
+ * which any demo can `import` and bind to its component.
  *
  * Origin handling: outgoing `postMessage` calls use `location.origin` as
  * the targetOrigin (not `'*'`), so the message is delivered only when

--- a/docs/demos/src/iframe-bridge.ts
+++ b/docs/demos/src/iframe-bridge.ts
@@ -1,3 +1,4 @@
+import { isObject } from '@vuecs/core';
 import { setPalette } from '@vuecs/design';
 import { ref, watch } from 'vue';
 import type { Ref } from 'vue';
@@ -9,16 +10,19 @@ import { type DemoThemeName, setDemoTheme } from './shared';
  *
  *   parent → iframe { type: 'set-color-mode', mode: 'light' | 'dark' }
  *   parent → iframe { type: 'set-variants', values: { <variantName>: <value> } }
+ *   parent → iframe { type: 'set-props',    values: { <propPath>: <value> } }
  *   parent → iframe { type: 'set-palette', primary?, neutral? }
  *   iframe → parent { type: 'demo-resize', height: number }
  *   iframe → parent { type: 'demo-variants', catalog, defaults }
+ *   iframe → parent { type: 'demo-props',    catalog, defaults }
  *
  * The parent (`Demo.vue`) listens for `demo-resize` to size the iframe to
  * its content; for `demo-variants` to render variant dropdowns in the
- * toolbar. The iframe listens for `set-color-mode` to flip the `.dark`
- * class on `<html>` and for `set-variants` to update `variantState` —
- * which any demo Vue component can `import` and bind to its
- * `:theme-variant` prop.
+ * toolbar; for `demo-props` to render rich type-aware controls. The iframe
+ * listens for `set-color-mode` to flip the `.dark` class on `<html>`,
+ * for `set-variants` to update `variantState`, and for `set-props` to
+ * update `propState` — both of which any demo can `import` and bind to
+ * its component.
  *
  * Origin handling: outgoing `postMessage` calls use `location.origin` as
  * the targetOrigin (not `'*'`), so the message is delivered only when
@@ -33,8 +37,42 @@ import { type DemoThemeName, setDemoTheme } from './shared';
  * defense-in-depth against same-origin sibling frames.
  */
 
+export type PropBooleanSpec = {
+    type: 'boolean',
+    default: boolean,
+    section?: string,
+    label?: string,
+};
+export type PropEnumSpec = {
+    type: 'enum',
+    default: string,
+    options: readonly string[],
+    section?: string,
+    label?: string,
+};
+export type PropNumberSpec = {
+    type: 'number',
+    default: number,
+    min?: number,
+    max?: number,
+    step?: number,
+    section?: string,
+    label?: string,
+};
+export type PropStringSpec = {
+    type: 'string',
+    default: string,
+    section?: string,
+    label?: string,
+    placeholder?: string,
+};
+export type PropSpec = PropBooleanSpec | PropEnumSpec | PropNumberSpec | PropStringSpec;
+export type PropCatalog = Record<string, PropSpec>;
+export type PropValues = Record<string, boolean | string | number>;
+
 type ParentMessage =    | { type: 'set-color-mode', mode: 'light' | 'dark' } |
     { type: 'set-variants', values: Record<string, string> } |
+    { type: 'set-props', values: PropValues } |
     {
         type: 'set-palette',
         primary?: string,
@@ -47,10 +85,26 @@ type VariantValues = Record<string, string>;
 
 /**
  * Reactive variant values, updated when the parent posts `set-variants`.
- * Demos that support variant switching: `import { variantState }` and
+ * Demos that only switch theme variants can `import { variantState }` and
  * pass it as `:theme-variant="variantState"` on their VC* component.
+ *
+ * For demos with richer prop controls (booleans, numbers, nested
+ * `themeVariant.size` paths), use `propState` instead — it carries the
+ * full payload as a nested object you can spread with `v-bind`.
  */
 export const variantState: Ref<VariantValues> = ref({});
+
+/**
+ * Reactive prop values, updated when the parent posts `set-props`.
+ * Built from the catalog announced via `announceProps`. Dot-pathed keys
+ * (`themeVariant.size`) are nested into objects, so a demo can write:
+ *
+ *     <VCPagination v-bind="propState" />
+ *
+ * and every announced prop — `total`, `limit`, `themeVariant`, etc. —
+ * becomes interactive.
+ */
+export const propState: Ref<Record<string, unknown>> = ref({});
 
 let pendingHeight: number | null = null;
 let rafHandle: number | null = null;
@@ -78,6 +132,32 @@ const applyColorMode = (mode: 'light' | 'dark'): void => {
     postHeight();
 };
 
+/**
+ * Walk dot-path keys (`themeVariant.size`) and build a nested object so
+ * the demo's `v-bind="propState"` spreads top-level scalars and passes
+ * the nested objects intact (`themeVariant` becomes `{ size, variant }`).
+ */
+const buildNestedState = (values: PropValues): Record<string, unknown> => {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(values)) {
+        const parts = key.split('.');
+        if (parts.length === 1) {
+            result[key] = value;
+            continue;
+        }
+        let cursor: Record<string, unknown> = result;
+        for (let i = 0; i < parts.length - 1; i += 1) {
+            const part = parts[i];
+            if (!isObject(cursor[part])) {
+                cursor[part] = {};
+            }
+            cursor = cursor[part] as Record<string, unknown>;
+        }
+        cursor[parts[parts.length - 1]] = value;
+    }
+    return result;
+};
+
 const handleParentMessage = (event: MessageEvent<ParentMessage>): void => {
     // Reject cross-origin messages outright. Demos are same-origin with
     // the docs host, so any other origin means an unintended embedder.
@@ -86,11 +166,13 @@ const handleParentMessage = (event: MessageEvent<ParentMessage>): void => {
     // not sibling same-origin frames.
     if (event.source !== window.parent) return;
     const { data } = event;
-    if (!data || typeof data !== 'object') return;
+    if (!isObject(data)) return;
     if (data.type === 'set-color-mode') {
         applyColorMode(data.mode);
     } else if (data.type === 'set-variants') {
         variantState.value = { ...data.values };
+    } else if (data.type === 'set-props') {
+        propState.value = buildNestedState(data.values);
     } else if (data.type === 'set-palette') {
         // Live runtime palette swap — rewrites `--vc-color-<scale>-*`
         // CSS custom props to point at a different Tailwind palette.
@@ -118,6 +200,10 @@ const handleParentMessage = (event: MessageEvent<ParentMessage>): void => {
  *
  * The first key in `catalog` is rendered first in the toolbar; pass
  * keys in display order.
+ *
+ * Convenience wrapper for the most common case: an enum-only catalog
+ * driving `:theme-variant`. For richer demos with booleans, numbers, or
+ * mixed prop families, use `announceProps` instead.
  */
 export function announceVariants(catalog: VariantCatalog, defaults: VariantValues): void {
     if (typeof window === 'undefined' || window.parent === window) return;
@@ -125,6 +211,28 @@ export function announceVariants(catalog: VariantCatalog, defaults: VariantValue
     window.parent.postMessage(
         {
             type: 'demo-variants',
+            catalog,
+            defaults,
+        },
+        window.location.origin,
+    );
+}
+
+/**
+ * Announce a typed prop catalog so the parent can render rich controls
+ * (toggle / select / slider / text input) per prop. Updates flow back
+ * via `set-props` and surface as `propState` — the demo binds it with
+ * `v-bind="propState"` so every announced prop becomes interactive.
+ *
+ * Dot-path keys (`themeVariant.size`) auto-build nested objects, so you
+ * can group variant axes under their parent prop without ad-hoc plumbing.
+ */
+export function announceProps(catalog: PropCatalog, defaults: PropValues): void {
+    if (typeof window === 'undefined' || window.parent === window) return;
+    propState.value = buildNestedState(defaults);
+    window.parent.postMessage(
+        {
+            type: 'demo-props',
             catalog,
             defaults,
         },
@@ -142,9 +250,10 @@ export function installIframeBridge(): void {
     const ro = new ResizeObserver(postHeight);
     ro.observe(document.documentElement);
 
-    // Variant changes can reflow the demo (e.g. size: lg shifts heights);
-    // re-measure on mutation.
+    // Variant / prop changes can reflow the demo (e.g. size: lg shifts
+    // heights); re-measure on mutation.
     watch(variantState, () => postHeight(), { deep: true });
+    watch(propState, () => postHeight(), { deep: true });
 
     // Fire an initial measurement once layout settles.
     requestAnimationFrame(postHeight);

--- a/docs/demos/src/list.demo.vue
+++ b/docs/demos/src/list.demo.vue
@@ -6,6 +6,7 @@ import {
     VCListItemText,
 } from '@vuecs/list';
 import { ref } from 'vue';
+import { variantState } from './iframe-bridge';
 
 type Fruit = {
     id: number; 
@@ -38,9 +39,15 @@ function remove(id: number): void {
 
 <template>
     <div style="max-width: 28rem;">
-        <VCList :data="data">
+        <VCList
+            :data="data"
+            :theme-variant="variantState"
+        >
             <template #item="{ data: item }">
-                <VCListItem :data="item">
+                <VCListItem
+                    :data="item"
+                    :theme-variant="variantState"
+                >
                     <VCListItemText>
                         <span class="font-medium">{{ item.name }}</span>
                         <span class="text-xs text-fg-muted">

--- a/docs/demos/src/list.ts
+++ b/docs/demos/src/list.ts
@@ -1,6 +1,6 @@
 import list from '@vuecs/list';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './list.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(list);
 app.mount('#app');
+
+announceVariants({ density: ['compact', 'normal', 'spacious'] }, { density: 'normal' });
 
 installIframeBridge();

--- a/docs/demos/src/modal.demo.vue
+++ b/docs/demos/src/modal.demo.vue
@@ -8,6 +8,7 @@ import {
     VCModalTrigger,
 } from '@vuecs/overlays';
 import { ref } from 'vue';
+import { variantState } from './iframe-bridge';
 
 const open = ref(false);
 </script>
@@ -20,7 +21,7 @@ const open = ref(false);
         >
             Open dialog
         </VCModalTrigger>
-        <VCModalContent>
+        <VCModalContent :theme-variant="variantState">
             <!--
               <VCModalClose /> with no children renders the default × in the
               top-right corner — that's the position the theme-tailwind

--- a/docs/demos/src/modal.ts
+++ b/docs/demos/src/modal.ts
@@ -1,6 +1,6 @@
 import overlays from '@vuecs/overlays';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './modal.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(overlays);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg', 'xl'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/pagination.demo.vue
+++ b/docs/demos/src/pagination.demo.vue
@@ -1,25 +1,26 @@
 <script setup lang="ts">
 import { VCPagination } from '@vuecs/pagination';
 import { ref } from 'vue';
-import { variantState } from './iframe-bridge';
+import { propState } from './iframe-bridge';
 
-const meta = ref({
-    total: 100,
-    offset: 0,
-    limit: 10,
-});
+const offset = ref(0);
 
 const load = (next: { offset: number }) => {
-    meta.value.offset = next.offset;
+    offset.value = next.offset;
 };
 </script>
 
 <template>
+    <!--
+      `v-bind="propState"` spreads every announced prop — `total`, `limit`,
+      `busy`, `hideDisabled`, `themeVariant` (nested from `themeVariant.*`
+      paths in the catalog). The local `offset` ref overrides the catalog's
+      offset so the user-driven page change isn't clobbered by toolbar
+      state on each tick.
+    -->
     <VCPagination
-        :total="meta.total"
-        :offset="meta.offset"
-        :limit="meta.limit"
-        :theme-variant="variantState"
+        v-bind="propState"
+        :offset="offset"
         @load="load"
     />
 </template>

--- a/docs/demos/src/pagination.ts
+++ b/docs/demos/src/pagination.ts
@@ -1,6 +1,6 @@
 import pagination from '@vuecs/pagination';
 import { createApp } from 'vue';
-import { announceVariants, installIframeBridge } from './iframe-bridge';
+import { announceProps, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './pagination.demo.vue';
 
@@ -9,12 +9,53 @@ installVuecs(app);
 app.use(pagination);
 app.mount('#app');
 
-announceVariants(
+announceProps(
     {
-        variant: ['outline', 'soft', 'ghost'],
-        size: ['sm', 'md', 'lg'],
+        total: {
+            type: 'number', 
+            default: 100, 
+            min: 1, 
+            max: 1000, 
+            section: 'Data',
+        },
+        limit: {
+            type: 'number', 
+            default: 10, 
+            min: 1, 
+            max: 100, 
+            section: 'Data',
+        },
+        busy: {
+            type: 'boolean', 
+            default: false, 
+            section: 'State', 
+        },
+        hideDisabled: {
+            type: 'boolean', 
+            default: false, 
+            section: 'State', 
+        },
+        'themeVariant.variant': {
+            type: 'enum', 
+            default: 'outline', 
+            options: ['outline', 'soft', 'ghost'], 
+            section: 'Variant',
+        },
+        'themeVariant.size': {
+            type: 'enum', 
+            default: 'md', 
+            options: ['sm', 'md', 'lg'], 
+            section: 'Variant',
+        },
     },
-    { variant: 'outline', size: 'md' },
+    {
+        total: 100,
+        limit: 10,
+        busy: false,
+        hideDisabled: false,
+        'themeVariant.variant': 'outline',
+        'themeVariant.size': 'md',
+    },
 );
 
 installIframeBridge();

--- a/docs/demos/src/popover.demo.vue
+++ b/docs/demos/src/popover.demo.vue
@@ -6,6 +6,7 @@ import {
     VCPopoverContent,
     VCPopoverTrigger,
 } from '@vuecs/overlays';
+import { variantState } from './iframe-bridge';
 </script>
 
 <template>
@@ -23,6 +24,7 @@ import {
             <VCPopoverContent
                 :side="side"
                 :side-offset="8"
+                :theme-variant="variantState"
             >
                 <div class="flex flex-col gap-1">
                     <p class="text-sm font-semibold">

--- a/docs/demos/src/popover.ts
+++ b/docs/demos/src/popover.ts
@@ -1,6 +1,6 @@
 import overlays from '@vuecs/overlays';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './popover.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(overlays);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/stepper.demo.vue
+++ b/docs/demos/src/stepper.demo.vue
@@ -9,6 +9,7 @@ import {
     VCStepperTrigger,
 } from '@vuecs/navigation';
 import { ref } from 'vue';
+import { variantState } from './iframe-bridge';
 
 const current = ref(2);
 const steps = [
@@ -20,7 +21,10 @@ const steps = [
 
 <template>
     <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 32rem;">
-        <VCStepper v-model="current">
+        <VCStepper
+            v-model="current"
+            :theme-variant="variantState"
+        >
             <template
                 v-for="(step, index) in steps"
                 :key="index"

--- a/docs/demos/src/stepper.ts
+++ b/docs/demos/src/stepper.ts
@@ -1,6 +1,6 @@
 import navigation from '@vuecs/navigation';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './stepper.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(navigation);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/tag.demo.vue
+++ b/docs/demos/src/tag.demo.vue
@@ -1,12 +1,19 @@
 <script setup lang="ts">
 import { VCTag, VCTags } from '@vuecs/elements';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
+import { variantState } from './iframe-bridge';
 
 const tags = ref([
     { value: 'vue', label: 'Vue' },
     { value: 'reka', label: 'Reka UI' },
     { value: 'tailwind', label: 'Tailwind' },
 ]);
+
+// VCTags exposes a top-level `size` prop that forwards to each chip;
+// pull the value from variantState rather than passing themeVariant
+// (themeVariant.size on Tags only scales the wrapper gap, not the
+// children's chip size).
+const tagSize = computed(() => variantState.value.size as 'sm' | 'md' | 'lg' | undefined);
 
 function remove(value: string | number | undefined) {
     tags.value = tags.value.filter((t) => t.value !== value);
@@ -19,15 +26,19 @@ function remove(value: string | number | undefined) {
             <VCTag
                 value="static"
                 label="Static chip"
+                :size="tagSize"
             />
             <VCTag
                 value="removable"
                 label="Removable"
                 removable
+                :size="tagSize"
             />
         </div>
         <VCTags
             :items="tags"
+            :size="tagSize"
+            :theme-variant="variantState"
             removable
             @remove="remove"
         />

--- a/docs/demos/src/tag.ts
+++ b/docs/demos/src/tag.ts
@@ -1,6 +1,6 @@
 import elements from '@vuecs/elements';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './tag.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(elements);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/tooltip.demo.vue
+++ b/docs/demos/src/tooltip.demo.vue
@@ -6,6 +6,7 @@ import {
     VCTooltipProvider,
     VCTooltipTrigger,
 } from '@vuecs/overlays';
+import { variantState } from './iframe-bridge';
 </script>
 
 <template>
@@ -24,6 +25,7 @@ import {
                 <VCTooltipContent
                     :side="side"
                     :side-offset="6"
+                    :theme-variant="variantState"
                 >
                     Tooltip on the {{ side }}
                     <VCTooltipArrow />

--- a/docs/demos/src/tooltip.ts
+++ b/docs/demos/src/tooltip.ts
@@ -1,6 +1,6 @@
 import overlays from '@vuecs/overlays';
 import { createApp } from 'vue';
-import { installIframeBridge } from './iframe-bridge';
+import { announceVariants, installIframeBridge } from './iframe-bridge';
 import { installVuecs } from './shared';
 import Demo from './tooltip.demo.vue';
 
@@ -8,5 +8,7 @@ const app = createApp(Demo);
 installVuecs(app);
 app.use(overlays);
 app.mount('#app');
+
+announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/src/.vitepress/theme/components/Demo.vue
+++ b/docs/src/.vitepress/theme/components/Demo.vue
@@ -4,11 +4,11 @@ import {
     computed,
     onBeforeUnmount,
     onMounted,
-    reactive,
     ref,
     useTemplateRef,
     watch,
 } from 'vue';
+import { isObject } from '@vuecs/core';
 import { usePalette } from '@vuecs/design';
 import { useDemoTheme } from '../use-demo-theme';
 
@@ -21,14 +21,17 @@ interface Props {
      * `.vp-doc` chrome don't leak in. Files live under
      * `docs/demos/src/<name>.{html,ts,demo.vue}` (built by
      * `docs/demos/vite.config.ts` into `docs/src/public/demos/`).
+     *
+     * `<Demo>` is the passive showcase variant — preview + code, no
+     * controls. For interactive variant/prop toolbars use `<Playground>`,
+     * which speaks the `announceVariants` / `announceProps`
+     * postMessage protocol with the iframe.
      */
     name?: string;
     /**
-     * Component name to show in the live-config snippet (e.g. `VCPagination`).
-     * If omitted, derived from `name` by capitalising and prefixing `VC` —
-     * which works for single-word demos (countdown → VCCountdown). For
-     * multi-word kebab-case names (form-checkbox-group → VCFormCheckboxGroup)
-     * pass it explicitly.
+     * Component name shown in the iframe accessibility title (e.g.
+     * `VCCountdown`). If omitted, derived from `name` by capitalising
+     * and prefixing `VC`.
      */
     component?: string;
 }
@@ -42,31 +45,13 @@ const frameRef = useTemplateRef<globalThis.HTMLIFrameElement>('frame');
 const frameHeight = ref<number>(160);
 let copyTimer: ReturnType<typeof setTimeout> | null = null;
 
-// Variant catalog announced by the iframe via postMessage. Empty until
-// the demo mounts and calls `announceVariants(...)` in iframe-bridge —
-// at that point we render a dropdown per variant key in the toolbar.
-const variantCatalog = ref<Record<string, readonly string[]>>({});
-const variantValues = reactive<Record<string, string>>({});
-
-// Global palette state — lives in the navbar `SettingsModal` component.
-// Demo.vue subscribes and forwards changes to its iframe. Local
-// dropdowns intentionally NOT rendered here (palette is page-wide, not
-// per-component, so it belongs in the navbar).
-//
-// `usePalette()` from `@vuecs/design` is shared (createSharedComposable),
-// so this returns the same `current` ref the navbar's SettingsModal
-// writes to.
+// Global palette / color-mode / theme state. Forwarded to the iframe so
+// the demo's visuals stay in sync with the docs-site preferences (set
+// in the navbar's SettingsModal).
 const { current: palette } = usePalette();
 const { current: demoTheme } = useDemoTheme();
-
 const { isDark } = useData();
 
-// `withBase` prepends VitePress's configured `base` (currently '/' for the
-// vuecs.dev deploy). If the site is ever moved to a subpath (e.g. a
-// project page at `/vuecs/`), the iframe URL follows. The demos' own
-// internal asset paths use Vite's `base` in `docs/demos/vite.config.ts`
-// — that value must be kept in sync with VitePress's `base + 'demos/'`
-// when changing deploy paths.
 const frameSrc = computed(() => (props.name ? withBase(`/demos/${props.name}.html`) : null));
 
 const componentName = computed(() => {
@@ -76,59 +61,16 @@ const componentName = computed(() => {
     return `VC${camel}`;
 });
 
-// Per-iframe accessibility name. Pages with multiple demos (e.g.
-// form-select-search has two) need distinct titles so screen readers
-// can tell them apart.
 const frameTitle = computed(() => {
     if (props.title) return `${props.title} demo`;
     return `${componentName.value} demo`;
 });
 
-const variantSnippet = computed(() => {
-    const keys = Object.keys(variantValues);
-    if (keys.length === 0) return '';
-    const inner = keys.map((k) => `${k}: '${variantValues[k]}'`).join(', ');
-    return `<${componentName.value} :theme-variant="{ ${inner} }" />`;
-});
-
-// Fall back to the design-token defaults from `@vuecs/design/assets/index.css`
-// when no palette has been picked yet. Without these the snippet would
-// render `setPalette({ primary: 'undefined', neutral: 'undefined' })` for
-// fresh visitors with empty localStorage — a misleading copy-paste example.
-const paletteSnippet = computed(() => {
-    const primary = palette.value.primary ?? 'blue';
-    const neutral = palette.value.neutral ?? 'neutral';
-    return `setPalette({ primary: '${primary}', neutral: '${neutral}' });`;
-});
-
-const hasVariants = computed(() => Object.keys(variantCatalog.value).length > 0);
-
-/*
- * postMessage targetOrigin: demos are served same-origin with the docs
- * host (`vuecs.dev/demos/<name>.html` for the deploy, localhost for
- * dev). Pinning the targetOrigin to `globalThis.location.origin`
- * ensures the message is delivered ONLY to a same-origin parent —
- * cross-origin embedders never receive control messages.
- */
 const postColorMode = (): void => {
     const win = frameRef.value?.contentWindow;
     if (!win) return;
     win.postMessage(
         { type: 'set-color-mode', mode: isDark.value ? 'dark' : 'light' },
-        globalThis.location.origin,
-    );
-};
-
-const postVariants = (): void => {
-    const win = frameRef.value?.contentWindow;
-    if (!win) return;
-    // Skip empty payloads — `onFrameLoad` clears `variantValues` before
-    // the iframe announces its catalog, which would otherwise trigger
-    // the deep watcher and post an empty `set-variants` round-trip
-    // that the iframe immediately overwrites with its own announce.
-    if (Object.keys(variantValues).length === 0) return;
-    win.postMessage(
-        { type: 'set-variants', values: { ...variantValues } },
         globalThis.location.origin,
     );
 };
@@ -156,63 +98,24 @@ const postTheme = (): void => {
 };
 
 const onFrameLoad = (): void => {
-    // Reset variant state for the new iframe (in case Demo.vue is reused
-    // across navigations and the previous demo had a different catalog).
-    variantCatalog.value = {};
-    Object.keys(variantValues).forEach((k) => delete variantValues[k]);
     postColorMode();
     postPalette();
     postTheme();
 };
 
 const onFrameMessage = (event: MessageEvent): void => {
-    // Only accept messages from THIS demo's iframe. Both checks together:
-    //  - origin: rejects cross-origin messages (defense if Demo.vue is
-    //    ever embedded in an unexpected context)
-    //  - source: rejects same-origin sibling iframes that aren't ours
     if (event.origin !== globalThis.location.origin) return;
     if (event.source !== frameRef.value?.contentWindow) return;
-    const data = event.data as {
-        type?: string;
-        height?: number;
-        catalog?: Record<string, readonly string[]>;
-        defaults?: Record<string, string>;
-    };
-    if (!data || typeof data !== 'object') return;
+    const { data } = event;
+    if (!isObject(data)) return;
     if (data.type === 'demo-resize' && typeof data.height === 'number') {
         frameHeight.value = data.height;
-        return;
-    }
-    if (data.type === 'demo-variants' && data.catalog && data.defaults) {
-        variantCatalog.value = data.catalog;
-        Object.keys(variantValues).forEach((k) => delete variantValues[k]);
-        Object.assign(variantValues, data.defaults);
     }
 };
 
-watch(isDark, () => {
-    postColorMode();
-});
-
-watch(
-    variantValues,
-    () => {
-        postVariants();
-    },
-    { deep: true },
-);
-
-watch(
-    palette,
-    () => {
-        postPalette();
-    },
-    { deep: true },
-);
-
-watch(demoTheme, () => {
-    postTheme();
-});
+watch(isDark, () => postColorMode());
+watch(palette, () => postPalette(), { deep: true });
+watch(demoTheme, () => postTheme());
 
 onMounted(() => {
     globalThis.window.addEventListener('message', onFrameMessage);
@@ -226,11 +129,7 @@ const copy = async () => {
     if (!codeRoot.value) return;
     // When the slot contains a VitePress code-group (::: code-group), the
     // active tab carries the `.active` class. Run two queries in priority
-    // order — `querySelector('a, b')` returns the FIRST DOM-order match
-    // across both selectors (not the first selector that matches), which
-    // would always pick the inactive first tab's <pre>. The two-step
-    // lookup actually tracks the active tab; falls back to any <pre> for
-    // the single-code-block case.
+    // order so we don't grab the inactive first tab's <pre>.
     const pre = codeRoot.value.querySelector('.vp-code-group .blocks > .active pre') ??
         codeRoot.value.querySelector('pre');
     if (!pre) return;
@@ -239,15 +138,9 @@ const copy = async () => {
     try {
         await navigator.clipboard.writeText(text);
     } catch {
-        // Clipboard API can reject in insecure contexts or permission
-        // denial — swallow and leave `copied` false so the button
-        // doesn't claim success.
         return;
     }
     copied.value = true;
-    // Clear any pending timer so rapid successive clicks restart the
-    // 1.5s "Copied" window from the latest click instead of letting an
-    // older timer flip back early.
     if (copyTimer) clearTimeout(copyTimer);
     copyTimer = setTimeout(() => { copied.value = false; }, 1500);
 };
@@ -260,40 +153,6 @@ const copy = async () => {
             class="vc-demo-title"
         >
             {{ title }}
-        </div>
-
-        <div
-            v-if="hasVariants"
-            class="vc-demo-controls"
-        >
-            <div class="vc-demo-controls-row">
-                <span class="vc-demo-controls-label">Variant</span>
-                <div class="vc-demo-controls-fields">
-                    <label
-                        v-for="(values, key) in variantCatalog"
-                        :key="key"
-                        class="vc-demo-control"
-                    >
-                        <span class="vc-demo-control-name">{{ key }}</span>
-                        <select
-                            v-model="variantValues[key]"
-                            class="vc-demo-control-select"
-                        >
-                            <option
-                                v-for="value in values"
-                                :key="value"
-                                :value="value"
-                            >
-                                {{ value }}
-                            </option>
-                        </select>
-                    </label>
-                </div>
-            </div>
-            <div class="vc-demo-snippet">
-                <code class="vc-demo-snippet-code">{{ variantSnippet }}</code>
-                <code class="vc-demo-snippet-code vc-demo-snippet-code--muted">{{ paletteSnippet }}</code>
-            </div>
         </div>
 
         <div
@@ -357,106 +216,14 @@ const copy = async () => {
     background: var(--vc-color-bg-elevated);
 }
 
-/* Controls panel — sits above the iframe preview, contains the variant
-   dropdowns + the live-config snippet showing how the consumer would
-   write the same call. The palette controls live in the navbar; the
-   snippet here mirrors both the variant and the palette so the user
-   sees the full picture in one place. */
-.vc-demo-controls {
-    padding: 0.5rem 0.75rem;
-    border-bottom: 1px solid var(--vc-color-border);
-    background: var(--vc-color-bg-elevated);
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.vc-demo-controls-row {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    flex-wrap: wrap;
-}
-
-.vc-demo-controls-label {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--vc-color-fg-muted);
-    min-width: 4rem;
-}
-
-.vc-demo-controls-fields {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-}
-
-.vc-demo-control {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-}
-
-.vc-demo-control-name {
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--vc-color-fg-muted);
-    text-transform: capitalize;
-}
-
-.vc-demo-control-select {
-    font-size: 0.75rem;
-    padding: 0.125rem 0.375rem;
-    border: 1px solid var(--vc-color-border);
-    border-radius: 0.25rem;
-    background: var(--vc-color-bg);
-    color: var(--vc-color-fg);
-    cursor: pointer;
-}
-.vc-demo-control-select:focus {
-    outline: none;
-    border-color: var(--vc-color-primary-500);
-    box-shadow: 0 0 0 1px var(--vc-color-primary-500);
-}
-
-/* Live-config snippet — shows the Vue/JS call the user would write
-   to reproduce the current state. Updates reactively. */
-.vc-demo-snippet {
-    display: flex;
-    flex-direction: column;
-    gap: 0.125rem;
-    padding: 0.5rem 0.625rem;
-    border-radius: 0.375rem;
-    background: var(--vc-color-bg);
-    border: 1px dashed var(--vc-color-border);
-    font-family: var(--font-mono);
-}
-
-.vc-demo-snippet-code {
-    font-size: 0.6875rem;
-    color: var(--vc-color-fg);
-    white-space: pre-wrap;
-    word-break: break-word;
-    background: transparent;
-    padding: 0;
-    border: 0;
-}
-
-.vc-demo-snippet-code--muted {
-    color: var(--vc-color-fg-muted);
-}
-
 .vc-demo-preview {
     padding: 1.5rem;
     background: var(--vc-color-bg);
 }
 
-/* Iframe demos own their own document padding (see docs/demos/src/style.css);
-   the host preview just needs to provide the surface and let the iframe
-   span it. */
+/* Iframe demos own their own document padding (see
+   docs/demos/src/style.css); the host preview just needs to provide the
+   surface and let the iframe span it. */
 .vc-demo-preview--iframe {
     padding: 0;
 }
@@ -500,8 +267,6 @@ const copy = async () => {
 .vc-demo-copy { margin-left: auto; }
 .vc-demo-copy:disabled { opacity: 0.5; cursor: not-allowed; }
 
-/* The default slot renders VitePress-styled <pre> elements; reset margins so
-   they sit flush in the demo body. */
 .vc-demo-code :deep(div[class*='language-']) {
     margin: 0;
     border-radius: 0;

--- a/docs/src/.vitepress/theme/components/Playground.vue
+++ b/docs/src/.vitepress/theme/components/Playground.vue
@@ -1,0 +1,546 @@
+<script setup lang="ts">
+import { useData, withBase } from 'vitepress';
+import {
+    computed,
+    onBeforeUnmount,
+    onMounted,
+    reactive,
+    ref,
+    useTemplateRef,
+    watch,
+} from 'vue';
+import { isObject } from '@vuecs/core';
+import { usePalette } from '@vuecs/design';
+import type { PropCatalog, PropSpec, PropValues } from '../../../../demos/src/iframe-bridge';
+import { useDemoTheme } from '../use-demo-theme';
+
+interface Props {
+    title?: string;
+    /**
+     * Name of the iframe-isolated demo. Loaded as
+     * `<iframe src="/demos/<name>.html">`. The iframe announces its
+     * variant / prop catalog via postMessage; the toolbar above the
+     * preview renders the matching controls (select for enums, checkbox
+     * for booleans, range+number for numbers, text input for strings).
+     *
+     * For passive showcases without controls, use `<Demo>` instead — it
+     * drops the announce/postMessage round-trip entirely.
+     */
+    name: string;
+    /**
+     * Component name shown in iframe accessibility labels (e.g.
+     * `VCPagination`). If omitted, derived from `name` by capitalising
+     * and prefixing `VC`. Pass explicitly for multi-word kebab-case
+     * names like `form-checkbox-group → VCFormCheckboxGroup`.
+     */
+    component?: string;
+}
+
+const props = defineProps<Props>();
+
+const showCode = ref(true);
+const copied = ref(false);
+const codeRoot = useTemplateRef<globalThis.HTMLElement>('codeRoot');
+const frameRef = useTemplateRef<globalThis.HTMLIFrameElement>('frame');
+const frameHeight = ref<number>(160);
+let copyTimer: ReturnType<typeof setTimeout> | null = null;
+
+// Variant catalog — populated from the iframe's `announceVariants` call.
+// Renders a single-row dropdown strip in the toolbar.
+const variantCatalog = ref<Record<string, readonly string[]>>({});
+const variantValues = reactive<Record<string, string>>({});
+
+// Rich prop catalog — populated from the iframe's `announceProps` call.
+// Each entry is a typed spec; the toolbar renders the matching control.
+// Dot-pathed keys (`themeVariant.size`) are auto-grouped into nested
+// objects on the iframe side.
+const propCatalog = ref<PropCatalog>({});
+const propValues = reactive<PropValues>({});
+
+// Global palette / color-mode / theme state. Demo and Playground both
+// forward these to their iframes so visuals stay in sync with the
+// docs-site preferences (set in the navbar's SettingsModal).
+const { current: palette } = usePalette();
+const { current: demoTheme } = useDemoTheme();
+const { isDark } = useData();
+
+const frameSrc = computed(() => withBase(`/demos/${props.name}.html`));
+
+const componentName = computed(() => {
+    if (props.component) return props.component;
+    const camel = props.name.split('-').map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join('');
+    return `VC${camel}`;
+});
+
+const frameTitle = computed(() => {
+    if (props.title) return `${props.title} playground`;
+    return `${componentName.value} playground`;
+});
+
+const hasVariants = computed(() => Object.keys(variantCatalog.value).length > 0);
+const hasProps = computed(() => Object.keys(propCatalog.value).length > 0);
+
+// Group rich-prop entries by their `section` (or 'General' if unset) so
+// related controls land together. Each group renders its own row.
+const propSections = computed(() => {
+    const sections = new Map<string, Array<{ key: string; spec: PropSpec }>>();
+    for (const [key, spec] of Object.entries(propCatalog.value)) {
+        const section = spec.section ?? 'General';
+        if (!sections.has(section)) sections.set(section, []);
+        sections.get(section)!.push({ key, spec });
+    }
+    return Array.from(sections.entries()).map(([title, entries]) => ({ title, entries }));
+});
+
+// Display label — explicit `label` wins, otherwise prettify the key.
+// `themeVariant.size` → `size`, `hideDisabled` → `hide disabled`.
+const labelFor = (key: string, spec: PropSpec): string => {
+    if (spec.label) return spec.label;
+    const tail = key.includes('.') ? key.split('.').pop()! : key;
+    return tail.replace(/([A-Z])/g, ' $1').trim().toLowerCase();
+};
+
+/*
+ * Pinning targetOrigin to `globalThis.location.origin` ensures messages
+ * are delivered ONLY to a same-origin parent — cross-origin embedders
+ * never receive control messages.
+ */
+const postColorMode = (): void => {
+    const win = frameRef.value?.contentWindow;
+    if (!win) return;
+    win.postMessage(
+        { type: 'set-color-mode', mode: isDark.value ? 'dark' : 'light' },
+        globalThis.location.origin,
+    );
+};
+
+const postVariants = (): void => {
+    const win = frameRef.value?.contentWindow;
+    if (!win) return;
+    if (Object.keys(variantValues).length === 0) return;
+    win.postMessage(
+        { type: 'set-variants', values: { ...variantValues } },
+        globalThis.location.origin,
+    );
+};
+
+const postProps = (): void => {
+    const win = frameRef.value?.contentWindow;
+    if (!win) return;
+    if (Object.keys(propValues).length === 0) return;
+    win.postMessage(
+        { type: 'set-props', values: { ...propValues } },
+        globalThis.location.origin,
+    );
+};
+
+const postPalette = (): void => {
+    const win = frameRef.value?.contentWindow;
+    if (!win) return;
+    win.postMessage(
+        {
+            type: 'set-palette',
+            primary: palette.value.primary ?? 'blue',
+            neutral: palette.value.neutral ?? 'neutral',
+        },
+        globalThis.location.origin,
+    );
+};
+
+const postTheme = (): void => {
+    const win = frameRef.value?.contentWindow;
+    if (!win) return;
+    win.postMessage(
+        { type: 'set-theme', theme: demoTheme.value },
+        globalThis.location.origin,
+    );
+};
+
+const onFrameLoad = (): void => {
+    // Forward initial color-mode / palette / theme state to the freshly
+    // loaded iframe.
+    //
+    // Important: do NOT clear `variantCatalog` / `propCatalog` here. The
+    // iframe's `announceVariants` / `announceProps` posts its message
+    // during module-script execution, which can land in the parent's
+    // queue BEFORE the iframe's `load` event fires — clearing here would
+    // erase the catalog we just received and the toolbar would never
+    // show controls. Catalog reset belongs on the `frameSrc` change
+    // watcher below (different demo → reset stale catalog).
+    postColorMode();
+    postPalette();
+    postTheme();
+};
+
+const onFrameMessage = (event: MessageEvent): void => {
+    if (event.origin !== globalThis.location.origin) return;
+    if (event.source !== frameRef.value?.contentWindow) return;
+    const { data } = event;
+    if (!isObject(data)) return;
+    if (data.type === 'demo-resize' && typeof data.height === 'number') {
+        frameHeight.value = data.height;
+        return;
+    }
+    if (data.type === 'demo-variants' && data.catalog && data.defaults) {
+        variantCatalog.value = data.catalog as Record<string, readonly string[]>;
+        Object.keys(variantValues).forEach((k) => delete variantValues[k]);
+        Object.assign(variantValues, data.defaults);
+        return;
+    }
+    if (data.type === 'demo-props' && data.catalog && data.defaults) {
+        propCatalog.value = data.catalog as PropCatalog;
+        Object.keys(propValues).forEach((k) => delete propValues[k]);
+        Object.assign(propValues, data.defaults);
+    }
+};
+
+watch(isDark, () => {
+    postColorMode();
+});
+
+watch(variantValues, () => postVariants(), { deep: true });
+watch(propValues, () => postProps(), { deep: true });
+watch(palette, () => postPalette(), { deep: true });
+watch(demoTheme, () => postTheme());
+
+// Reset toolbar state when navigating to a different demo. The iframe
+// will repopulate with its own announce; clearing here just prevents
+// the previous demo's catalog from briefly showing before the new one
+// announces.
+watch(frameSrc, () => {
+    variantCatalog.value = {};
+    Object.keys(variantValues).forEach((k) => delete variantValues[k]);
+    propCatalog.value = {};
+    Object.keys(propValues).forEach((k) => delete propValues[k]);
+});
+
+onMounted(() => {
+    globalThis.window.addEventListener('message', onFrameMessage);
+});
+
+onBeforeUnmount(() => {
+    globalThis.window.removeEventListener('message', onFrameMessage);
+});
+
+const copy = async () => {
+    if (!codeRoot.value) return;
+    const pre = codeRoot.value.querySelector('.vp-code-group .blocks > .active pre') ??
+        codeRoot.value.querySelector('pre');
+    if (!pre) return;
+    const text = pre.textContent ?? '';
+    if (!navigator?.clipboard) return;
+    try {
+        await navigator.clipboard.writeText(text);
+    } catch {
+        return;
+    }
+    copied.value = true;
+    if (copyTimer) clearTimeout(copyTimer);
+    copyTimer = setTimeout(() => { copied.value = false; }, 1500);
+};
+</script>
+
+<template>
+    <div class="vc-demo vc-demo--playground">
+        <div
+            v-if="title"
+            class="vc-demo-title"
+        >
+            {{ title }}
+        </div>
+
+        <div
+            v-if="hasVariants"
+            class="vc-demo-controls"
+        >
+            <div class="vc-demo-controls-row">
+                <span class="vc-demo-controls-label">Variant</span>
+                <div class="vc-demo-controls-fields">
+                    <label
+                        v-for="(values, key) in variantCatalog"
+                        :key="key"
+                        class="vc-demo-control"
+                    >
+                        <span class="vc-demo-control-name">{{ key }}</span>
+                        <select
+                            v-model="variantValues[key]"
+                            class="vc-demo-control-select"
+                        >
+                            <option
+                                v-for="value in values"
+                                :key="value"
+                                :value="value"
+                            >
+                                {{ value }}
+                            </option>
+                        </select>
+                    </label>
+                </div>
+            </div>
+        </div>
+
+        <div
+            v-if="hasProps"
+            class="vc-demo-controls"
+        >
+            <div
+                v-for="section in propSections"
+                :key="section.title"
+                class="vc-demo-controls-row"
+            >
+                <span class="vc-demo-controls-label">{{ section.title }}</span>
+                <div class="vc-demo-controls-fields">
+                    <label
+                        v-for="entry in section.entries"
+                        :key="entry.key"
+                        class="vc-demo-control"
+                    >
+                        <span class="vc-demo-control-name">{{ labelFor(entry.key, entry.spec) }}</span>
+                        <input
+                            v-if="entry.spec.type === 'boolean'"
+                            v-model="propValues[entry.key] as boolean"
+                            type="checkbox"
+                            class="vc-demo-control-checkbox"
+                        >
+                        <select
+                            v-else-if="entry.spec.type === 'enum'"
+                            v-model="propValues[entry.key] as string"
+                            class="vc-demo-control-select"
+                        >
+                            <option
+                                v-for="value in entry.spec.options"
+                                :key="value"
+                                :value="value"
+                            >
+                                {{ value }}
+                            </option>
+                        </select>
+                        <template v-else-if="entry.spec.type === 'number'">
+                            <input
+                                v-if="entry.spec.min !== undefined && entry.spec.max !== undefined"
+                                v-model.number="propValues[entry.key] as number"
+                                type="range"
+                                :min="entry.spec.min"
+                                :max="entry.spec.max"
+                                :step="entry.spec.step ?? 1"
+                                class="vc-demo-control-range"
+                            >
+                            <input
+                                v-model.number="propValues[entry.key] as number"
+                                type="number"
+                                :min="entry.spec.min"
+                                :max="entry.spec.max"
+                                :step="entry.spec.step ?? 1"
+                                class="vc-demo-control-number"
+                            >
+                        </template>
+                        <input
+                            v-else-if="entry.spec.type === 'string'"
+                            v-model="propValues[entry.key] as string"
+                            type="text"
+                            :placeholder="entry.spec.placeholder"
+                            class="vc-demo-control-text"
+                        >
+                    </label>
+                </div>
+            </div>
+        </div>
+
+        <div class="vc-demo-preview vc-demo-preview--iframe">
+            <iframe
+                ref="frame"
+                :src="frameSrc"
+                :style="{ height: `${frameHeight}px` }"
+                :title="frameTitle"
+                @load="onFrameLoad"
+            />
+        </div>
+
+        <div class="vc-demo-toolbar">
+            <button
+                type="button"
+                class="vc-demo-toggle"
+                @click="showCode = !showCode"
+            >
+                {{ showCode ? 'Hide code' : 'Show code' }}
+            </button>
+            <button
+                type="button"
+                class="vc-demo-copy"
+                :disabled="!showCode"
+                @click="copy"
+            >
+                {{ copied ? 'Copied' : 'Copy' }}
+            </button>
+        </div>
+
+        <div
+            v-show="showCode"
+            ref="codeRoot"
+            class="vc-demo-code"
+        >
+            <slot name="code" />
+        </div>
+    </div>
+</template>
+
+<style scoped>
+/* Playground reuses the same shell styles as Demo. The `--playground`
+   modifier is reserved for future visual differentiation (e.g. a
+   "Playground" badge in the title bar) — currently identical to Demo. */
+.vc-demo {
+    border: 1px solid var(--vc-color-border);
+    border-radius: 0.625rem;
+    overflow: hidden;
+    margin: 1.25rem 0 1.5rem;
+    background: var(--vc-color-bg);
+}
+
+.vc-demo-title {
+    padding: 0.625rem 1rem;
+    border-bottom: 1px solid var(--vc-color-border);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--vc-color-fg-muted);
+    background: var(--vc-color-bg-elevated);
+}
+
+.vc-demo-controls {
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid var(--vc-color-border);
+    background: var(--vc-color-bg-elevated);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.vc-demo-controls-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.vc-demo-controls-label {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--vc-color-fg-muted);
+    min-width: 4rem;
+}
+
+.vc-demo-controls-fields {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.vc-demo-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+}
+
+.vc-demo-control-name {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--vc-color-fg-muted);
+    text-transform: capitalize;
+}
+
+.vc-demo-control-select,
+.vc-demo-control-number,
+.vc-demo-control-text {
+    font-size: 0.75rem;
+    padding: 0.125rem 0.375rem;
+    border: 1px solid var(--vc-color-border);
+    border-radius: 0.25rem;
+    background: var(--vc-color-bg);
+    color: var(--vc-color-fg);
+    cursor: pointer;
+}
+.vc-demo-control-number {
+    width: 4.5rem;
+    cursor: text;
+}
+.vc-demo-control-text {
+    width: 9rem;
+    cursor: text;
+}
+.vc-demo-control-select:focus,
+.vc-demo-control-number:focus,
+.vc-demo-control-text:focus {
+    outline: none;
+    border-color: var(--vc-color-primary-500);
+    box-shadow: 0 0 0 1px var(--vc-color-primary-500);
+}
+
+.vc-demo-control-checkbox {
+    width: 0.875rem;
+    height: 0.875rem;
+    accent-color: var(--vc-color-primary-600);
+    cursor: pointer;
+}
+
+.vc-demo-control-range {
+    width: 7rem;
+    accent-color: var(--vc-color-primary-600);
+    cursor: pointer;
+}
+
+.vc-demo-preview {
+    padding: 1.5rem;
+    background: var(--vc-color-bg);
+}
+
+.vc-demo-preview--iframe {
+    padding: 0;
+}
+
+.vc-demo-preview iframe {
+    display: block;
+    width: 100%;
+    border: 0;
+    background: var(--vc-color-bg);
+    transition: height 0.15s ease;
+}
+
+.vc-demo-toolbar {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 0.375rem 0.5rem;
+    border-top: 1px solid var(--vc-color-border);
+    border-bottom: 1px solid var(--vc-color-border);
+    background: var(--vc-color-bg-elevated);
+}
+
+.vc-demo-toggle,
+.vc-demo-copy {
+    padding: 0.25rem 0.625rem;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--vc-color-fg-muted);
+    font-size: 0.75rem;
+    font-weight: 500;
+    border-radius: 0.375rem;
+    cursor: pointer;
+}
+.vc-demo-toggle:hover,
+.vc-demo-copy:hover:not(:disabled) {
+    color: var(--vc-color-fg);
+    border-color: var(--vc-color-border);
+}
+.vc-demo-copy { margin-left: auto; }
+.vc-demo-copy:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.vc-demo-code :deep(div[class*='language-']) {
+    margin: 0;
+    border-radius: 0;
+}
+.vc-demo-code :deep(pre) {
+    margin: 0;
+}
+</style>

--- a/docs/src/.vitepress/theme/components/Playground.vue
+++ b/docs/src/.vitepress/theme/components/Playground.vue
@@ -158,7 +158,10 @@ const postTheme = (): void => {
 
 const onFrameLoad = (): void => {
     // Forward initial color-mode / palette / theme state to the freshly
-    // loaded iframe.
+    // loaded iframe — and re-post the user's current toolbar selections
+    // so the preview matches the toolbar after a same-src iframe reload
+    // (HMR, manual refresh) rather than snapping back to the iframe's
+    // declared defaults.
     //
     // Important: do NOT clear `variantCatalog` / `propCatalog` here. The
     // iframe's `announceVariants` / `announceProps` posts its message
@@ -170,6 +173,8 @@ const onFrameLoad = (): void => {
     postColorMode();
     postPalette();
     postTheme();
+    postVariants();
+    postProps();
 };
 
 const onFrameMessage = (event: MessageEvent): void => {

--- a/docs/src/.vitepress/theme/index.ts
+++ b/docs/src/.vitepress/theme/index.ts
@@ -4,6 +4,7 @@ import tailwindTheme from '@vuecs/theme-tailwind';
 import type { Theme } from 'vitepress';
 import DefaultTheme from 'vitepress/theme';
 import Demo from './components/Demo.vue';
+import Playground from './components/Playground.vue';
 import Layout from './Layout.vue';
 
 import './style.css';
@@ -28,5 +29,6 @@ export default {
         app.use(vuecs, { themes: [tailwindTheme()] });
         app.use(overlays);
         app.component('Demo', Demo);
+        app.component('Playground', Playground);
     },
 } satisfies Theme;

--- a/docs/src/components/avatar.md
+++ b/docs/src/components/avatar.md
@@ -6,7 +6,7 @@ Image with graceful fallback (initials, icon, or arbitrary slot). Built on [Reka
 npm install @vuecs/elements
 ```
 
-<Demo name="avatar">
+<Playground name="avatar">
   <template #code>
 
 ::: code-group
@@ -42,7 +42,7 @@ import { VCAvatar } from '@vuecs/elements';
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Props
 

--- a/docs/src/components/badge.md
+++ b/docs/src/components/badge.md
@@ -8,7 +8,7 @@ Status pill. Variants (`solid` / `soft` / `outline`) compose with the standard s
 npm install @vuecs/elements
 ```
 
-<Demo name="badge">
+<Playground name="badge">
   <template #code>
 
 ::: code-group
@@ -16,12 +16,23 @@ npm install @vuecs/elements
 ```vue [Vue]
 <script setup lang="ts">
 import { VCBadge } from '@vuecs/elements';
+
+const colors = ['primary', 'neutral', 'success', 'warning', 'error', 'info'] as const;
+const variants = ['solid', 'soft', 'outline'] as const;
 </script>
 
 <template>
-    <VCBadge color="success">Live</VCBadge>
-    <VCBadge color="warning" variant="soft">Beta</VCBadge>
-    <VCBadge color="error" variant="outline">Deprecated</VCBadge>
+    <!-- Color × variant grid: every (color, variant) cell renders. -->
+    <div v-for="variant in variants" :key="variant">
+        <VCBadge
+            v-for="color in colors"
+            :key="`${variant}-${color}`"
+            :variant="variant"
+            :color="color"
+        >
+            {{ color }}
+        </VCBadge>
+    </div>
 </template>
 ```
 
@@ -36,7 +47,7 @@ import { VCBadge } from '@vuecs/elements';
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Props
 

--- a/docs/src/components/button.md
+++ b/docs/src/components/button.md
@@ -8,7 +8,7 @@ npm install @vuecs/button
 
 ## Basic usage
 
-<Demo name="button">
+<Playground name="button">
 
   <template #code>
 
@@ -17,23 +17,43 @@ npm install @vuecs/button
 ```vue [Vue]
 <script setup lang="ts">
 import { VCButton } from '@vuecs/button';
+import { useSubmitButton } from '@vuecs/forms';
+import { ref } from 'vue';
+
+const isEditing = ref(false);
+const submit = useSubmitButton({ isEditing: () => isEditing.value });
 </script>
 
 <template>
-    <!-- Solid (default variant) — color picks the visual treatment. -->
-    <VCButton color="primary" label="Save" />
-    <VCButton color="error" label="Delete" />
+    <!-- Color axis (solid is the default variant). -->
+    <VCButton color="primary" label="Primary" />
+    <VCButton color="success" label="Success" />
+    <VCButton color="warning" label="Warning" />
+    <VCButton color="error" label="Danger" />
+    <VCButton color="neutral" label="Neutral" />
 
-    <!-- Variants control the treatment (solid / soft / outline / ghost / link). -->
-    <VCButton variant="outline" color="primary" label="Cancel" />
-    <VCButton variant="ghost" color="neutral" label="Skip" />
-    <VCButton variant="link" color="primary" label="Read more" />
+    <!-- Variant axis (primary is the default color). -->
+    <VCButton variant="solid" label="Solid" />
+    <VCButton variant="soft" label="Soft" />
+    <VCButton variant="outline" label="Outline" />
+    <VCButton variant="ghost" label="Ghost" />
+    <VCButton variant="link" label="Link" />
 
-    <!-- Loading shows a structural busy state (cursor: wait + opacity pulse). -->
-    <VCButton :loading="true" color="primary" label="Saving…" />
+    <!-- Size + state axes. `loading` shows the structural busy state
+         (cursor: wait + opacity pulse); `disabled` is the inert sibling. -->
+    <VCButton size="sm" label="Small" />
+    <VCButton size="md" label="Medium" />
+    <VCButton size="lg" label="Large" />
+    <VCButton :loading="true" label="Loading…" />
+    <VCButton :disabled="true" label="Disabled" />
 
-    <!-- Icons are Iconify name strings, resolved through <VCIcon> — or pass <template #leading> / #trailing for full control. -->
-    <VCButton icon-left="lucide:plus" color="success" label="Create" />
+    <!-- useSubmitButton() returns a reactive bind-object — label / icon /
+         color swap when `isEditing` flips. The DefaultsManager hook in a
+         real bind site. -->
+    <button @click="isEditing = !isEditing">
+        Toggle isEditing ({{ isEditing ? 'on' : 'off' }})
+    </button>
+    <VCButton v-bind="submit" />
 </template>
 ```
 
@@ -54,7 +74,7 @@ import { VCButton } from '@vuecs/button';
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Props
 

--- a/docs/src/components/button.md
+++ b/docs/src/components/button.md
@@ -3,7 +3,9 @@
 General-purpose button with semantic `color`, `variant`, and `size` variants. The two themes that ship visual class mappings (`@vuecs/theme-tailwind`, `@vuecs/theme-bootstrap`) provide the full color × variant × size matrix; consumers switch looks by changing variant values, not by re-styling per instance.
 
 ```bash
-npm install @vuecs/button
+# `@vuecs/forms` is only needed for the `useSubmitButton()` helper shown
+# below; the button itself ships standalone in `@vuecs/button`.
+npm install @vuecs/button @vuecs/forms
 ```
 
 ## Basic usage

--- a/docs/src/components/context-menu.md
+++ b/docs/src/components/context-menu.md
@@ -6,7 +6,7 @@ Right-click-triggered menu. Same shape as DropdownMenu but anchored to the curso
 npm install @vuecs/overlays
 ```
 
-<Demo name="context-menu" component="VCContextMenu">
+<Playground name="context-menu" component="VCContextMenu">
   <template #code>
 
 ::: code-group
@@ -56,7 +56,7 @@ const lastAction = ref<string>('—');
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Compound API
 

--- a/docs/src/components/dropdown-menu.md
+++ b/docs/src/components/dropdown-menu.md
@@ -6,7 +6,7 @@ Click-triggered menu of actions. Built on [Reka UI](https://reka-ui.com/)'s Drop
 npm install @vuecs/overlays
 ```
 
-<Demo name="dropdown-menu" component="VCDropdownMenu">
+<Playground name="dropdown-menu" component="VCDropdownMenu">
   <template #code>
 
 ::: code-group
@@ -56,7 +56,7 @@ const lastAction = ref<string>('—');
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Compound API
 

--- a/docs/src/components/form-checkbox.md
+++ b/docs/src/components/form-checkbox.md
@@ -10,7 +10,7 @@ npm install @vuecs/forms
 
 ## Basic usage
 
-<Demo name="form-checkbox">
+<Playground name="form-checkbox">
 
   <template #code>
 
@@ -61,7 +61,7 @@ const selected = ref<string[]>(['a']);
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Custom label markup
 

--- a/docs/src/components/form-input.md
+++ b/docs/src/components/form-input.md
@@ -8,7 +8,7 @@ npm install @vuecs/forms
 
 ## Basic usage
 
-<Demo name="form-input">
+<Playground name="form-input">
 
   <template #code>
 
@@ -40,7 +40,7 @@ const value = ref('');
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Props
 

--- a/docs/src/components/form-number.md
+++ b/docs/src/components/form-number.md
@@ -8,7 +8,7 @@ npm install @vuecs/forms
 
 ## Basic usage
 
-<Demo name="form-number">
+<Playground name="form-number">
 
   <template #code>
 
@@ -47,7 +47,7 @@ const price = ref<number>(19.99);
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Locale + currency formatting
 

--- a/docs/src/components/form-radio.md
+++ b/docs/src/components/form-radio.md
@@ -8,7 +8,7 @@ npm install @vuecs/forms
 
 ## Basic usage
 
-<Demo name="form-radio">
+<Playground name="form-radio">
 
   <template #code>
 
@@ -43,7 +43,7 @@ const size = ref<string>('md');
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Options shorthand
 

--- a/docs/src/components/form-select.md
+++ b/docs/src/components/form-select.md
@@ -10,7 +10,7 @@ npm install @vuecs/forms
 
 ## Basic usage
 
-<Demo name="form-select">
+<Playground name="form-select">
 
   <template #code>
 
@@ -64,7 +64,7 @@ const regions = [
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## The `FormOption` shape
 

--- a/docs/src/components/form-switch.md
+++ b/docs/src/components/form-switch.md
@@ -8,7 +8,7 @@ npm install @vuecs/forms
 
 ## Basic usage
 
-<Demo name="form-switch">
+<Playground name="form-switch">
 
   <template #code>
 
@@ -48,7 +48,7 @@ const dnd = ref(false);
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Custom label markup
 

--- a/docs/src/components/form-tags.md
+++ b/docs/src/components/form-tags.md
@@ -10,7 +10,7 @@ npm install @vuecs/forms
 
 ## Basic usage
 
-<Demo name="form-tags">
+<Playground name="form-tags">
 
   <template #code>
 
@@ -25,7 +25,7 @@ const tags = ref<string[]>(['vue', 'reka', 'tailwind']);
 </script>
 
 <template>
-    <VCFormTags v-model="tags" placeholder="Add a tag…" />
+    <VCFormTags v-model="tags" placeholder="Add a tag…" add-on-paste />
 </template>
 ```
 
@@ -41,7 +41,7 @@ const tags = ref<string[]>(['vue', 'reka', 'tailwind']);
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Props
 

--- a/docs/src/components/form-textarea.md
+++ b/docs/src/components/form-textarea.md
@@ -8,7 +8,7 @@ npm install @vuecs/forms
 
 ## Basic usage
 
-<Demo name="form-textarea">
+<Playground name="form-textarea">
 
   <template #code>
 
@@ -37,7 +37,7 @@ const value = ref('');
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Props
 

--- a/docs/src/components/gravatar.md
+++ b/docs/src/components/gravatar.md
@@ -30,9 +30,9 @@ import { VCGravatar } from '@vuecs/gravatar';
 <template>
     <!-- displaySize drives the rendered chip; size is the URL `?s=` parameter -->
     <!-- (match it to displaySize × 2 for retina-crisp rendering). -->
-    <VCGravatar email="contact@tada5hi.net" display-size="md" :size="80" />
-    <VCGravatar email="hello@example.com" display-size="md" :size="80" />
-    <VCGravatar email="anon@example.com" display-size="md" :size="80" />
+    <VCGravatar email="alice@example.com" display-size="md" :size="80" alt="Alice's avatar" />
+    <VCGravatar email="bob@example.com" display-size="md" :size="80" alt="Bob's avatar" />
+    <VCGravatar email="charlie@example.com" display-size="md" :size="80" alt="Charlie's avatar" />
 </template>
 ```
 

--- a/docs/src/components/gravatar.md
+++ b/docs/src/components/gravatar.md
@@ -30,7 +30,9 @@ import { VCGravatar } from '@vuecs/gravatar';
 <template>
     <!-- displaySize drives the rendered chip; size is the URL `?s=` parameter -->
     <!-- (match it to displaySize × 2 for retina-crisp rendering). -->
-    <VCGravatar email="user@example.com" display-size="md" :size="80" />
+    <VCGravatar email="contact@tada5hi.net" display-size="md" :size="80" />
+    <VCGravatar email="hello@example.com" display-size="md" :size="80" />
+    <VCGravatar email="anon@example.com" display-size="md" :size="80" />
 </template>
 ```
 

--- a/docs/src/components/hover-card.md
+++ b/docs/src/components/hover-card.md
@@ -8,7 +8,7 @@ Floating panel that opens on hover, with a built-in grace area for the cursor tr
 npm install @vuecs/overlays
 ```
 
-<Demo name="hover-card" component="VCHoverCard">
+<Playground name="hover-card" component="VCHoverCard">
   <template #code>
 
 ::: code-group
@@ -26,7 +26,7 @@ import {
 <template>
     <p>
         Built by
-        <VCHoverCard>
+        <VCHoverCard :open-delay="300">
             <VCHoverCardTrigger as="a" href="#">@octocat</VCHoverCardTrigger>
             <VCHoverCardContent :side-offset="8">
                 <p class="font-semibold">@octocat</p>
@@ -50,7 +50,7 @@ import {
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Compound API
 

--- a/docs/src/components/list.md
+++ b/docs/src/components/list.md
@@ -12,7 +12,7 @@ This package is the successor to `@vuecs/list-controls@2.x`. It's a clean break 
 
 ## Basic usage
 
-<Demo name="list">
+<Playground name="list">
   <template #code>
 
 ::: code-group
@@ -70,7 +70,7 @@ function remove(id: number): void {
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Two composition modes
 

--- a/docs/src/components/modal.md
+++ b/docs/src/components/modal.md
@@ -19,7 +19,7 @@ npm install @vuecs/overlays
 | `VCModalDescription` | `DialogDescription` | aria-describedby target. |
 | `VCModalClose` | `DialogClose` | Button that closes. Slotless `<VCModalClose />` renders the corner-X (default `×` glyph + `closeIcon` theme slot). With slot content (e.g. "Cancel") it renders neutrally so consumer classes compose. Pass `icon` to force the corner-X even with custom content. Auto `aria-label="Close"` when slotless. |
 
-<Demo name="modal" component="VCModal">
+<Playground name="modal" component="VCModal">
   <template #code>
 
 ::: code-group
@@ -74,7 +74,7 @@ const open = ref(false);
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ::: tip Two presentations, one component
 `<VCModalClose>` picks between two theme slots based on slot content and the `icon` prop:

--- a/docs/src/components/pagination.md
+++ b/docs/src/components/pagination.md
@@ -8,7 +8,7 @@ npm install @vuecs/pagination
 
 ## Basic usage
 
-<Demo name="pagination">
+<Playground name="pagination">
   <template #code>
 
 ::: code-group
@@ -49,7 +49,7 @@ const load = (next) => {
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Icons
 

--- a/docs/src/components/popover.md
+++ b/docs/src/components/popover.md
@@ -6,7 +6,7 @@ Floating panel anchored to a trigger. Built on [Reka UI](https://reka-ui.com/)'s
 npm install @vuecs/overlays
 ```
 
-<Demo name="popover" component="VCPopover">
+<Playground name="popover" component="VCPopover">
   <template #code>
 
 ::: code-group
@@ -50,7 +50,7 @@ import {
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Compound API
 

--- a/docs/src/components/stepper.md
+++ b/docs/src/components/stepper.md
@@ -8,7 +8,7 @@ The compound parts let you assemble the step item exactly the way your design ne
 npm install @vuecs/navigation
 ```
 
-<Demo name="stepper" component="VCStepper">
+<Playground name="stepper" component="VCStepper">
   <template #code>
 
 ::: code-group
@@ -63,7 +63,7 @@ const steps = [
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Compound API
 

--- a/docs/src/components/tag.md
+++ b/docs/src/components/tag.md
@@ -8,7 +8,7 @@ A removable, value-bound chip and a list helper that renders one chip per item. 
 npm install @vuecs/elements
 ```
 
-<Demo name="tag">
+<Playground name="tag">
   <template #code>
 
 ::: code-group
@@ -46,7 +46,7 @@ function remove(value: string | number | undefined) {
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## `<VCTag>`
 

--- a/docs/src/components/tooltip.md
+++ b/docs/src/components/tooltip.md
@@ -6,7 +6,7 @@ Hover/focus-triggered text bubble. Built on [Reka UI](https://reka-ui.com/)'s To
 npm install @vuecs/overlays
 ```
 
-<Demo name="tooltip" component="VCTooltip">
+<Playground name="tooltip" component="VCTooltip">
   <template #code>
 
 ::: code-group
@@ -48,7 +48,7 @@ import {
 :::
 
   </template>
-</Demo>
+</Playground>
 
 ## Compound API
 

--- a/docs/src/guide/variants.md
+++ b/docs/src/guide/variants.md
@@ -86,6 +86,23 @@ Variant resolution is implemented as two pure functions in `@vuecs/core`:
 
 Same pattern as the theme resolver — zero Vue imports, fully unit-testable.
 
+## Built-in variant axes
+
+Most vuecs components ship with at least one variant axis defined by
+the active theme package. The most common axes:
+
+| Axis | Values | Components |
+|---|---|---|
+| `size` | `sm` / `md` / `lg` (modal also `xl`) | Button, Badge, Tag, Avatar, Pagination, FormInput, FormTextarea, FormSelect, FormNumber, FormCheckbox, FormSwitch, FormRadio, FormTags, Modal, Popover, HoverCard, Tooltip, DropdownMenu, ContextMenu, Navigation, Stepper |
+| `density` | `compact` / `normal` / `spacious` | List, ListItem |
+| `variant` | varies — usually `solid` / `outline` / `soft` / `ghost` (+ `link` on Button) | Button, Badge, Pagination |
+| `color` | `primary` / `neutral` / `success` / `warning` / `error` / `info` | Button, Badge |
+
+You can flip these live in the docs site demos via the toolbar above
+each `<Demo>` block — open the [pagination
+demo](/components/pagination) for a richer example with boolean and
+number controls in addition to the variant axis.
+
 ## See also
 
 - [Theme System](/guide/theme-system) — how variants integrate into the four-layer resolution chain

--- a/docs/src/guide/variants.md
+++ b/docs/src/guide/variants.md
@@ -99,7 +99,7 @@ the active theme package. The most common axes:
 | `color` | `primary` / `neutral` / `success` / `warning` / `error` / `info` | Button, Badge |
 
 You can flip these live in the docs site demos via the toolbar above
-each `<Demo>` block — open the [pagination
+each `<Playground>` block — open the [pagination
 demo](/components/pagination) for a richer example with boolean and
 number controls in addition to the variant axis.
 

--- a/packages/core/test/unit/theme/theme-tailwind.spec.ts
+++ b/packages/core/test/unit/theme/theme-tailwind.spec.ts
@@ -42,10 +42,12 @@ describe('tailwindTheme', () => {
         expect(theme.elements.formInputCheckbox).toBeUndefined();
     });
 
-    it('should define pagination with active state using Tailwind `!` modifier to beat base link classes', () => {
+    it('should define pagination with active state using Tailwind v4 `!` suffix to beat base link classes', () => {
+        // Tailwind v4 deprecated the prefix `!class` form (silently no-ops);
+        // the suffix `class!` form is the only working syntax.
         const entry = theme.elements.pagination as ThemeElementDefinition;
-        expect(entry.classes!.linkActive).toContain('!bg-primary-600');
-        expect(entry.classes!.linkActive).toContain('!text-on-primary');
+        expect(entry.classes!.linkActive).toContain('bg-primary-600!');
+        expect(entry.classes!.linkActive).toContain('text-on-primary!');
     });
 
     it('should reference only semantic color tokens (no raw Tailwind palette names)', () => {

--- a/packages/elements/assets/avatar.css
+++ b/packages/elements/assets/avatar.css
@@ -1,7 +1,7 @@
 /*
  * Structural defaults for VCAvatar. Square 2.5rem circle with overflow
- * clipping so the image and fallback share the same shape. Themes can
- * resize / restyle via the `avatar.root` slot.
+ * clipping so the image and fallback share the same shape — color is
+ * theme territory (see badge.css for the broader rationale).
  */
 .vc-avatar {
     display: inline-flex;
@@ -10,8 +10,6 @@
     overflow: hidden;
     width: 2.5rem;
     height: 2.5rem;
-    background-color: var(--vc-color-bg-muted, #f3f4f6);
-    color: var(--vc-color-fg-muted, #6b7280);
     border-radius: 9999px;
     user-select: none;
     vertical-align: middle;

--- a/packages/elements/assets/avatar.css
+++ b/packages/elements/assets/avatar.css
@@ -2,53 +2,42 @@
  * Structural defaults for VCAvatar. Square 2.5rem circle with overflow
  * clipping so the image and fallback share the same shape. Themes can
  * resize / restyle via the `avatar.root` slot.
- *
- * Wrapped in `@layer components` so Tailwind v4 utility classes (which
- * land in `@layer utilities` — declared after `components` in Tailwind's
- * default order) win when a theme drives `bg-*` / `text-*` / `h-*` /
- * `w-*` per slot. Unlayered structural CSS would otherwise clobber
- * utility classes regardless of source order.
  */
-@layer components {
-    .vc-avatar {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        overflow: hidden;
-        width: 2.5rem;
-        height: 2.5rem;
-        background-color: var(--vc-color-bg-muted, #f3f4f6);
-        color: var(--vc-color-fg-muted, #6b7280);
-        border-radius: 9999px;
-        user-select: none;
-        vertical-align: middle;
-    }
-
-    .vc-avatar-image {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-    }
-
-    .vc-avatar-fallback {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        height: 100%;
-        font-size: 0.875rem;
-        font-weight: 500;
-        line-height: 1;
-    }
-
-    /*
-     * Size variant classes — referenced by the `avatar.size.{sm,md,lg}` theme
-     * variant entries. Themes that have utility-class equivalents (Tailwind:
-     * `h-8 w-8`, `h-10 w-10`, `h-14 w-14`) can stack those instead/alongside;
-     * these structural classes give a working baseline for ecosystems
-     * (Bootstrap, custom CSS) where no equivalent utility exists.
-     */
-    .vc-avatar-sm { width: 2rem; height: 2rem; }
-    .vc-avatar-md { width: 2.5rem; height: 2.5rem; }
-    .vc-avatar-lg { width: 3.5rem; height: 3.5rem; }
+.vc-avatar {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    width: 2.5rem;
+    height: 2.5rem;
+    background-color: var(--vc-color-bg-muted, #f3f4f6);
+    color: var(--vc-color-fg-muted, #6b7280);
+    border-radius: 9999px;
+    user-select: none;
+    vertical-align: middle;
 }
+
+.vc-avatar-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.vc-avatar-fallback {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1;
+}
+
+/*
+ * Size variant classes — referenced by the `avatar.size.{sm,md,lg}` theme
+ * variant entries.
+ */
+.vc-avatar-sm { width: 2rem; height: 2rem; }
+.vc-avatar-md { width: 2.5rem; height: 2.5rem; }
+.vc-avatar-lg { width: 3.5rem; height: 3.5rem; }

--- a/packages/elements/assets/badge.css
+++ b/packages/elements/assets/badge.css
@@ -1,26 +1,21 @@
 /*
- * Structural defaults for VCBadge. Tiny inline pill — visual treatment
- * (color, variant, size) comes from theme entries via the variant
- * system. Without a theme, every badge looks identical to give
- * consumers a "something rendered" baseline.
+ * Structural defaults for VCBadge. Tiny inline pill — shape only.
  *
- * Wrapped in `@layer components` so Tailwind v4 utility classes (which
- * land in `@layer utilities` — declared after `components` in Tailwind's
- * default order) win when a theme drives `bg-*` / `text-*` per variant.
- * Unlayered structural CSS would otherwise clobber utility classes
- * regardless of source order.
+ * Color (background, foreground, border) is theme territory: every shipped
+ * theme drives the full color × variant matrix via `compoundVariants`.
+ * Keeping color out of structural avoids the unlayered-vs-utility cascade
+ * fight that would otherwise pin every badge to one neutral baseline.
+ *
+ * Un-themed `<VCBadge>` renders as a transparent pill with inherited text
+ * color — a pure shape primitive.
  */
-@layer components {
-    .vc-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.25rem;
-        padding: 0.125rem 0.5rem;
-        font-size: 0.75rem;
-        font-weight: 500;
-        line-height: 1.25;
-        color: var(--vc-color-fg, #111827);
-        background-color: var(--vc-color-bg-muted, #f3f4f6);
-        border-radius: 9999px;
-    }
+.vc-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    line-height: 1.25;
+    border-radius: 9999px;
 }

--- a/packages/elements/assets/tag.css
+++ b/packages/elements/assets/tag.css
@@ -1,61 +1,55 @@
 /*
- * Structural defaults for VCTag and VCTags. Both ship a baseline
- * pill look so consumers see something usable without a theme — themes
- * layer on top via the `tag` / `tags` keys.
+ * Structural defaults for VCTag and VCTags. Shape only — color is theme
+ * territory. See badge.css for the rationale (themes drive color via
+ * variants; keeping it out of structural avoids cascade conflicts).
  *
- * Wrapped in `@layer components` so Tailwind v4 utility classes (which
- * land in `@layer utilities` — declared after `components` in Tailwind's
- * default order) win when a theme drives `bg-*` / `text-*` per slot.
- * Unlayered structural CSS would otherwise clobber utility classes
- * regardless of source order.
+ * Un-themed `<VCTag>` renders as a transparent pill with inherited text
+ * color. The remove button keeps a hover background so it remains
+ * discoverable on hover regardless of theme color choices.
  */
-@layer components {
-    .vc-tag {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.25rem;
-        padding: 0.125rem 0.5rem;
-        font-size: 0.75rem;
-        line-height: 1.25;
-        color: var(--vc-color-on-primary, #fff);
-        background-color: var(--vc-color-primary-600, #2563eb);
-        border-radius: 9999px;
-    }
+.vc-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1.25;
+    border-radius: 9999px;
+}
 
-    .vc-tag-icon {
-        display: inline-flex;
-        align-items: center;
-    }
+.vc-tag-icon {
+    display: inline-flex;
+    align-items: center;
+}
 
-    .vc-tag-remove {
-        appearance: none;
-        -webkit-appearance: none;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        /* Sized in `em` (not `rem`) so the button tracks the badge's
-           font-size and stays the same height as the surrounding text.
-           A fixed `1rem` was 16px regardless of theme — taller than
-           Bootstrap's 0.75em (~12px) badge text, which stretched the
-           row and made removable tags taller than non-removable ones. */
-        width: 1em;
-        height: 1em;
-        padding: 0;
-        color: inherit;
-        background-color: transparent;
-        border: 0;
-        border-radius: 9999px;
-        cursor: pointer;
-        line-height: 1;
-    }
+.vc-tag-remove {
+    appearance: none;
+    -webkit-appearance: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    /* Sized in `em` (not `rem`) so the button tracks the badge's
+       font-size and stays the same height as the surrounding text.
+       A fixed `1rem` was 16px regardless of theme — taller than
+       Bootstrap's 0.75em (~12px) badge text, which stretched the
+       row and made removable tags taller than non-removable ones. */
+    width: 1em;
+    height: 1em;
+    padding: 0;
+    color: inherit;
+    background-color: transparent;
+    border: 0;
+    border-radius: 9999px;
+    cursor: pointer;
+    line-height: 1;
+}
 
-    .vc-tag-remove:hover {
-        background-color: rgba(0, 0, 0, 0.15);
-    }
+.vc-tag-remove:hover {
+    background-color: rgba(0, 0, 0, 0.15);
+}
 
-    .vc-tags {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.375rem;
-    }
+.vc-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
 }

--- a/packages/elements/assets/tag.css
+++ b/packages/elements/assets/tag.css
@@ -45,7 +45,9 @@
 }
 
 .vc-tag-remove:hover {
-    background-color: rgba(0, 0, 0, 0.15);
+    /* Derive the tint from `currentColor` so dark / semantic tag themes
+       (where text isn't black) keep a sensible hover affordance. */
+    background-color: color-mix(in srgb, currentColor 15%, transparent);
 }
 
 .vc-tags {

--- a/packages/forms/assets/form-checkbox.css
+++ b/packages/forms/assets/form-checkbox.css
@@ -4,6 +4,14 @@
  * Reka renders a real <button role="checkbox"> with `data-state="checked|unchecked|indeterminate"`.
  * The indicator is a child element only present (or visible) while checked/indeterminate.
  * Colors reference @vuecs/design tokens with hex fallbacks.
+ *
+ * Unlayered: Bootstrap's reboot resets `button { border-radius: 0 }` (and
+ * other button defaults) — putting our structural CSS in `@layer components`
+ * would lose to that unlayered reboot rule, breaking the box shape. Themes
+ * that need to override sizing (Tailwind: per-size variants) use the
+ * `vc-form-checkbox-{sm,lg}` structural helpers below instead of utility
+ * classes like `h-3 w-3` (which sit in `@layer utilities` and lose to
+ * unlayered structural CSS).
  */
 .vc-form-checkbox-wrapper {
     display: inline-flex;
@@ -60,6 +68,19 @@
 .vc-form-checkbox:disabled {
     cursor: not-allowed;
     opacity: 0.5;
+}
+
+/* Size helpers — themes drive these via `formCheckbox.variants.size.{sm,lg}`.
+   Tailwind v4 utilities (`h-3 w-3`) sit in `@layer utilities` and lose to
+   unlayered structural CSS, so we ship dedicated structural helpers and
+   reference them from both Tailwind and Bootstrap theme entries. */
+.vc-form-checkbox-sm {
+    width: 0.75rem;
+    height: 0.75rem;
+}
+.vc-form-checkbox-lg {
+    width: 1.25rem;
+    height: 1.25rem;
 }
 
 /* Indicator — Reka mounts this when state ≠ unchecked. We supply a default

--- a/packages/forms/assets/form-checkbox.css
+++ b/packages/forms/assets/form-checkbox.css
@@ -78,9 +78,17 @@
     width: 0.75rem;
     height: 0.75rem;
 }
+.vc-form-checkbox-sm .vc-form-checkbox-indicator::before {
+    width: 0.5rem;
+    height: 0.5rem;
+}
 .vc-form-checkbox-lg {
     width: 1.25rem;
     height: 1.25rem;
+}
+.vc-form-checkbox-lg .vc-form-checkbox-indicator::before {
+    width: 0.875rem;
+    height: 0.875rem;
 }
 
 /* Indicator — Reka mounts this when state ≠ unchecked. We supply a default

--- a/packages/forms/assets/form-radio.css
+++ b/packages/forms/assets/form-radio.css
@@ -9,6 +9,9 @@
  *   .vc-form-radio-group   → outer container of multiple radios (column)
  *   .vc-form-radio-wrapper → per-single-radio inline wrapper around
  *                            the radio button + its label
+ *
+ * Unlayered: see form-checkbox.css for rationale (Bootstrap reboot resets
+ * `button { border-radius: 0 }`). Size variants drive `vc-form-radio-{sm,lg}`.
  */
 .vc-form-radio-group {
     display: flex;
@@ -95,3 +98,20 @@
     transform: translate(-50%, -50%);
 }
 
+/* Size helpers — themes drive these via `formRadio.variants.size.{sm,lg}`. */
+.vc-form-radio-sm {
+    width: 0.75rem;
+    height: 0.75rem;
+}
+.vc-form-radio-sm .vc-form-radio-indicator {
+    width: 0.375rem;
+    height: 0.375rem;
+}
+.vc-form-radio-lg {
+    width: 1.25rem;
+    height: 1.25rem;
+}
+.vc-form-radio-lg .vc-form-radio-indicator {
+    width: 0.625rem;
+    height: 0.625rem;
+}

--- a/packages/forms/assets/form-select.css
+++ b/packages/forms/assets/form-select.css
@@ -7,6 +7,10 @@
  * target any of these via attribute selectors. Structural CSS below keeps the
  * widget visible and usable out-of-the-box; theme packages add color / hover
  * polish on top.
+ *
+ * Unlayered: see form-checkbox.css for rationale (Bootstrap reboot resets
+ * `button { border-radius: 0 }`). Size variants are driven via the
+ * `vc-form-select-trigger-{sm,lg}` structural helpers below.
  */
 .vc-form-select-trigger {
     display: inline-flex;
@@ -126,4 +130,19 @@
     height: 1px;
     margin: 0.25rem 0;
     background-color: var(--vc-color-border, #d1d5db);
+}
+
+/* Size helpers — themes drive these via `formSelect.variants.size.{sm,lg}`.
+   Bootstrap's `form-control-{sm,lg}` and Tailwind's per-size utilities both
+   sit in CSS layers we'd lose to (Bootstrap unlayered for some rules, Tailwind
+   utilities for others), so we ship dedicated structural helpers. */
+.vc-form-select-trigger-sm {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    line-height: 1rem;
+}
+.vc-form-select-trigger-lg {
+    padding: 0.5rem 0.875rem;
+    font-size: 1rem;
+    line-height: 1.5rem;
 }

--- a/packages/forms/assets/form-switch.css
+++ b/packages/forms/assets/form-switch.css
@@ -3,6 +3,10 @@
  *
  * Reka renders a real <button role="switch"> with `data-state="checked|unchecked"`.
  * The thumb slides via translate; transitions are kept short to feel snappy.
+ *
+ * Unlayered: see form-checkbox.css for rationale (Bootstrap reboot
+ * resets `button { border-radius: 0 }`). Size variants are driven via
+ * the `vc-form-switch-{sm,lg}` structural helpers below.
  */
 .vc-form-switch-wrapper {
     display: inline-flex;
@@ -75,4 +79,30 @@
 
 .vc-form-switch[data-state="checked"] .vc-form-switch-thumb {
     translate: 1rem 0;
+}
+
+/* Size helpers — themes drive these via `formSwitch.variants.size.{sm,lg}`.
+   Track and thumb scale together; the `[data-state="checked"]` translate
+   distance matches the new track width minus thumb. */
+.vc-form-switch-sm {
+    width: 1.75rem;
+    height: 1rem;
+}
+.vc-form-switch-sm .vc-form-switch-thumb {
+    width: 0.625rem;
+    height: 0.625rem;
+}
+.vc-form-switch-sm[data-state="checked"] .vc-form-switch-thumb {
+    translate: 0.75rem 0;
+}
+.vc-form-switch-lg {
+    width: 2.75rem;
+    height: 1.5rem;
+}
+.vc-form-switch-lg .vc-form-switch-thumb {
+    width: 1.125rem;
+    height: 1.125rem;
+}
+.vc-form-switch-lg[data-state="checked"] .vc-form-switch-thumb {
+    translate: 1.25rem 0;
 }

--- a/packages/forms/src/components/form-select-search/FormSelectSearch.vue
+++ b/packages/forms/src/components/form-select-search/FormSelectSearch.vue
@@ -205,8 +205,14 @@ export default defineComponent({
         // return the same number of matches but different items, and the
         // length-only watcher would miss the content swap, leaving the
         // dropdown showing the previous query's results.
+        //
+        // Reset currentIndex to -1 (no item highlighted) instead of 0 — the
+        // visual "current" highlight should only appear after the user
+        // explicitly arrow-keys. The Enter handler still falls back to the
+        // first item when nothing is highlighted (see selected.length === 0
+        // branch), so keyboard-first selection still works.
         watch(items, () => {
-            currentIndex.value = 0;
+            currentIndex.value = -1;
             setItemsDisplayed();
         });
 
@@ -422,7 +428,7 @@ export default defineComponent({
                                 theme.item,
                                 {
                                     [theme.itemActive]: active,
-                                    [theme.itemCurrent]: index === currentIndex || (index === 0 && currentIndex === -1),
+                                    [theme.itemCurrent]: index === currentIndex,
                                 },
                             ]"
                             @mousedown="toggle(entry)"

--- a/packages/navigation/assets/index.css
+++ b/packages/navigation/assets/index.css
@@ -83,6 +83,10 @@
     opacity: 0.6;
 }
 
+/* Indicator owns shape only — color (border, background, text) is theme
+   territory because each step's `data-state` (active/completed/inactive)
+   demands a different color. Themes drive that via `group-data-[state=…]:`
+   utility variants (Tailwind) or attribute selectors (Bootstrap). */
 .vc-stepper-indicator {
     display: inline-flex;
     align-items: center;
@@ -90,9 +94,6 @@
     width: 2rem;
     height: 2rem;
     border-radius: 9999px;
-    border: 1px solid var(--vc-color-border, #e5e7eb);
-    background-color: var(--vc-color-bg, #fff);
-    color: var(--vc-color-fg-muted, #6b7280);
     font-weight: 600;
     font-size: 0.875rem;
     line-height: 1;
@@ -101,10 +102,21 @@
 .vc-stepper-separator {
     flex: 1 1 auto;
     height: 1px;
-    background-color: var(--vc-color-border, #e5e7eb);
 }
 
 .vc-stepper[data-orientation="vertical"] .vc-stepper-separator {
     width: 1px;
     height: 2rem;
+}
+
+/* Size helpers — themes drive these via `stepper.variants.size.{sm,lg}`. */
+.vc-stepper-indicator-sm {
+    width: 1.5rem;
+    height: 1.5rem;
+    font-size: 0.75rem;
+}
+.vc-stepper-indicator-lg {
+    width: 2.5rem;
+    height: 2.5rem;
+    font-size: 1rem;
 }

--- a/packages/navigation/src/components/stepper/Stepper.vue
+++ b/packages/navigation/src/components/stepper/Stepper.vue
@@ -4,6 +4,7 @@ import type { ExtractPublicPropTypes, PropType } from 'vue';
 import { StepperRoot } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
+import { provideStepperContext } from './context';
 import { stepperThemeDefaults } from './theme';
 import type { StepperThemeClasses } from './types';
 
@@ -36,6 +37,16 @@ export default defineComponent({
         slots,
         emit,
     }) {
+        // Propagate theme-class + theme-variant to descendant indicator /
+        // title / description / separator / item / trigger parts so a single
+        // `<VCStepper :theme-variant="{ size: 'sm' }">` resizes the whole
+        // stepper, and `:theme-class="{ indicator: 'ring-2' }">` skins every
+        // indicator. Children fall back to their own per-instance values
+        // when the consumer wants to override them.
+        provideStepperContext({
+            themeClass: () => props.themeClass,
+            themeVariant: () => props.themeVariant,
+        });
         const theme = useComponentTheme('stepper', props, stepperThemeDefaults);
         return () => h(
             StepperRoot,

--- a/packages/navigation/src/components/stepper/StepperDescription.vue
+++ b/packages/navigation/src/components/stepper/StepperDescription.vue
@@ -3,7 +3,8 @@ import { defineComponent, h, mergeProps } from 'vue';
 import type { ExtractPublicPropTypes, PropType } from 'vue';
 import { StepperDescription } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
-import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
+import type { ThemeClassesOverride, UseComponentThemeProps, VariantValues } from '@vuecs/core';
+import { useStepperContext } from './context';
 import { stepperThemeDefaults } from './theme';
 import type { StepperThemeClasses } from './types';
 
@@ -25,7 +26,14 @@ export default defineComponent({
     inheritAttrs: false,
     props: stepperDescriptionProps,
     setup(props, { attrs, slots }) {
-        const theme = useComponentTheme('stepper', props, stepperThemeDefaults);
+        const ctx = useStepperContext();
+        const themeProps: UseComponentThemeProps<StepperThemeClasses> = {
+            get themeClass() { return { ...(ctx?.themeClass() ?? {}), ...(props.themeClass ?? {}) }; },
+            get themeVariant() {
+                return { ...(ctx?.themeVariant() ?? {}), ...(props.themeVariant ?? {}) };
+            },
+        };
+        const theme = useComponentTheme('stepper', themeProps, stepperThemeDefaults);
         return () => h(
             StepperDescription,
             mergeProps(attrs, {

--- a/packages/navigation/src/components/stepper/StepperIndicator.vue
+++ b/packages/navigation/src/components/stepper/StepperIndicator.vue
@@ -3,7 +3,8 @@ import { defineComponent, h, mergeProps } from 'vue';
 import type { ExtractPublicPropTypes, PropType } from 'vue';
 import { StepperIndicator } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
-import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
+import type { ThemeClassesOverride, UseComponentThemeProps, VariantValues } from '@vuecs/core';
+import { useStepperContext } from './context';
 import { stepperThemeDefaults } from './theme';
 import type { StepperThemeClasses } from './types';
 
@@ -25,7 +26,17 @@ export default defineComponent({
     inheritAttrs: false,
     props: stepperIndicatorProps,
     setup(props, { attrs, slots }) {
-        const theme = useComponentTheme('stepper', props, stepperThemeDefaults);
+        // Inherit theme-variant (notably `size`) from the parent <VCStepper>
+        // so the consumer doesn't have to repeat `:theme-variant` on every
+        // indicator. Per-instance `props.themeVariant` still wins.
+        const ctx = useStepperContext();
+        const themeProps: UseComponentThemeProps<StepperThemeClasses> = {
+            get themeClass() { return { ...(ctx?.themeClass() ?? {}), ...(props.themeClass ?? {}) }; },
+            get themeVariant() {
+                return { ...(ctx?.themeVariant() ?? {}), ...(props.themeVariant ?? {}) };
+            },
+        };
+        const theme = useComponentTheme('stepper', themeProps, stepperThemeDefaults);
         return () => h(
             StepperIndicator,
             mergeProps(attrs, {

--- a/packages/navigation/src/components/stepper/StepperItem.vue
+++ b/packages/navigation/src/components/stepper/StepperItem.vue
@@ -3,7 +3,8 @@ import { defineComponent, h, mergeProps } from 'vue';
 import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
 import { StepperItem } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
-import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
+import type { ThemeClassesOverride, UseComponentThemeProps, VariantValues } from '@vuecs/core';
+import { useStepperContext } from './context';
 import { stepperThemeDefaults } from './theme';
 import type { StepperThemeClasses } from './types';
 
@@ -34,7 +35,14 @@ export default defineComponent({
         default: StepperItemSlotProps;
     }>,
     setup(props, { attrs, slots }) {
-        const theme = useComponentTheme('stepper', props, stepperThemeDefaults);
+        const ctx = useStepperContext();
+        const themeProps: UseComponentThemeProps<StepperThemeClasses> = {
+            get themeClass() { return { ...(ctx?.themeClass() ?? {}), ...(props.themeClass ?? {}) }; },
+            get themeVariant() {
+                return { ...(ctx?.themeVariant() ?? {}), ...(props.themeVariant ?? {}) };
+            },
+        };
+        const theme = useComponentTheme('stepper', themeProps, stepperThemeDefaults);
         return () => h(
             StepperItem,
             // `step` is required on StepperItem; vue-tsc loses that

--- a/packages/navigation/src/components/stepper/StepperSeparator.vue
+++ b/packages/navigation/src/components/stepper/StepperSeparator.vue
@@ -3,7 +3,8 @@ import { defineComponent, h, mergeProps } from 'vue';
 import type { ExtractPublicPropTypes, PropType } from 'vue';
 import { StepperSeparator } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
-import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
+import type { ThemeClassesOverride, UseComponentThemeProps, VariantValues } from '@vuecs/core';
+import { useStepperContext } from './context';
 import { stepperThemeDefaults } from './theme';
 import type { StepperThemeClasses } from './types';
 
@@ -25,7 +26,14 @@ export default defineComponent({
     inheritAttrs: false,
     props: stepperSeparatorProps,
     setup(props, { attrs, slots }) {
-        const theme = useComponentTheme('stepper', props, stepperThemeDefaults);
+        const ctx = useStepperContext();
+        const themeProps: UseComponentThemeProps<StepperThemeClasses> = {
+            get themeClass() { return { ...(ctx?.themeClass() ?? {}), ...(props.themeClass ?? {}) }; },
+            get themeVariant() {
+                return { ...(ctx?.themeVariant() ?? {}), ...(props.themeVariant ?? {}) };
+            },
+        };
+        const theme = useComponentTheme('stepper', themeProps, stepperThemeDefaults);
         return () => h(
             StepperSeparator,
             mergeProps(attrs, {

--- a/packages/navigation/src/components/stepper/StepperTitle.vue
+++ b/packages/navigation/src/components/stepper/StepperTitle.vue
@@ -3,7 +3,8 @@ import { defineComponent, h, mergeProps } from 'vue';
 import type { ExtractPublicPropTypes, PropType } from 'vue';
 import { StepperTitle } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
-import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
+import type { ThemeClassesOverride, UseComponentThemeProps, VariantValues } from '@vuecs/core';
+import { useStepperContext } from './context';
 import { stepperThemeDefaults } from './theme';
 import type { StepperThemeClasses } from './types';
 
@@ -25,7 +26,14 @@ export default defineComponent({
     inheritAttrs: false,
     props: stepperTitleProps,
     setup(props, { attrs, slots }) {
-        const theme = useComponentTheme('stepper', props, stepperThemeDefaults);
+        const ctx = useStepperContext();
+        const themeProps: UseComponentThemeProps<StepperThemeClasses> = {
+            get themeClass() { return { ...(ctx?.themeClass() ?? {}), ...(props.themeClass ?? {}) }; },
+            get themeVariant() {
+                return { ...(ctx?.themeVariant() ?? {}), ...(props.themeVariant ?? {}) };
+            },
+        };
+        const theme = useComponentTheme('stepper', themeProps, stepperThemeDefaults);
         return () => h(
             StepperTitle,
             mergeProps(attrs, {

--- a/packages/navigation/src/components/stepper/StepperTrigger.vue
+++ b/packages/navigation/src/components/stepper/StepperTrigger.vue
@@ -3,7 +3,8 @@ import { defineComponent, h, mergeProps } from 'vue';
 import type { ExtractPublicPropTypes, PropType } from 'vue';
 import { StepperTrigger } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
-import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
+import type { ThemeClassesOverride, UseComponentThemeProps, VariantValues } from '@vuecs/core';
+import { useStepperContext } from './context';
 import { stepperThemeDefaults } from './theme';
 import type { StepperThemeClasses } from './types';
 
@@ -25,7 +26,14 @@ export default defineComponent({
     inheritAttrs: false,
     props: stepperTriggerProps,
     setup(props, { attrs, slots }) {
-        const theme = useComponentTheme('stepper', props, stepperThemeDefaults);
+        const ctx = useStepperContext();
+        const themeProps: UseComponentThemeProps<StepperThemeClasses> = {
+            get themeClass() { return { ...(ctx?.themeClass() ?? {}), ...(props.themeClass ?? {}) }; },
+            get themeVariant() {
+                return { ...(ctx?.themeVariant() ?? {}), ...(props.themeVariant ?? {}) };
+            },
+        };
+        const theme = useComponentTheme('stepper', themeProps, stepperThemeDefaults);
         return () => h(
             StepperTrigger,
             mergeProps(

--- a/packages/navigation/src/components/stepper/context.ts
+++ b/packages/navigation/src/components/stepper/context.ts
@@ -1,0 +1,29 @@
+import type { InjectionKey } from 'vue';
+import { inject, provide } from 'vue';
+import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
+import type { StepperThemeClasses } from './types';
+
+/**
+ * Context shared from `<VCStepper>` to its descendant parts so that
+ * theme-class and theme-variant values applied to the root propagate
+ * automatically to indicator / title / description / separator / item /
+ * trigger without the consumer having to repeat the props on every
+ * child. Per-instance values on a child still win over inherited ones.
+ *
+ * Optional — children render bare (without inherited theme values) when
+ * mounted outside `<VCStepper>` for unit tests / Storybook.
+ */
+export type StepperContext = {
+    themeClass: () => ThemeClassesOverride<StepperThemeClasses> | undefined;
+    themeVariant: () => VariantValues | undefined;
+};
+
+const STEPPER_CONTEXT_KEY: InjectionKey<StepperContext> = Symbol('vcStepperContext');
+
+export function provideStepperContext(ctx: StepperContext): void {
+    provide(STEPPER_CONTEXT_KEY, ctx);
+}
+
+export function useStepperContext(): StepperContext | null {
+    return inject(STEPPER_CONTEXT_KEY, null);
+}

--- a/packages/navigation/src/components/stepper/index.ts
+++ b/packages/navigation/src/components/stepper/index.ts
@@ -6,6 +6,9 @@ export { default as VCStepperTitle } from './StepperTitle.vue';
 export { default as VCStepperDescription } from './StepperDescription.vue';
 export { default as VCStepperSeparator } from './StepperSeparator.vue';
 
+export { provideStepperContext, useStepperContext } from './context';
+export type { StepperContext } from './context';
+
 export type { StepperProps } from './Stepper.vue';
 export type { StepperItemProps, StepperItemSlotProps } from './StepperItem.vue';
 export type { StepperTriggerProps } from './StepperTrigger.vue';

--- a/packages/pagination/assets/index.css
+++ b/packages/pagination/assets/index.css
@@ -2,6 +2,12 @@
  * Structural defaults for VCPagination. Colors and typography live in the
  * theme; this file only handles the geometry (list reset, button grouping,
  * shared borders, shared corner radii).
+ *
+ * Unlayered: themes that apply `rounded-md` (or equivalent) to every
+ * link via the variant class string would otherwise beat layered
+ * radius-zero rules and re-round the inner corners. Keeping the whole
+ * file unlayered preserves the joined-pill identity regardless of theme
+ * source order.
  */
 .vc-pagination {
     display: flex;

--- a/themes/bootstrap/assets/index.css
+++ b/themes/bootstrap/assets/index.css
@@ -380,3 +380,35 @@
 .vc-list-footer:empty {
     display: none;
 }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * @vuecs/navigation Stepper — Bootstrap utility classes can't carry
+ * `[data-state=…]` attribute selectors, so the theme entry's `bg-light`
+ * / `border-secondary-subtle` / `text-muted` apply uniformly. Add CSS
+ * here to differentiate active + completed steps. Both states use the
+ * primary color so the trail of progress reads as one continuous run
+ * (matches the Tailwind theme).
+ *
+ * `!important` is required because Bootstrap's `.bg-*` / `.border-*` /
+ * `.text-*` utility classes ship with `!important` themselves — without
+ * matching that, the higher-specificity attribute selector still loses
+ * to the `!important` on the utility.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.vc-stepper-item[data-state="active"] .vc-stepper-indicator,
+.vc-stepper-item[data-state="completed"] .vc-stepper-indicator {
+    background-color: var(--vc-color-primary-600) !important;
+    border-color: var(--vc-color-primary-600) !important;
+    color: var(--vc-color-on-primary) !important;
+}
+
+.vc-stepper-item[data-state="active"] .vc-stepper-title,
+.vc-stepper-item[data-state="completed"] .vc-stepper-title {
+    color: var(--vc-color-fg) !important;
+}
+
+/* Bootstrap renders the separator via `border-top` (1px-tall element +
+   border-top edge), so colorize via `border-top-color` not `background`. */
+.vc-stepper-separator[data-state="completed"] {
+    border-top-color: var(--vc-color-primary-600) !important;
+}

--- a/themes/bootstrap/assets/index.css
+++ b/themes/bootstrap/assets/index.css
@@ -382,6 +382,22 @@
 }
 
 /* ────────────────────────────────────────────────────────────────────────────
+ * @vuecs/overlays Modal — Bootstrap's `.modal-sm` / `.modal-lg` /
+ * `.modal-xl` sizing relies on a `.modal-dialog` wrapper to read
+ * `--bs-modal-width` and apply `max-width`. Reka's DialogContent renders
+ * a single positioned element (no `.modal-dialog`), so applying the size
+ * class on `.modal-content` was previously a no-op. Re-implement the
+ * width contract here so the Bootstrap theme's size variants take
+ * effect on our compound shape. Defaults match Bootstrap 5 (sm=300,
+ * lg=800, xl=1140); md keeps the unsized default which centers via
+ * the theme's `position-fixed top-50 start-50 translate-middle`.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.vc-modal-content.modal-sm { max-width: 300px; width: calc(100% - 1rem); }
+.vc-modal-content.modal-lg { max-width: 800px; width: calc(100% - 1rem); }
+.vc-modal-content.modal-xl { max-width: 1140px; width: calc(100% - 1rem); }
+
+/* ────────────────────────────────────────────────────────────────────────────
  * @vuecs/navigation Stepper — Bootstrap utility classes can't carry
  * `[data-state=…]` attribute selectors, so the theme entry's `bg-light`
  * / `border-secondary-subtle` / `text-muted` apply uniformly. Add CSS

--- a/themes/bootstrap/src/index.ts
+++ b/themes/bootstrap/src/index.ts
@@ -18,6 +18,17 @@ export default function bootstrapTheme(): Theme {
                     groupAppend: 'input-group-text',
                     groupPrepend: 'input-group-text',
                 },
+                // Bootstrap's `.form-control-{sm,lg}` modifies padding +
+                // font-size on top of `.form-control`. There's no `-md`
+                // class — md IS the default.
+                variants: {
+                    size: {
+                        sm: { root: 'form-control-sm', group: 'input-group-sm' },
+                        md: { root: '' },
+                        lg: { root: 'form-control-lg', group: 'input-group-lg' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             // Reka renders the checkbox / radio / switch as `<button role="…">`,
             // not native `<input type="…">`. Bootstrap's `.form-check-input`
@@ -36,6 +47,17 @@ export default function bootstrapTheme(): Theme {
                     label: 'form-check-label',
                     group: '',
                 },
+                // Bootstrap doesn't ship sm/lg form-check sizes, so fall
+                // back to the structural CSS `vc-form-checkbox-{sm,lg}`
+                // helpers (defined in @vuecs/forms styles).
+                variants: {
+                    size: {
+                        sm: { root: 'vc-form-checkbox-sm', label: 'small' },
+                        md: { root: '' },
+                        lg: { root: 'vc-form-checkbox-lg', label: 'fs-5' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             formCheckboxGroup: { classes: { root: 'd-flex flex-column gap-2' } },
             formSwitch: {
@@ -45,6 +67,14 @@ export default function bootstrapTheme(): Theme {
                     label: 'form-check-label',
                     group: '',
                 },
+                variants: {
+                    size: {
+                        sm: { root: 'vc-form-switch-sm', label: 'small' },
+                        md: { root: '' },
+                        lg: { root: 'vc-form-switch-lg', label: 'fs-5' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             formSelect: {
                 classes: {
@@ -63,6 +93,14 @@ export default function bootstrapTheme(): Theme {
                     groupLabel: 'dropdown-header',
                     separator: 'dropdown-divider',
                 },
+                variants: {
+                    size: {
+                        sm: { trigger: 'form-control-sm' },
+                        md: { trigger: '' },
+                        lg: { trigger: 'form-control-lg' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             formSelectSearch: {
                 classes: {
@@ -89,6 +127,14 @@ export default function bootstrapTheme(): Theme {
                     label: 'form-check-label',
                     group: '',
                 },
+                variants: {
+                    size: {
+                        sm: { root: 'vc-form-radio-sm', label: 'small' },
+                        md: { root: '' },
+                        lg: { root: 'vc-form-radio-lg', label: 'fs-5' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             formRadioGroup: { classes: { root: 'd-flex flex-column gap-2' } },
             // PinInputInput DOES render a real <input>, so `.form-control`
@@ -123,6 +169,24 @@ export default function bootstrapTheme(): Theme {
                     decrement: 'btn btn-outline-secondary',
                     increment: 'btn btn-outline-secondary',
                 },
+                variants: {
+                    size: {
+                        sm: {
+                            root: 'input-group-sm', 
+                            input: 'form-control-sm', 
+                            decrement: 'btn-sm', 
+                            increment: 'btn-sm', 
+                        },
+                        md: { root: '' },
+                        lg: {
+                            root: 'input-group-lg', 
+                            input: 'form-control-lg', 
+                            decrement: 'btn-lg', 
+                            increment: 'btn-lg', 
+                        },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             formTags: {
                 classes: {
@@ -136,6 +200,14 @@ export default function bootstrapTheme(): Theme {
                     itemDelete: 'd-inline-flex align-items-center justify-content-center bg-transparent border-0 text-white p-0 ms-1 lh-1',
                     input: 'form-control border-0 flex-grow-1 p-0 shadow-none',
                 },
+                variants: {
+                    size: {
+                        sm: { root: 'form-control-sm p-1', item: 'small' },
+                        md: { root: '' },
+                        lg: { root: 'form-control-lg p-3', item: 'fs-6' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             button: {
                 // `.btn` is `display: inline-block` by default — gives the
@@ -202,24 +274,62 @@ export default function bootstrapTheme(): Theme {
                     size: 'md', 
                 },
             },
-            formTextarea: { classes: { root: 'form-control' } },
-            list: { classes: { root: 'd-flex flex-column gap-1' } },
+            formTextarea: {
+                classes: { root: 'form-control' },
+                variants: {
+                    size: {
+                        sm: { root: 'form-control-sm' },
+                        md: { root: '' },
+                        lg: { root: 'form-control-lg' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            list: {
+                classes: { root: 'd-flex flex-column gap-1' },
+                variants: {
+                    density: {
+                        compact: { root: 'gap-0' },
+                        normal: { root: '' },
+                        spacious: { root: 'gap-3' },
+                    },
+                },
+                defaultVariants: { density: 'normal' },
+            },
             listHeader: { classes: { root: 'd-flex align-items-center' } },
             listBody: { classes: { root: 'list-unstyled m-0' } },
             // `<VCListItem>` owns the row's flex layout. `<VCListItemText>`
             // takes `flex-grow-1` so it consumes available space and pushes
             // any trailing `<VCListItemActions>` clusters to the right edge.
-            listItem: { classes: { root: 'd-flex flex-row align-items-center gap-1' } },
+            listItem: {
+                classes: { root: 'd-flex flex-row align-items-center gap-1' },
+                variants: {
+                    density: {
+                        compact: { root: 'py-0' },
+                        normal: { root: 'py-1' },
+                        spacious: { root: 'py-3' },
+                    },
+                },
+                defaultVariants: { density: 'normal' },
+            },
             listItemText: { classes: { root: 'd-inline-flex flex-column flex-grow-1 text-truncate' } },
             listItemActions: { classes: { root: 'd-inline-flex align-items-center gap-1' } },
             listFooter: { classes: { root: 'd-flex align-items-center' } },
             listLoading: { classes: { root: 'py-2 text-center text-muted small' } },
-            listEmpty: { classes: { root: 'alert alert-warning alert-sm' } },
+            listEmpty: { classes: { root: 'alert alert-warning small p-2' } },
             navigation: {
                 classes: {
                     group: 'nav-items',
                     link: 'nav-link',
                 },
+                variants: {
+                    size: {
+                        sm: { link: 'small py-1 px-2' },
+                        md: { link: '' },
+                        lg: { link: 'fs-6 py-3 px-4' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             // Reka encodes orientation as `data-orientation`; Bootstrap has
             // `<hr>` styling for horizontal but no built-in vertical rule —
@@ -244,7 +354,7 @@ export default function bootstrapTheme(): Theme {
                 },
                 variants: {
                     size: {
-                        sm: { root: 'fs-7 px-2 py-1' },
+                        sm: { root: 'small px-2 py-1' },
                         md: { root: '' },
                         lg: { root: 'fs-6 px-3 py-2' },
                     },
@@ -256,6 +366,14 @@ export default function bootstrapTheme(): Theme {
                     root: 'd-flex flex-wrap align-items-center gap-2',
                     item: '',
                 },
+                variants: {
+                    size: {
+                        sm: { root: 'gap-1' },
+                        md: { root: '' },
+                        lg: { root: 'gap-3' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             avatar: {
                 classes: {
@@ -263,13 +381,14 @@ export default function bootstrapTheme(): Theme {
                     image: 'w-100 h-100 object-fit-cover',
                     fallback: 'd-inline-flex align-items-center justify-content-center w-100 h-100 fw-medium small lh-1',
                 },
-                // Bootstrap doesn't ship h-8/h-10/h-14 utilities, so the
-                // size variants reference the structural `vc-avatar-{sm,md,lg}`
-                // classes shipped in @vuecs/elements/assets/avatar.css.
+                // Bootstrap doesn't ship h-8/h-10/h-14 utilities. `md` is
+                // the no-op default — the structural `.vc-avatar` rule
+                // already sets the medium size. `vc-avatar-{sm,lg}` are
+                // shipped in @vuecs/elements/assets/avatar.css.
                 variants: {
                     size: {
                         sm: { root: 'vc-avatar-sm' },
-                        md: { root: 'vc-avatar-md' },
+                        md: { root: '' },
                         lg: { root: 'vc-avatar-lg' },
                     },
                 },
@@ -285,7 +404,7 @@ export default function bootstrapTheme(): Theme {
                 classes: { root: 'badge rounded-pill' },
                 variants: {
                     size: {
-                        sm: { root: 'fs-7 px-2 py-1' },
+                        sm: { root: 'small px-2 py-1' },
                         md: { root: '' },
                         lg: { root: 'fs-6 px-3 py-2' },
                     },
@@ -389,6 +508,18 @@ export default function bootstrapTheme(): Theme {
                     closeIcon: 'btn-close position-absolute top-0 end-0 m-2',
                     back: 'btn btn-sm btn-link p-1',
                 },
+                // Bootstrap maps modal sizes via `.modal-sm` / `.modal-lg` /
+                // `.modal-xl` on the .modal element. Our content slot stands
+                // in for `.modal-dialog` so we apply the size class there.
+                variants: {
+                    size: {
+                        sm: { content: 'modal-sm' },
+                        md: { content: '' },
+                        lg: { content: 'modal-lg' },
+                        xl: { content: 'modal-xl' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             popover: {
                 classes: {
@@ -400,6 +531,18 @@ export default function bootstrapTheme(): Theme {
                     close: '',
                     closeIcon: 'btn-close position-absolute top-0 end-0 m-1',
                 },
+                // Bootstrap doesn't ship size variants for popovers — adjust
+                // font-size + padding via utility classes; the popover
+                // shrinks/grows to content, so explicit width tuning is left
+                // to consumers via per-instance themeClass.
+                variants: {
+                    size: {
+                        sm: { content: 'small p-2' },
+                        md: { content: '' },
+                        lg: { content: 'fs-6 p-4' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             hoverCard: {
                 classes: {
@@ -407,6 +550,14 @@ export default function bootstrapTheme(): Theme {
                     content: 'popover bs-popover-auto show vc-overlay-anim',
                     arrow: 'popover-arrow',
                 },
+                variants: {
+                    size: {
+                        sm: { content: 'small p-2' },
+                        md: { content: '' },
+                        lg: { content: 'fs-6 p-4' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             // Bootstrap doesn't ship a stepper component — we wire the rough
             // shape with utility classes (gap-* + rounded-circle for the
@@ -422,6 +573,17 @@ export default function bootstrapTheme(): Theme {
                     description: 'small text-muted',
                     separator: 'flex-grow-1 border-top border-secondary-subtle',
                 },
+                // Bootstrap doesn't ship circular size utilities; use the
+                // structural `vc-stepper-indicator-{sm,lg}` helpers added to
+                // @vuecs/navigation's stepper structural CSS.
+                variants: {
+                    size: {
+                        sm: { indicator: 'vc-stepper-indicator-sm', title: 'small' },
+                        md: { indicator: '' },
+                        lg: { indicator: 'vc-stepper-indicator-lg', title: 'fs-6' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             tooltip: {
                 classes: {
@@ -429,6 +591,14 @@ export default function bootstrapTheme(): Theme {
                     content: 'tooltip bs-tooltip-auto show tooltip-inner vc-tooltip-anim',
                     arrow: 'tooltip-arrow',
                 },
+                variants: {
+                    size: {
+                        sm: { content: 'small px-2 py-1' },
+                        md: { content: '' },
+                        lg: { content: 'fs-6 px-3 py-2' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             dropdownMenu: {
                 classes: {
@@ -446,6 +616,27 @@ export default function bootstrapTheme(): Theme {
                     subContent: 'dropdown-menu show vc-overlay-anim',
                     arrow: '',
                 },
+                // Bootstrap doesn't ship dropdown size variants. Layer
+                // utility classes for spacing/font-size; the structural
+                // dropdown chrome stays untouched.
+                variants: {
+                    size: {
+                        sm: {
+                            content: 'small p-1', 
+                            item: 'py-1 px-2', 
+                            subTrigger: 'py-1 px-2', 
+                            subContent: 'small p-1', 
+                        },
+                        md: { content: '' },
+                        lg: {
+                            content: 'fs-6', 
+                            item: 'py-2 px-3', 
+                            subTrigger: 'py-2 px-3', 
+                            subContent: 'fs-6', 
+                        },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             contextMenu: {
                 classes: {
@@ -462,6 +653,24 @@ export default function bootstrapTheme(): Theme {
                     subTrigger: 'dropdown-item dropdown-toggle',
                     subContent: 'dropdown-menu show vc-overlay-anim',
                 },
+                variants: {
+                    size: {
+                        sm: {
+                            content: 'small p-1', 
+                            item: 'py-1 px-2', 
+                            subTrigger: 'py-1 px-2', 
+                            subContent: 'small p-1', 
+                        },
+                        md: { content: '' },
+                        lg: {
+                            content: 'fs-6', 
+                            item: 'py-2 px-3', 
+                            subTrigger: 'py-2 px-3', 
+                            subContent: 'fs-6', 
+                        },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
         },
     };

--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -39,6 +39,26 @@ export default function tailwindTheme(): Theme {
                     groupAppend: 'inline-flex items-center rounded-r-md border border-l-0 border-border bg-bg-muted px-3 text-sm text-fg-muted',
                     groupPrepend: 'inline-flex items-center rounded-l-md border border-r-0 border-border bg-bg-muted px-3 text-sm text-fg-muted',
                 },
+                // Size axis mirrors the button family — `sm` shrinks padding
+                // + font-size for dense forms, `lg` scales up for primary
+                // call-to-action inputs. tailwind-merge dedupes the
+                // overlap with the default `px-3 py-2 text-sm` chrome.
+                variants: {
+                    size: {
+                        sm: {
+                            root: 'px-2 py-1 text-xs', 
+                            groupAppend: 'px-2 text-xs', 
+                            groupPrepend: 'px-2 text-xs', 
+                        },
+                        md: { root: '' },
+                        lg: {
+                            root: 'px-4 py-3 text-base', 
+                            groupAppend: 'px-4 text-base', 
+                            groupPrepend: 'px-4 text-base', 
+                        },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             formCheckbox: {
                 classes: {
@@ -47,6 +67,20 @@ export default function tailwindTheme(): Theme {
                     label: 'text-sm text-fg cursor-pointer select-none',
                     group: 'inline-flex items-center gap-2',
                 },
+                // Sizing references the structural `vc-form-checkbox-{sm,lg}` helpers
+                // (defined in @vuecs/forms/assets/form-checkbox.css) — utility-class
+                // sizing like `h-3 w-3` lives in `@layer utilities` which loses to
+                // the unlayered structural `.vc-form-checkbox` rule. Label
+                // font-size uses Tailwind v4's `class!` important suffix to beat
+                // the structural label rule.
+                variants: {
+                    size: {
+                        sm: { root: 'vc-form-checkbox-sm', label: 'text-xs!' },
+                        md: { root: '' },
+                        lg: { root: 'vc-form-checkbox-lg', label: 'text-base!' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             formCheckboxGroup: { classes: { root: 'flex flex-col gap-2 data-[orientation=horizontal]:flex-row data-[orientation=horizontal]:items-center' } },
             formSwitch: {
@@ -56,6 +90,17 @@ export default function tailwindTheme(): Theme {
                     label: 'text-sm text-fg cursor-pointer select-none',
                     group: 'inline-flex items-center gap-2',
                 },
+                // Sizing references the structural `vc-form-switch-{sm,lg}` helpers
+                // (track + thumb + checked-translate scale together via descendant
+                // selectors). See formCheckbox above for rationale.
+                variants: {
+                    size: {
+                        sm: { root: 'vc-form-switch-sm', label: 'text-xs!' },
+                        md: { root: '' },
+                        lg: { root: 'vc-form-switch-lg', label: 'text-base!' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             formSelect: {
                 classes: {
@@ -70,6 +115,16 @@ export default function tailwindTheme(): Theme {
                     groupLabel: 'px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-fg-muted',
                     separator: '-mx-1 my-1 h-px bg-border',
                 },
+                // Trigger size uses the structural `vc-form-select-trigger-{sm,lg}`
+                // helpers — see formCheckbox above for rationale.
+                variants: {
+                    size: {
+                        sm: { trigger: 'vc-form-select-trigger-sm', item: 'py-1 pl-6 text-xs!' },
+                        md: { trigger: '' },
+                        lg: { trigger: 'vc-form-select-trigger-lg', item: 'py-2 pl-8 text-base!' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             formSelectSearch: {
                 classes: {
@@ -92,6 +147,16 @@ export default function tailwindTheme(): Theme {
                     label: 'text-sm text-fg cursor-pointer select-none',
                     group: 'inline-flex items-center gap-2',
                 },
+                // Sizing references the structural `vc-form-radio-{sm,lg}` helpers
+                // (root + indicator scale together via descendant selectors).
+                variants: {
+                    size: {
+                        sm: { root: 'vc-form-radio-sm', label: 'text-xs!' },
+                        md: { root: '' },
+                        lg: { root: 'vc-form-radio-lg', label: 'text-base!' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             formRadioGroup: { classes: { root: 'flex flex-col gap-2 data-[orientation=horizontal]:flex-row data-[orientation=horizontal]:items-center data-[orientation=horizontal]:gap-4' } },
             formPin: {
@@ -119,6 +184,22 @@ export default function tailwindTheme(): Theme {
                     decrement: 'inline-flex w-8 items-center justify-center bg-bg-muted text-fg hover:bg-bg-elevated focus-visible:outline-2 focus-visible:outline-primary-500 -outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
                     increment: 'inline-flex w-8 items-center justify-center bg-bg-muted text-fg hover:bg-bg-elevated focus-visible:outline-2 focus-visible:outline-primary-500 -outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50',
                 },
+                variants: {
+                    size: {
+                        sm: {
+                            input: 'px-2 py-1 text-xs', 
+                            decrement: 'w-6 text-xs', 
+                            increment: 'w-6 text-xs', 
+                        },
+                        md: { input: '' },
+                        lg: {
+                            input: 'px-4 py-3 text-base', 
+                            decrement: 'w-10 text-base', 
+                            increment: 'w-10 text-base', 
+                        },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             formTags: {
                 classes: {
@@ -128,6 +209,22 @@ export default function tailwindTheme(): Theme {
                     itemDelete: 'inline-flex h-4 w-4 items-center justify-center rounded-full bg-transparent text-current hover:bg-black/10',
                     input: 'flex-1 min-w-24 bg-transparent border-0 outline-none text-fg px-0 py-0.5 text-sm',
                 },
+                variants: {
+                    size: {
+                        sm: {
+                            root: 'px-1.5! py-1!',
+                            item: 'px-1.5! py-px! text-[0.625rem]!',
+                            input: 'text-xs!',
+                        },
+                        md: { root: '' },
+                        lg: {
+                            root: 'px-3! py-2! text-base!',
+                            item: 'px-2.5! py-1! text-sm!',
+                            input: 'text-base!',
+                        },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             button: {
                 classes: {
@@ -198,9 +295,33 @@ export default function tailwindTheme(): Theme {
                     size: 'md', 
                 },
             },
-            formTextarea: { classes: { root: 'block w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:bg-bg-muted' } },
+            formTextarea: {
+                classes: { root: 'block w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:bg-bg-muted' },
+                variants: {
+                    size: {
+                        sm: { root: 'px-2 py-1 text-xs' },
+                        md: { root: '' },
+                        lg: { root: 'px-4 py-3 text-base' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
             validationGroup: { classes: { item: 'text-xs text-error-600' } },
-            list: { classes: { root: 'flex flex-col gap-1' } },
+            list: {
+                classes: { root: 'flex flex-col gap-1' },
+                // Density axis controls the gap between items. `compact`
+                // suits dense data tables, `normal` is the default,
+                // `spacious` reads as breathing room around long-form
+                // entries (e.g. activity feeds).
+                variants: {
+                    density: {
+                        compact: { root: 'gap-0' },
+                        normal: { root: '' },
+                        spacious: { root: 'gap-3' },
+                    },
+                },
+                defaultVariants: { density: 'normal' },
+            },
             // `empty:hidden` — when shorthand mode auto-composes a part
             // and the consumer didn't supply that slot, the resulting
             // empty wrapper collapses out of layout instead of taking
@@ -213,7 +334,19 @@ export default function tailwindTheme(): Theme {
             // truncates cleanly. `<VCListItemActions>` is positionally
             // unopinionated so N clusters compose naturally — the text's
             // `flex-1` is what pushes them to the right edge.
-            listItem: { classes: { root: 'flex flex-row items-center gap-2 py-1' } },
+            listItem: {
+                classes: { root: 'flex flex-row items-center gap-2 py-1' },
+                // Match the parent list's density: tighter vertical padding
+                // for compact rows, generous padding for spacious rows.
+                variants: {
+                    density: {
+                        compact: { root: 'py-0.5' },
+                        normal: { root: '' },
+                        spacious: { root: 'py-3' },
+                    },
+                },
+                defaultVariants: { density: 'normal' },
+            },
             listItemText: { classes: { root: 'inline-flex min-w-0 flex-1 flex-col' } },
             listItemActions: { classes: { root: 'inline-flex items-center gap-1' } },
             listLoading: { classes: { root: 'py-2 text-center text-sm text-fg-muted' } },
@@ -229,6 +362,14 @@ export default function tailwindTheme(): Theme {
                     linkIcon: 'inline-flex h-4 w-4 shrink-0 items-center justify-center',
                     linkText: 'flex-1 truncate',
                 },
+                variants: {
+                    size: {
+                        sm: { link: 'px-2 py-1 text-xs', linkIcon: 'h-3 w-3' },
+                        md: { link: '' },
+                        lg: { link: 'px-4 py-3 text-base', linkIcon: 'h-5 w-5' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             pagination: {
                 classes: {
@@ -239,7 +380,7 @@ export default function tailwindTheme(): Theme {
                     // variant. Keeping concerns split lets consumers pick a
                     // size and a visual treatment independently.
                     link: 'inline-flex items-center justify-center gap-1.5 rounded-md leading-none focus:outline-none focus:ring-1 focus:ring-ring',
-                    linkActive: '!border-primary-600 !bg-primary-600 !text-on-primary hover:!bg-primary-700',
+                    linkActive: 'border-primary-600! bg-primary-600! text-on-primary! hover:bg-primary-700!',
                     // The component composes `link + ellipsis` onto
                     // PaginationEllipsis so it inherits the box styling
                     // (size, border, bg) from the link slot. These overrides
@@ -288,12 +429,16 @@ export default function tailwindTheme(): Theme {
                     remove: 'inline-flex items-center justify-center rounded-full bg-transparent text-current hover:bg-black/15 focus:outline-none focus-visible:ring-2 focus-visible:ring-on-primary',
                 },
                 // Size axis mirrors @vuecs/elements badge so a `<VCTag size="lg">`
-                // and `<VCBadge size="lg">` read at the same scale.
+                // and `<VCBadge size="lg">` read at the same scale. The `!`
+                // suffix is needed because the structural `.vc-tag` rule
+                // (`@vuecs/elements/assets/tag.css`) sits unlayered and beats
+                // utilities in `@layer utilities` — the suffix promotes each
+                // utility above the structural padding/font-size defaults.
                 variants: {
                     size: {
-                        sm: { root: 'px-1.5 py-px text-[0.625rem] gap-0.5', remove: 'h-3 w-3' },
-                        md: { root: 'px-2 py-0.5 text-xs', remove: 'h-4 w-4' },
-                        lg: { root: 'px-2.5 py-1 text-sm', remove: 'h-5 w-5' },
+                        sm: { root: 'px-1.5! py-px! text-[0.625rem]! gap-0.5!', remove: 'h-3! w-3!' },
+                        md: { root: 'px-2! py-0.5! text-xs!', remove: 'h-4! w-4!' },
+                        lg: { root: 'px-2.5! py-1! text-sm!', remove: 'h-5! w-5!' },
                     },
                 },
                 defaultVariants: { size: 'md' },
@@ -303,6 +448,18 @@ export default function tailwindTheme(): Theme {
                     root: 'flex flex-wrap items-center gap-1.5',
                     item: '',
                 },
+                // Gap scales with the chip size so the row reads at a
+                // consistent visual rhythm. The Tags component forwards its
+                // `size` prop to each <VCTag> child so the chips themselves
+                // also resize.
+                variants: {
+                    size: {
+                        sm: { root: 'gap-1' },
+                        md: { root: '' },
+                        lg: { root: 'gap-2' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             avatar: {
                 classes: {
@@ -310,14 +467,19 @@ export default function tailwindTheme(): Theme {
                     image: 'h-full w-full object-cover',
                     fallback: 'inline-flex h-full w-full items-center justify-center font-medium leading-none',
                 },
-                // Mirrors @vuecs/elements badge size axis so a
-                // `<VCAvatar size="lg">` reads at the same scale as a
-                // `<VCBadge size="lg">`.
+                // Sizing references the structural `vc-avatar-{sm,md,lg}` helpers
+                // (defined in @vuecs/elements/assets/avatar.css) — Tailwind
+                // utility-class sizing like `h-8 w-8` lives in `@layer utilities`
+                // which loses to the unlayered structural `.vc-avatar` rule.
+                // `md` is the no-op default — the structural `.vc-avatar` rule
+                // already sets the medium size. `vc-avatar-{sm,lg}` helpers
+                // override at the structural level (utility classes lose to
+                // unlayered structural; see form-checkbox.css rationale).
                 variants: {
                     size: {
-                        sm: { root: 'h-8 w-8', fallback: 'text-xs' },
-                        md: { root: 'h-10 w-10', fallback: 'text-sm' },
-                        lg: { root: 'h-14 w-14', fallback: 'text-base' },
+                        sm: { root: 'vc-avatar-sm', fallback: 'text-xs!' },
+                        md: { fallback: 'text-sm!' },
+                        lg: { root: 'vc-avatar-lg', fallback: 'text-base!' },
                     },
                 },
                 defaultVariants: { size: 'md' },
@@ -325,11 +487,14 @@ export default function tailwindTheme(): Theme {
             aspectRatio: { classes: { root: 'block w-full' } },
             badge: {
                 classes: { root: 'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium leading-tight' },
+                // Size variants use the `!` suffix to override the unlayered
+                // structural `.vc-badge` padding/font-size defaults — see
+                // tag.size above for rationale.
                 variants: {
                     size: {
-                        sm: { root: 'px-1.5 py-px text-[0.625rem]' },
-                        md: { root: 'px-2 py-0.5 text-xs' },
-                        lg: { root: 'px-2.5 py-1 text-sm' },
+                        sm: { root: 'px-1.5! py-px! text-[0.625rem]!' },
+                        md: { root: 'px-2! py-0.5! text-xs!' },
+                        lg: { root: 'px-2.5! py-1! text-sm!' },
                     },
                 },
                 // Color × variant matrix for the `solid` / `soft` / `outline`
@@ -382,6 +547,17 @@ export default function tailwindTheme(): Theme {
                     closeIcon: 'absolute right-3 top-3 inline-flex h-7 w-7 items-center justify-center rounded-md text-fg-muted hover:bg-bg-muted hover:text-fg focus:outline-none focus:ring-2 focus:ring-ring',
                     back: 'inline-flex h-7 w-7 items-center justify-center rounded-md text-fg-muted hover:bg-bg-muted hover:text-fg focus:outline-none focus:ring-2 focus:ring-ring',
                 },
+                // Modal size axis = max-width tier. md (lg) is the default;
+                // sm fits compact confirms, lg fits forms, xl fits dashboards.
+                variants: {
+                    size: {
+                        sm: { content: 'max-w-sm p-4 gap-3' },
+                        md: { content: '' },
+                        lg: { content: 'max-w-2xl' },
+                        xl: { content: 'max-w-4xl' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             popover: {
                 classes: {
@@ -393,6 +569,14 @@ export default function tailwindTheme(): Theme {
                     close: 'focus:outline-none focus:ring-2 focus:ring-ring',
                     closeIcon: 'absolute right-2 top-2 inline-flex h-6 w-6 items-center justify-center rounded-md text-fg-muted hover:bg-bg-muted hover:text-fg focus:outline-none focus:ring-2 focus:ring-ring',
                 },
+                variants: {
+                    size: {
+                        sm: { content: 'w-56 p-3 text-xs' },
+                        md: { content: '' },
+                        lg: { content: 'w-96 p-5 text-base' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             hoverCard: {
                 classes: {
@@ -400,22 +584,59 @@ export default function tailwindTheme(): Theme {
                     content: 'z-50 w-64 rounded-md border border-border bg-bg p-4 text-sm text-fg shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
                     arrow: 'fill-bg',
                 },
+                variants: {
+                    size: {
+                        sm: { content: 'w-48 p-3 text-xs' },
+                        md: { content: '' },
+                        lg: { content: 'w-80 p-5 text-base' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             stepper: {
                 classes: {
                     root: 'flex items-center gap-2 data-[orientation=vertical]:flex-col data-[orientation=vertical]:items-stretch',
-                    item: 'flex flex-1 items-center gap-2 data-[orientation=vertical]:flex-row',
+                    // `group` scopes the indicator's `group-data-[state=active]:`
+                    // / `group-data-[state=completed]:` variants. Without it,
+                    // every step renders identical (the variant prefix has
+                    // nothing to anchor to and never matches).
+                    item: 'group flex flex-1 items-center gap-2 data-[orientation=vertical]:flex-row',
                     // The trigger is a circle that swaps colors based on the
                     // step's `data-state` (active / completed / inactive). It
                     // also receives `data-disabled` from Reka when the linear
                     // option blocks navigation; muted styling reads as
                     // "currently unreachable".
                     trigger: 'inline-flex shrink-0 items-center justify-center rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-60 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-60',
-                    indicator: 'inline-flex h-8 w-8 items-center justify-center rounded-full border border-border bg-bg text-sm font-semibold text-fg-muted group-data-[state=active]:border-primary-600 group-data-[state=active]:bg-primary-600 group-data-[state=active]:text-on-primary group-data-[state=completed]:border-success-600 group-data-[state=completed]:bg-success-600 group-data-[state=completed]:text-on-success',
+                    // Active + completed both light up primary so the
+                    // "where you've been" trail reads as one continuous
+                    // progression. Completed-as-success made the row
+                    // visually noisy and broke the linear-progress metaphor.
+                    indicator: 'inline-flex h-8 w-8 items-center justify-center rounded-full border border-border bg-bg text-sm font-semibold text-fg-muted group-data-[state=active]:border-primary-600 group-data-[state=active]:bg-primary-600 group-data-[state=active]:text-on-primary group-data-[state=completed]:border-primary-600 group-data-[state=completed]:bg-primary-600 group-data-[state=completed]:text-on-primary',
                     title: 'text-sm font-medium text-fg',
                     description: 'text-xs text-fg-muted',
-                    separator: 'h-px flex-1 shrink bg-border data-[state=completed]:bg-success-600 data-[orientation=vertical]:h-8 data-[orientation=vertical]:w-px',
+                    separator: 'h-px flex-1 shrink bg-border data-[state=completed]:bg-primary-600 data-[orientation=vertical]:h-8 data-[orientation=vertical]:w-px',
                 },
+                // Indicator sizing references the structural
+                // `vc-stepper-indicator-{sm,lg}` helpers (defined in
+                // @vuecs/navigation/assets/index.css). Title / description
+                // font-sizes use the `!` suffix to override base structural
+                // text-size defaults set on neighboring elements.
+                variants: {
+                    size: {
+                        sm: {
+                            indicator: 'vc-stepper-indicator-sm',
+                            title: 'text-xs!',
+                            description: 'text-[0.625rem]!',
+                        },
+                        md: { indicator: '' },
+                        lg: {
+                            indicator: 'vc-stepper-indicator-lg',
+                            title: 'text-base!',
+                            description: 'text-sm!',
+                        },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             tooltip: {
                 classes: {
@@ -423,6 +644,14 @@ export default function tailwindTheme(): Theme {
                     content: 'z-50 overflow-hidden rounded-md bg-neutral-900 px-3 py-1.5 text-xs text-on-neutral shadow-md data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=delayed-open]:zoom-in-95 dark:bg-neutral-50 dark:text-neutral-900',
                     arrow: 'fill-neutral-900 dark:fill-neutral-50',
                 },
+                variants: {
+                    size: {
+                        sm: { content: 'px-2 py-1 text-[0.625rem]' },
+                        md: { content: '' },
+                        lg: { content: 'px-4 py-2 text-sm' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             dropdownMenu: {
                 classes: {
@@ -440,6 +669,24 @@ export default function tailwindTheme(): Theme {
                     subContent: 'z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-bg p-1 text-sm text-fg shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
                     arrow: 'fill-bg',
                 },
+                variants: {
+                    size: {
+                        sm: {
+                            content: 'min-w-[6rem] text-xs', 
+                            item: 'px-1.5 py-1', 
+                            subTrigger: 'px-1.5 py-1', 
+                            subContent: 'min-w-[6rem] text-xs', 
+                        },
+                        md: { content: '' },
+                        lg: {
+                            content: 'min-w-[12rem] text-base', 
+                            item: 'px-3 py-2', 
+                            subTrigger: 'px-3 py-2', 
+                            subContent: 'min-w-[12rem] text-base', 
+                        },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
             contextMenu: {
                 classes: {
@@ -456,6 +703,24 @@ export default function tailwindTheme(): Theme {
                     subTrigger: 'relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 outline-none data-[highlighted]:bg-bg-muted data-[state=open]:bg-bg-muted data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
                     subContent: 'z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-bg p-1 text-sm text-fg shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
                 },
+                variants: {
+                    size: {
+                        sm: {
+                            content: 'min-w-[6rem] text-xs', 
+                            item: 'px-1.5 py-1', 
+                            subTrigger: 'px-1.5 py-1', 
+                            subContent: 'min-w-[6rem] text-xs', 
+                        },
+                        md: { content: '' },
+                        lg: {
+                            content: 'min-w-[12rem] text-base', 
+                            item: 'px-3 py-2', 
+                            subTrigger: 'px-3 py-2', 
+                            subContent: 'min-w-[12rem] text-base', 
+                        },
+                    },
+                },
+                defaultVariants: { size: 'md' },
             },
         },
     };


### PR DESCRIPTION
…olation

Demo authoring split — `<Demo>` (passive showcase: iframe + code, no controls) vs `<Playground>` (interactive sandbox: iframe + code + toolbar). Both share `iframe-bridge.ts`; only `<Playground>` reads the `announceVariants` / `announceProps` postMessage round-trip. Migrated 20+ component pages and added the `announceProps` API with typed catalog (boolean / enum / number / string + dot-path nesting for `themeVariant.size` etc.).

Stepper compound — added `provideStepperContext` / `useStepperContext` so `themeClass` and `themeVariant` applied to `<VCStepper>` propagate to descendant indicator / title / description / separator / item / trigger parts. Solves the size-variant-doesn't-work complaint without forcing consumers to repeat `:theme-variant` on every child. Per-instance overrides still win.

Structural-CSS color isolation — for components whose themes drive colors via variants (`.vc-badge`, `.vc-tag`, `.vc-stepper-indicator`, `.vc-stepper-separator`), dropped color/background/border from the structural defaults so theme classes always win. Reverted the earlier `@layer components` wrapping experiment that broke Bootstrap mode (Bootstrap reboot's `button { border-radius: 0 }` and `bg-* !important` utilities beat `@layer components`). Other structural files stay unlayered with their colors intact (no theme-variant conflict).

Bootstrap stepper data-state visualization — Bootstrap utility classes can't carry `[data-state=…]` attribute selectors, so added rules in the bridge CSS (`themes/bootstrap/assets/index.css`) with `!important` to win over Bootstrap utilities (which themselves use `!important`).

Tailwind + Bootstrap themes — completed steps now use `primary` (was `success`) so active+completed read as one continuous progression. Size variants in Tailwind theme switch to structural helper classes (`vc-form-checkbox-{sm,lg}`, `vc-stepper-indicator-{sm,lg}`, `vc-avatar-{sm,lg}`) where they exist; remaining cases use the v4 `class!` important suffix. Replaced `fs-7` (not shipped in BS5) with `small`. Fixed pre-existing pagination `linkActive` prefix-`!` (silent no-op in v4) → suffix-`!`.

VCFormSelectSearch — first item no longer auto-highlights as "current" on initial render. The Enter handler still selects the first item when no item is keyboard-focused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive component playgrounds in documentation with live variant and prop controls.
  * Added size variants (sm, md, lg) across form components and UI elements.
  * Enhanced theme variant support with improved context propagation.

* **Documentation**
  * Updated component documentation to use interactive playgrounds instead of static demos.
  * Added variant axes documentation and per-component variant catalogs.

* **Bug Fixes**
  * Form search highlighting now correctly resets when filtering items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->