### PR TITLE
feat: add @vuecs/theme-bulma + extend design-tokens docs

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -774,6 +774,53 @@ component CSS is Sass-compiled to literal hex, so the design-token
 bridge had no practical effect on Bootstrap-rendered widgets, only on
 consumer-authored CSS that referenced `var(--primary)`.
 
+### Bulma bridge (theme-bulma)
+
+`@vuecs/theme-bulma` ships an optional CSS file at `assets/index.css`
+that wires Bulma 1.0+'s `:root` theme-color variables onto `--vc-color-*`.
+Same shape as the Bootstrap bridge: `style` conditional export so a bare
+`@import "@vuecs/theme-bulma"` resolves to the bridge. Bulma 1.0+
+components read `--bulma-*` at runtime, so runtime palette switches via
+`setPalette()` propagate.
+
+Notable mapping decisions:
+- `--bulma-link → --vc-color-info-500` (preserves Bulma's two-tone
+  palette where `link` is a separate "informational" axis from
+  `primary`; differs from the BS bridge's `--bs-link-color → primary-600`).
+- `ghost` / `link` button-variant mappings are reversed vs. Bootstrap.
+  Bulma's `is-ghost` is the underlined-anchor button (= our `link`);
+  Bulma's `is-text` is the borderless transparent button (= our `ghost`).
+- DropdownMenu / FormSelect content uses `.dropdown-content` (Bulma's
+  inner box-styled element) rather than `.dropdown-menu`, because
+  `.dropdown-menu` is gated by parent `.dropdown.is-active` and Reka's
+  portal-mounted content has no parent.
+- Stepper and Switch are hand-rolled via gap-fill rules in the bridge
+  CSS — neither ships in Bulma core. Same approach as the BS bridge,
+  using design-system tokens for color.
+
+Bulma 1.0 routes per-variant theming through HSL **channel** vars
+(`--bulma-button-h/s/l`), not named color tokens. A `.button.is-primary`
+sets `--bulma-button-h: var(--bulma-primary-h)` etc., and the base
+`.button` rule resolves `background-color: hsl(--bulma-button-h, …)`.
+Pure CSS can't decompose `var(--vc-color-primary-600)` into H/S/L
+channels, so we can't bridge that path — overriding
+`--bulma-button-background-color` is a no-op because Bulma never reads
+it. The bridge instead overrides the **resolved** `background-color` /
+`border-color` / `color` properties directly on each per-variant
+selector. Specificity 0,2,0 beats Bulma's base `.button` (0,1,0); no
+`!important` needed.
+
+Trade-off: Bulma's auto-computed hover/active lightness deltas are
+short-circuited. The bridge re-specifies hover (`-700`) and active
+(`-800`) shades manually per variant — same pattern as the BS bridge's
+explicit `--bs-btn-hover-bg` overrides.
+
+Utility classes that read HSL channels (`.has-background-light`,
+`.has-text-grey`, `.has-background-dark`) keep Bulma's default palette
+— `setPalette()` doesn't reach them. The variant matrix uses these
+utilities sparingly (avatar bg, stepper indicator default state,
+tooltip dark bg) where Bulma's defaults are visually acceptable.
+
 ### Short-form CSS imports
 
 All style-carrying packages use the `style` conditional export so
@@ -782,6 +829,7 @@ consumers can write bare imports:
 ```css
 @import "@vuecs/design";              /* → assets/index.css */
 @import "@vuecs/theme-bootstrap";     /* → assets/index.css (bridge) */
+@import "@vuecs/theme-bulma";         /* → assets/index.css (bridge) */
 @import "@vuecs/forms";       /* → dist/style.css */
 @import "@vuecs/navigation";          /* → dist/style.css */
 @import "@vuecs/pagination";          /* → dist/style.css */

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -21,6 +21,7 @@ vuecs/
     timeago/          # @vuecs/timeago
   themes/             # Theme packages (npm workspaces) — pure data, no Vue runtime deps
     bootstrap/        # @vuecs/theme-bootstrap — Bootstrap (currently v5) theme + design-token bridge (assets/index.css)
+    bulma/            # @vuecs/theme-bulma — Bulma 1.0+ theme + design-token bridge (assets/index.css)
     tailwind/         # @vuecs/theme-tailwind — Tailwind v4 theme (semantic tokens)
   icons/              # Icon-preset packages (npm workspaces) — Iconify-name vocabularies for @vuecs/icon, no runtime icon data
     font-awesome/     # @vuecs/icons-font-awesome — Font Awesome 6 Solid icon names (replaces the removed @vuecs/theme-font-awesome)

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -14,6 +14,7 @@
     "packages/overlays": "0.0.0",
     "packages/pagination": "1.3.1",
     "themes/bootstrap": "3.0.0",
+    "themes/bulma": "0.0.0",
     "themes/tailwind": "0.0.0",
     "icons/font-awesome": "0.0.0",
     "icons/lucide": "0.0.0",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ npm run lint:fix       # Auto-fix lint issues
 | `@vuecs/overlays` | Compound overlays on Reka primitives — Modal (+ `useModal()` view-stack composable), Popover, HoverCard, Tooltip, DropdownMenu, ContextMenu | 0.0.0 |
 | `@vuecs/pagination` | Pagination component | 1.3.1 |
 | `@vuecs/theme-bootstrap` | Bootstrap theme (currently targets v5; renamed from `@vuecs/theme-bootstrap-v5` in 3.0) | 3.0.0 |
+| `@vuecs/theme-bulma` | Bulma 1.0+ theme + design-token bridge | 0.0.0 |
 | `@vuecs/theme-tailwind` | Tailwind CSS theme (exports `merge: ClassesMergeFn`) | 0.0.0 |
 | `@vuecs/icons-font-awesome` | Font Awesome 6 Solid icon-name preset for vuecs (Iconify-backed; replaces the removed `@vuecs/theme-font-awesome`) | 0.0.0 |
 | `@vuecs/icons-lucide` | Lucide icon-name preset for vuecs (Iconify-backed) | 0.0.0 |
@@ -56,7 +57,7 @@ Layer 2': icons (@vuecs/core peer dep only — Iconify-name vocabularies for @vu
 Layer 3 (integration):       nuxt (depends on design + @nuxt/kit)
 ```
 
-`navigation` also depends on `@vuecs/link`. `pagination`, `overlays`, `forms`, `elements`, and `navigation` take a runtime dep on `reka-ui` (they wrap Reka's headless primitives — pagination, dialog/popover/hover-card/tooltip/menu, the form-input families, the atomic separator/avatar/aspect-ratio/visually-hidden elements, and the stepper respectively). `theme-tailwind` is designed to pair with `@vuecs/design` (Tailwind v4 + CSS-variable tokens); `theme-bootstrap` ships an optional bridge that maps Bootstrap's `--bs-*` theme vars onto the design-system tokens.
+`navigation` also depends on `@vuecs/link`. `pagination`, `overlays`, `forms`, `elements`, and `navigation` take a runtime dep on `reka-ui` (they wrap Reka's headless primitives — pagination, dialog/popover/hover-card/tooltip/menu, the form-input families, the atomic separator/avatar/aspect-ratio/visually-hidden elements, and the stepper respectively). `theme-tailwind` is designed to pair with `@vuecs/design` (Tailwind v4 + CSS-variable tokens); `theme-bootstrap` and `theme-bulma` each ship an optional bridge mapping their framework's runtime CSS variables (`--bs-*`, `--bulma-*`) onto the design-system tokens.
 
 ## Documentation Site
 

--- a/docs/demos/src/aspect-ratio.html
+++ b/docs/demos/src/aspect-ratio.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VCAspectRatio demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/aspect-ratio.html
+++ b/docs/demos/src/aspect-ratio.html
@@ -6,6 +6,7 @@
     <title>VCAspectRatio demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/avatar.html
+++ b/docs/demos/src/avatar.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VCAvatar demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/avatar.html
+++ b/docs/demos/src/avatar.html
@@ -6,6 +6,7 @@
     <title>VCAvatar demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/badge.html
+++ b/docs/demos/src/badge.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VCBadge demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/badge.html
+++ b/docs/demos/src/badge.html
@@ -6,6 +6,7 @@
     <title>VCBadge demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/button.html
+++ b/docs/demos/src/button.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/button.html
+++ b/docs/demos/src/button.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/context-menu.html
+++ b/docs/demos/src/context-menu.html
@@ -6,6 +6,7 @@
     <title>VCContextMenu demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/context-menu.html
+++ b/docs/demos/src/context-menu.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VCContextMenu demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/countdown.html
+++ b/docs/demos/src/countdown.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/countdown.html
+++ b/docs/demos/src/countdown.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/dropdown-menu.html
+++ b/docs/demos/src/dropdown-menu.html
@@ -6,6 +6,7 @@
     <title>VCDropdownMenu demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/dropdown-menu.html
+++ b/docs/demos/src/dropdown-menu.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VCDropdownMenu demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-checkbox.html
+++ b/docs/demos/src/form-checkbox.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-checkbox.html
+++ b/docs/demos/src/form-checkbox.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-input.html
+++ b/docs/demos/src/form-input.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-input.html
+++ b/docs/demos/src/form-input.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-number.html
+++ b/docs/demos/src/form-number.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-number.html
+++ b/docs/demos/src/form-number.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-pin.html
+++ b/docs/demos/src/form-pin.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-pin.html
+++ b/docs/demos/src/form-pin.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-radio.html
+++ b/docs/demos/src/form-radio.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-radio.html
+++ b/docs/demos/src/form-radio.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-select-search-multiple.html
+++ b/docs/demos/src/form-select-search-multiple.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-select-search-multiple.html
+++ b/docs/demos/src/form-select-search-multiple.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-select-search.html
+++ b/docs/demos/src/form-select-search.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-select-search.html
+++ b/docs/demos/src/form-select-search.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-select.html
+++ b/docs/demos/src/form-select.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-select.html
+++ b/docs/demos/src/form-select.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-slider.html
+++ b/docs/demos/src/form-slider.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-slider.html
+++ b/docs/demos/src/form-slider.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-switch.html
+++ b/docs/demos/src/form-switch.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-switch.html
+++ b/docs/demos/src/form-switch.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-tags.html
+++ b/docs/demos/src/form-tags.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-tags.html
+++ b/docs/demos/src/form-tags.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-textarea.html
+++ b/docs/demos/src/form-textarea.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/form-textarea.html
+++ b/docs/demos/src/form-textarea.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/gravatar.html
+++ b/docs/demos/src/gravatar.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/gravatar.html
+++ b/docs/demos/src/gravatar.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/hover-card.html
+++ b/docs/demos/src/hover-card.html
@@ -6,6 +6,7 @@
     <title>VCHoverCard demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/hover-card.html
+++ b/docs/demos/src/hover-card.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VCHoverCard demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/iframe-bridge.ts
+++ b/docs/demos/src/iframe-bridge.ts
@@ -185,10 +185,11 @@ const handleParentMessage = (event: MessageEvent<ParentMessage>): void => {
         setPalette(palette as Parameters<typeof setPalette>[0]);
         postHeight();
     } else if (data.type === 'set-theme') {
-        // Live runtime vuecs-theme swap (tailwind ↔ bootstrap). Calls
-        // ThemeManager.setThemes which triggers every useComponentTheme()
-        // computed to recompute. Bootstrap CSS is preloaded as a disabled
-        // <link> in the demo HTML shell; setDemoTheme toggles it.
+        // Live runtime vuecs-theme swap (tailwind ↔ bootstrap ↔ bulma).
+        // Calls ThemeManager.setThemes which triggers every
+        // useComponentTheme() computed to recompute. Each non-Tailwind
+        // framework's CSS is preloaded as a disabled <link> in the demo
+        // HTML shell; setDemoTheme toggles the right one on/off.
         setDemoTheme(data.theme);
         postHeight();
     }

--- a/docs/demos/src/link.html
+++ b/docs/demos/src/link.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/link.html
+++ b/docs/demos/src/link.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/list.html
+++ b/docs/demos/src/list.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/list.html
+++ b/docs/demos/src/list.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/modal-view-stack.html
+++ b/docs/demos/src/modal-view-stack.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>useModal view-stack demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/modal-view-stack.html
+++ b/docs/demos/src/modal-view-stack.html
@@ -6,6 +6,7 @@
     <title>useModal view-stack demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/modal.html
+++ b/docs/demos/src/modal.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VCModal demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/modal.html
+++ b/docs/demos/src/modal.html
@@ -6,6 +6,7 @@
     <title>VCModal demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/pagination.html
+++ b/docs/demos/src/pagination.html
@@ -6,6 +6,7 @@
     <title>VCPagination demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/pagination.html
+++ b/docs/demos/src/pagination.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VCPagination demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/popover.html
+++ b/docs/demos/src/popover.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VCPopover demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/popover.html
+++ b/docs/demos/src/popover.html
@@ -6,6 +6,7 @@
     <title>VCPopover demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/separator.html
+++ b/docs/demos/src/separator.html
@@ -6,6 +6,7 @@
     <title>VCSeparator demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/separator.html
+++ b/docs/demos/src/separator.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VCSeparator demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/shared.ts
+++ b/docs/demos/src/shared.ts
@@ -1,5 +1,6 @@
 import vuecs, { injectThemeManager } from '@vuecs/core';
 import bootstrapTheme from '@vuecs/theme-bootstrap';
+import bulmaTheme from '@vuecs/theme-bulma';
 import tailwindTheme from '@vuecs/theme-tailwind';
 import type { App } from 'vue';
 
@@ -7,14 +8,26 @@ import type { App } from 'vue';
  * Shared `@vuecs/core` install for every demo. Each iframe is its own
  * Vue app, so this runs once per demo. The default theme is
  * `@vuecs/theme-tailwind` (mirrors a real consumer who picked Tailwind);
- * the docs `<SettingsModal>` lets a reader flip to `bootstrap` for
- * visual QA via postMessage.
+ * the docs `<SettingsModal>` lets a reader flip to `bootstrap` or `bulma`
+ * for visual QA via postMessage.
  */
-export type DemoThemeName = 'tailwind' | 'bootstrap';
+export type DemoThemeName = 'tailwind' | 'bootstrap' | 'bulma';
 
 export const themeFactories: Record<DemoThemeName, () => ReturnType<typeof tailwindTheme>> = {
     tailwind: tailwindTheme,
     bootstrap: bootstrapTheme,
+    bulma: bulmaTheme,
+};
+
+/**
+ * Maps each non-Tailwind demo theme to the `data-*-css` attribute on the
+ * preloaded-but-disabled framework `<link>` in the demo HTML shell. The
+ * Tailwind theme has no entry — its styles are embedded by Vite, no
+ * framework-CSS toggle needed.
+ */
+const cssLinkAttrByTheme: Partial<Record<DemoThemeName, string>> = {
+    bootstrap: 'data-bootstrap-css',
+    bulma: 'data-bulma-css',
 };
 
 let installedApp: App | null = null;
@@ -29,17 +42,22 @@ export function installVuecs(app: App): void {
  * parent docs page postMessages a `set-theme` event from the
  * SettingsModal. Walks Vue's inject tree to grab the ThemeManager, then
  * calls `setThemes([newTheme()])`.
+ *
+ * Each non-Tailwind theme has a corresponding `<link disabled>` in the
+ * demo HTML shell that loads the framework CSS from a CDN. We toggle
+ * exactly one link enabled at a time so framework styles don't leak
+ * across themes.
  */
 export function setDemoTheme(name: DemoThemeName): void {
     if (!installedApp) return;
-    // Bootstrap CSS for `@vuecs/theme-bootstrap` is preloaded as a disabled
-    // <link> in the demo HTML shell; toggle it on/off so the bootstrap
-    // class names actually have visual effect (and don't leak into the
-    // tailwind preview when switched off).
-    const link = document.querySelector<globalThis.HTMLLinkElement>('link[data-bootstrap-css]');
-    if (link) {
-        link.disabled = name !== 'bootstrap';
+
+    for (const [theme, attr] of Object.entries(cssLinkAttrByTheme)) {
+        const link = document.querySelector<globalThis.HTMLLinkElement>(`link[${attr}]`);
+        if (link) {
+            link.disabled = name !== theme;
+        }
     }
+
     // `runWithContext` lets us call `inject()` outside a setup() — needed
     // because the iframe-bridge calls this from a `message` event handler.
     installedApp.runWithContext(() => {

--- a/docs/demos/src/stepper.html
+++ b/docs/demos/src/stepper.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VCStepper demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/stepper.html
+++ b/docs/demos/src/stepper.html
@@ -6,6 +6,7 @@
     <title>VCStepper demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/style.css
+++ b/docs/demos/src/style.css
@@ -26,6 +26,10 @@
    harmless — nothing reads them. */
 @import "@vuecs/theme-bootstrap";
 
+/* Bulma design-token bridge — same rationale as the Bootstrap bridge,
+   for `--bulma-*` tokens. Harmless when the Bulma CDN is off. */
+@import "@vuecs/theme-bulma";
+
 /* Scan theme-tailwind so JIT keeps the class names it emits. */
 @source "../../../themes/tailwind/src";
 

--- a/docs/demos/src/tag.html
+++ b/docs/demos/src/tag.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VCTag demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/tag.html
+++ b/docs/demos/src/tag.html
@@ -6,6 +6,7 @@
     <title>VCTag demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/timeago.html
+++ b/docs/demos/src/timeago.html
@@ -6,6 +6,7 @@
     <title>vuecs demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/timeago.html
+++ b/docs/demos/src/timeago.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>vuecs demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/tooltip.html
+++ b/docs/demos/src/tooltip.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VCTooltip demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/tooltip.html
+++ b/docs/demos/src/tooltip.html
@@ -6,6 +6,7 @@
     <title>VCTooltip demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/visually-hidden.html
+++ b/docs/demos/src/visually-hidden.html
@@ -6,6 +6,7 @@
     <title>VCVisuallyHidden demo</title>
     <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
+    <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/demos/src/visually-hidden.html
+++ b/docs/demos/src/visually-hidden.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>VCVisuallyHidden demo</title>
-    <link rel="stylesheet" href="./style.css" />
     <link rel="stylesheet" data-bootstrap-css href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" disabled />
     <link rel="stylesheet" data-bulma-css href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css" disabled />
+    <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
     <div id="app"></div>

--- a/docs/package.json
+++ b/docs/package.json
@@ -42,8 +42,10 @@
         "@vuecs/overlays": "*",
         "@vuecs/pagination": "*",
         "@vuecs/theme-bootstrap": "*",
+        "@vuecs/theme-bulma": "*",
         "@vuecs/theme-tailwind": "*",
         "@vuecs/timeago": "*",
+        "bulma": "^1.0.4",
         "tailwindcss": "^4.2.4",
         "vitepress": "^1.6.3",
         "vue": "^3.5.33"

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -187,6 +187,7 @@ export default defineConfig({
                         { text: 'Overview', link: '/themes/' },
                         { text: 'Tailwind', link: '/themes/tailwind' },
                         { text: 'Bootstrap', link: '/themes/bootstrap' },
+                        { text: 'Bulma', link: '/themes/bulma' },
                     ],
                 },
             ],

--- a/docs/src/.vitepress/theme/components/SettingsModal.vue
+++ b/docs/src/.vitepress/theme/components/SettingsModal.vue
@@ -26,6 +26,7 @@ const { current: demoTheme, set: setDemoTheme } = useDemoTheme();
 const themeOptions: { value: DemoThemeName; label: string }[] = [
     { value: 'tailwind', label: 'Tailwind' },
     { value: 'bootstrap', label: 'Bootstrap' },
+    { value: 'bulma', label: 'Bulma' },
 ];
 
 const primary = computed<PrimaryPalette>({

--- a/docs/src/.vitepress/theme/use-demo-theme.ts
+++ b/docs/src/.vitepress/theme/use-demo-theme.ts
@@ -1,7 +1,7 @@
 import { createSharedComposable } from '@vueuse/core';
 import { ref } from 'vue';
 
-export type DemoThemeName = 'tailwind' | 'bootstrap';
+export type DemoThemeName = 'tailwind' | 'bootstrap' | 'bulma';
 
 /**
  * Shared reactive state for the iframe-demo theme picker. Lives outside

--- a/docs/src/getting-started/index.md
+++ b/docs/src/getting-started/index.md
@@ -19,7 +19,7 @@ Most Vue libraries make you pick a CSS framework upfront and bake it in. vuecs t
 ## What's in the box
 
 - **Components** — form controls, navigation, pagination, list controls, countdown, gravatar, link, timeago, icon.
-- **Themes** — `@vuecs/theme-tailwind`, `@vuecs/theme-bootstrap`.
+- **Themes** — `@vuecs/theme-tailwind`, `@vuecs/theme-bootstrap`, `@vuecs/theme-bulma`.
 - **Icons** — `@vuecs/icon` (`<VCIcon>`, Iconify-backed) plus presets (`@vuecs/icons-lucide`, `@vuecs/icons-font-awesome`) that map vuecs's semantic-slot defaults to specific icon vocabularies.
 - **Design tokens** — `@vuecs/design` ships CSS variables + a runtime palette switcher.
 - **Nuxt module** — `@vuecs/nuxt` ships SSR-safe palette + color-mode composables.

--- a/docs/src/guide/design-tokens.md
+++ b/docs/src/guide/design-tokens.md
@@ -39,33 +39,244 @@ Override defaults at runtime with `setPalette({ primary: 'green', neutral: 'zinc
 
 These flip under `.dark`:
 
-```css
---vc-color-bg            /* page/card background */
---vc-color-bg-muted      /* slightly recessed */
---vc-color-bg-elevated   /* slightly raised */
---vc-color-fg            /* primary text */
---vc-color-fg-muted      /* secondary text */
---vc-color-border        /* default border */
---vc-color-border-muted  /* subtle border */
---vc-color-ring          /* focus ring */
+| Token | Light mode | Dark mode | Tailwind utility |
+|-------|------------|-----------|------------------|
+| `--vc-color-bg` | `white` | `neutral-900` | `bg-bg` |
+| `--vc-color-bg-muted` | `neutral-50` | `neutral-800` | `bg-bg-muted` |
+| `--vc-color-bg-elevated` | `neutral-100` | `neutral-800` | `bg-bg-elevated` |
+| `--vc-color-fg` | `neutral-900` | `neutral-200` | `text-fg` |
+| `--vc-color-fg-muted` | `neutral-500` | `neutral-500` | `text-fg-muted` |
+| `--vc-color-border` | `neutral-200` | `neutral-800` | `border-border` |
+| `--vc-color-border-muted` | `neutral-100` | `neutral-900` | `border-border-muted` |
+| `--vc-color-ring` | `primary-500` | `primary-400` | `ring-ring` |
 
---vc-color-on-primary    /* foreground on filled primary bg */
---vc-color-on-success    /* etc. */
-```
+The `on-*` tokens are the contrasting foreground when a filled semantic background is in use. `--vc-color-on-warning` is the only one that flips (warning fills are light, so the text needs a darker tone in light mode).
 
-In Tailwind utilities: `bg-bg`, `text-fg`, `border-border`, `ring-ring`, `text-on-primary`. These are exposed via the `@theme` block in `@vuecs/design`.
+| Token | Light mode | Dark mode |
+|-------|------------|-----------|
+| `--vc-color-on-primary` | `white` | `white` |
+| `--vc-color-on-neutral` | `white` | `white` |
+| `--vc-color-on-success` | `white` | `white` |
+| `--vc-color-on-warning` | `neutral-900` | `neutral-950` |
+| `--vc-color-on-error` | `white` | `white` |
+| `--vc-color-on-info` | `white` | `white` |
 
 ## Radius
 
 ```css
---vc-radius-sm:   0.125rem;
---vc-radius-md:   0.375rem;
---vc-radius-lg:   0.5rem;
---vc-radius-xl:   0.75rem;
+--vc-radius-sm:   0.125rem; /* 2px  */
+--vc-radius-md:   0.375rem; /* 6px  */
+--vc-radius-lg:   0.5rem;   /* 8px  */
+--vc-radius-xl:   0.75rem;  /* 12px */
 --vc-radius-full: 9999px;
 ```
 
 Available as Tailwind utilities `rounded-sm`, `rounded-md`, `rounded-lg`, `rounded-xl`, `rounded-full`.
+
+## Complete CSS variable reference
+
+Every `--vc-*` token shipped by `@vuecs/design`. Use this as the bridging target when wiring a non-Tailwind CSS framework against the design system.
+
+<details>
+<summary>Color scales — 66 tokens (6 scales × 11 shades)</summary>
+
+Each scale ships shades `50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950`. The `:root` block in `@vuecs/design/assets/index.css` binds each shade to a Tailwind palette by default (overridable via `setPalette()`):
+
+| Scale | Token shape | Default Tailwind palette |
+|-------|-------------|--------------------------|
+| `primary` | `--vc-color-primary-{50…950}` | `blue` |
+| `neutral` | `--vc-color-neutral-{50…950}` | `neutral` |
+| `success` | `--vc-color-success-{50…950}` | `green` |
+| `warning` | `--vc-color-warning-{50…950}` | `amber` |
+| `error` | `--vc-color-error-{50…950}` | `red` |
+| `info` | `--vc-color-info-{50…950}` | `sky` |
+
+Examples:
+
+```css
+--vc-color-primary-50    /* lightest tint — bg for soft variants */
+--vc-color-primary-100   /* */
+--vc-color-primary-200   /* */
+--vc-color-primary-300   /* */
+--vc-color-primary-400   /* dark-mode primary */
+--vc-color-primary-500   /* default ring color, hover seed */
+--vc-color-primary-600   /* default solid bg */
+--vc-color-primary-700   /* hover/active bg, soft-variant text */
+--vc-color-primary-800   /* */
+--vc-color-primary-900   /* */
+--vc-color-primary-950   /* darkest shade */
+```
+
+Same shape for the other five scales. Override an entire scale at runtime via `setPalette({ primary: 'green' })`.
+</details>
+
+<details>
+<summary>Semantic aliases — flip under `.dark`</summary>
+
+```css
+/* Backgrounds */
+--vc-color-bg            /* page/card background */
+--vc-color-bg-muted      /* slightly recessed */
+--vc-color-bg-elevated   /* slightly raised */
+
+/* Foregrounds */
+--vc-color-fg            /* primary text */
+--vc-color-fg-muted      /* secondary text */
+
+/* Borders */
+--vc-color-border        /* default */
+--vc-color-border-muted  /* subtle */
+
+/* Focus ring */
+--vc-color-ring
+```
+
+See the table above for the per-mode resolved values.
+</details>
+
+<details>
+<summary>`on-*` foreground tokens (for placement on filled semantic backgrounds)</summary>
+
+```css
+--vc-color-on-primary
+--vc-color-on-neutral
+--vc-color-on-success
+--vc-color-on-warning  /* flips: dark text in light mode, darker text in dark mode */
+--vc-color-on-error
+--vc-color-on-info
+```
+
+Use these on text/icon elements that sit on top of a filled semantic background — e.g. the label of a `bg-primary-600` button.
+</details>
+
+<details>
+<summary>Radius</summary>
+
+```css
+--vc-radius-sm:   0.125rem; /* 2px  */
+--vc-radius-md:   0.375rem; /* 6px  */
+--vc-radius-lg:   0.5rem;   /* 8px  */
+--vc-radius-xl:   0.75rem;  /* 12px */
+--vc-radius-full: 9999px;
+```
+
+These do not flip with dark mode. Override at the `:root` level if you want different values across the whole app.
+</details>
+
+## Bridging another CSS framework
+
+If you bring your own non-Tailwind framework (Bootstrap, Bulma, Foundation, UIkit, your own design system…) and want `setPalette()` calls to re-tint native framework components alongside vuecs ones, write a CSS-variable bridge that maps the framework's runtime tokens onto `--vc-color-*`.
+
+The shipped `@vuecs/theme-bootstrap` and `@vuecs/theme-bulma` bridges are concrete examples — mirror that structure.
+
+### Step 1 — Identify the framework's runtime tokens
+
+A bridge only works if the framework reads its colors from CSS variables **at runtime** (not Sass-compiled to literal hex at build time). Bootstrap 5.3+ does this via `--bs-*`; Bulma 1.0+ does it via `--bulma-*`. Older Sass-only frameworks (Bootstrap 4, Foundation 6 default builds) can't be bridged this way — the colors are baked into compiled stylesheets.
+
+### Step 2 — Pin import order
+
+```css
+/* styles.css */
+@import "<framework>";          /* defines the framework's default --x-* tokens */
+@import "@vuecs/design";        /* defines --vc-color-* */
+@import "<your bridge>";        /* overrides --x-* to reference --vc-color-* */
+```
+
+The bridge must come **after** both the framework and `@vuecs/design`, otherwise its rebinding loses to the framework's defaults.
+
+### Step 3 — Map global tokens at `:root`
+
+Most frameworks expose top-level color variables for the canonical semantic colors. Map each one to the matching `--vc-color-*` shade:
+
+```css
+:root {
+    --x-primary: var(--vc-color-primary-500);
+    --x-success: var(--vc-color-success-500);
+    --x-warning: var(--vc-color-warning-500);
+    --x-danger:  var(--vc-color-error-500);
+    --x-info:    var(--vc-color-info-500);
+
+    --x-body-bg:    var(--vc-color-bg);
+    --x-body-color: var(--vc-color-fg);
+    --x-border:     var(--vc-color-border);
+}
+```
+
+Then mirror the dark-mode variant under `.dark`, bumping the shade up one tier (e.g. `-500` → `-400`) so the brand colors stay legible on dark backgrounds:
+
+```css
+.dark {
+    --x-primary: var(--vc-color-primary-400);
+    --x-success: var(--vc-color-success-400);
+    /* … */
+}
+```
+
+The `--vc-color-bg`/`--vc-color-fg`/`--vc-color-border` tokens already flip via `@vuecs/design`, so you don't need to redeclare those in `.dark` — your `:root` rebinding tracks them automatically.
+
+### Step 4 — Per-component overrides
+
+Many frameworks redeclare their semantic colors **inside per-variant component blocks** (e.g. Bootstrap's `.btn-primary { --bs-btn-bg: …; --bs-btn-hover-bg: … }`). Overriding `--bs-primary` alone doesn't reach those — you need to redeclare the per-component chain too:
+
+```css
+.x-btn-primary {
+    --x-btn-bg:           var(--vc-color-primary-600);
+    --x-btn-border-color: var(--vc-color-primary-600);
+    --x-btn-hover-bg:     var(--vc-color-primary-700);
+    /* ... */
+}
+```
+
+Repeat per `(component, variant)` cell. The Bootstrap bridge does this for `.btn-*`, `.btn-outline-*`, `.alert-*`, `.bg-*`, `.text-*`, `.border-*`, `.text-bg-*`, and `.bg-*-subtle` / `.text-*-emphasis` pairs.
+
+### Step 5 — Watch out for channel-decomposition
+
+Most frameworks decompose colors into per-channel variables for hover/active state math, and routing the resolved color through those channels means the named `--<framework>-X-background-color` token is **never read**:
+
+- Bootstrap derives focus-ring translucency via `rgba(var(--bs-primary-rgb), 0.5)` — the RGB triplet, not `--bs-primary` itself.
+- Bulma 1.0 sets `.button.is-primary { --bulma-button-h: var(--bulma-primary-h); }` and resolves the bg via `hsl(var(--bulma-button-h), …)` — entirely bypassing `--bulma-button-background-color`.
+
+Pure CSS cannot decompose a hex token into RGB or HSL channels, so per-component named-color overrides are **no-ops** for HSL/channel-driven frameworks like Bulma. Two workable mitigations:
+
+- **Direct property override (preferred).** Skip the named `--<framework>-X-background-color` token and override the **resolved** properties directly on each per-variant selector:
+
+  ```css
+  .button.is-primary {
+      background-color: var(--vc-color-primary-600);
+      border-color: var(--vc-color-primary-600);
+      color: var(--vc-color-on-primary);
+  }
+  .button.is-primary:hover {
+      background-color: var(--vc-color-primary-700);
+  }
+  ```
+
+  Specificity (0,2,0) beats the framework's base rule (0,1,0); no `!important` needed. Trade-off: framework auto-computed hover/active deltas are short-circuited; re-specify them explicitly with `-700` / `-800` shades. The Bulma bridge ships with this approach.
+
+- **JS palette-change hook.** Decompose the active hex into channels in JS (read shade → compute H/S/L or RGB) and write `--<framework>-primary-h/s/l` (or `-rgb`) back to the DOM. Most flexible — preserves auto-derived hover deltas — but adds runtime complexity and can't run during SSR. None of the shipped bridges include this today.
+
+Document whichever you pick in your bridge file's header so consumers know how to extend it.
+
+### Step 6 — Ship via a `style` conditional export
+
+Add the bridge file's path to your package's `package.json` under the `style` conditional export so consumers can write a bare `@import "@vuecs/theme-<framework>"`:
+
+```json
+{
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "style": "./assets/index.css",
+            "import": "./dist/index.mjs"
+        },
+        "./index.css": "./assets/index.css",
+        "./assets/index.css": "./assets/index.css"
+    },
+    "style": "./assets/index.css"
+}
+```
+
+The top-level `style` field is for older bundlers that don't read conditional exports; both forms point at the same file.
 
 ## Runtime palette switching
 
@@ -85,15 +296,14 @@ Tailwind utilities like `bg-neutral-500` use **Tailwind's** default `--color-neu
 
 **Practical implication:** use `bg-bg`, `text-fg`, `border-border` (semantic aliases — they DO follow `setPalette({ neutral: ... })`) instead of `bg-neutral-100`, `text-neutral-900`, `border-neutral-200` (raw Tailwind, doesn't follow palette).
 
-## Bootstrap bridges
+## Shipped bridges
 
-For Bootstrap consumers, `@vuecs/theme-bootstrap` ships a design-token bridge (`assets/index.css`) that maps `--bs-*` theme vars onto `--vc-color-*`:
+Two CSS-variable bridges ship in-tree as concrete worked examples of the pattern documented in [Bridging another CSS framework](#bridging-another-css-framework):
 
-```css
-@import "@vuecs/theme-bootstrap";  /* via the `style` conditional export */
-```
+- `@vuecs/theme-bootstrap` maps Bootstrap 5.3+'s `--bs-*` tokens onto `--vc-color-*`.
+- `@vuecs/theme-bulma` maps Bulma 1.0+'s `--bulma-*` tokens onto `--vc-color-*`.
 
-Bootstrap 5 components read `--bs-*` at runtime, so the bridge propagates `setPalette()` to Bootstrap components. Bootstrap 4's bridge is shipped for API parity but has limited reach — Bootstrap 4's component CSS is Sass-compiled to literal hex, so the bridge only affects consumer-authored rules.
+Both are reached via the bare `@import "@vuecs/theme-<name>"` form (resolves to `assets/index.css` via the `style` conditional export). Both ship with the same RGB/HSL-triplet limitation noted in step 5 above — hover/active lightness deltas keep the framework's default palette.
 
 ## Pure / SSR-safe APIs
 

--- a/docs/src/guide/design-tokens.md
+++ b/docs/src/guide/design-tokens.md
@@ -303,7 +303,7 @@ Two CSS-variable bridges ship in-tree as concrete worked examples of the pattern
 - `@vuecs/theme-bootstrap` maps Bootstrap 5.3+'s `--bs-*` tokens onto `--vc-color-*`.
 - `@vuecs/theme-bulma` maps Bulma 1.0+'s `--bulma-*` tokens onto `--vc-color-*`.
 
-Both are reached via the bare `@import "@vuecs/theme-<name>"` form (resolves to `assets/index.css` via the `style` conditional export). Both ship with the same RGB/HSL-triplet limitation noted in step 5 above — hover/active lightness deltas keep the framework's default palette.
+Both are reached via the bare `@import "@vuecs/theme-<name>"` form (resolves to `assets/index.css` via the `style` conditional export). Both ship with the same RGB/HSL-triplet limitation noted in step 5 above — they re-specify hover (`-700`) and active (`-800`) lightness deltas explicitly per variant, so the framework's auto-derived hover/active deltas don't apply.
 
 ## Pure / SSR-safe APIs
 

--- a/docs/src/themes/bulma.md
+++ b/docs/src/themes/bulma.md
@@ -1,0 +1,64 @@
+# Bulma theme
+
+`@vuecs/theme-bulma` ships Bulma 1.0+ class mappings for every component, plus an optional CSS bridge that maps `--bulma-*` theme variables onto the `--vc-color-*` design tokens for runtime palette switching.
+
+```bash
+npm install @vuecs/theme-bulma bulma
+```
+
+## Wire it up
+
+```ts
+// main.ts
+import vuecs from '@vuecs/core';
+import bulma from '@vuecs/theme-bulma';
+
+app.use(vuecs, { themes: [bulma()] });
+```
+
+```css
+/* styles.css */
+@import "bulma/css/bulma.css";
+@import "@vuecs/theme-bulma";  /* optional: design-token bridge */
+@import "@vuecs/design";        /* optional: enable runtime palette switching */
+```
+
+The `@import "@vuecs/theme-bulma"` resolves to the package's bridge CSS (`assets/index.css`) via the `style` conditional export.
+
+## What the bridge does
+
+The bridge file maps Bulma's CSS theme variables onto vuecs design tokens:
+
+```css
+:root {
+    --bulma-primary: var(--vc-color-primary-500);
+    --bulma-success: var(--vc-color-success-500);
+    /* ... */
+}
+```
+
+Bulma 1.0 components read `--bulma-*` at runtime, so calling `setPalette({ primary: 'green' })` re-tints **both** vuecs components and Bulma-native components in real time.
+
+## Mapping notes
+
+A few places where Bulma's vocabulary diverges from the Bootstrap/Tailwind themes — useful context if you mix Bulma classes with vuecs components in your own code:
+
+- **`ghost` / `link` button variants are reversed.** Bulma's `is-ghost` is the underlined-anchor button (matching vuecs `link`); Bulma's `is-text` is the borderless transparent button (matching vuecs `ghost`). The mapping looks inverted at a glance but reads naturally in Bulma's own vocabulary.
+- **DropdownMenu / FormSelect content uses `.dropdown-content`, not `.dropdown-menu`.** Bulma gates `.dropdown-menu` visibility on the parent `.dropdown.is-active` wrapper. Reka renders the content via portal — there is no parent — so the theme applies `.dropdown-content` (the inner box-styled element) directly.
+- **`.tag` has only three sizes (default, `is-medium`, `is-large`).** vuecs's `sm/md/lg` map to default / `is-medium` / `is-large` — `<VCTag size="sm">` lands on Bulma's smallest tag.
+- **`.dark` is the dark-mode toggle.** Bulma 1.0 ships a `[data-theme="dark"]` mode out of the box; the bridge only flips on `.dark` (vuecs convention). Pick one source of truth.
+
+## Limitations
+
+- **HSL-channel-derived utility classes don't track palette switches.** Bulma's per-variant components (`.button.is-primary`, `.tag.is-primary`, …) compose colors via HSL channel vars (`--bulma-button-h/s/l`) rather than named `--bulma-X-background-color` tokens. The bridge works around this by overriding the resolved `background-color` / `border-color` / `color` properties directly on each per-variant selector — `setPalette()` re-tints those correctly. But channel-driven utility classes (`has-background-light`, `has-text-grey`, `has-background-dark`) keep Bulma's default palette; the matrix uses them only where the default is visually acceptable (avatar bg, stepper indicator default state, tooltip dark bg).
+- **Hover/active lightness deltas don't auto-derive.** Bulma normally interpolates hover/active states via `calc(var(--bulma-<color>-l) ± 5%)`. Because the bridge overrides the resolved color directly, those deltas are short-circuited; the bridge re-specifies hover (`-700`) and active (`-800`) shades explicitly per variant. Visually equivalent — just a different mechanism.
+- **Switch / stepper extensions target native `<input>` markup; Reka renders `<button role="…">`.** The theme's variant matrix layers Bulma utility classes on top of the structural `vc-form-{checkbox,switch,radio}` rules from `@vuecs/forms` and the structural stepper rules from `@vuecs/navigation` — those packages own shape and `data-state` checked-color visualization for these widgets.
+
+## When to drop the bridge
+
+If you don't care about runtime palette switching and want Bulma's stock colors as-is, skip the `@import "@vuecs/theme-bulma"` and `@import "@vuecs/design"` lines. The component classes still resolve through the theme; only the dynamic-color layer is opt-out.
+
+## See also
+
+- [Design Tokens](/guide/design-tokens) — what the bridge maps onto, including the bridging guide for additional CSS frameworks
+- [Theme System](/guide/theme-system) — layered resolution

--- a/docs/src/themes/bulma.md
+++ b/docs/src/themes/bulma.md
@@ -19,8 +19,8 @@ app.use(vuecs, { themes: [bulma()] });
 ```css
 /* styles.css */
 @import "bulma/css/bulma.css";
-@import "@vuecs/theme-bulma";  /* optional: design-token bridge */
 @import "@vuecs/design";        /* optional: enable runtime palette switching */
+@import "@vuecs/theme-bulma";   /* optional: design-token bridge */
 ```
 
 The `@import "@vuecs/theme-bulma"` resolves to the package's bridge CSS (`assets/index.css`) via the `style` conditional export.

--- a/docs/src/themes/index.md
+++ b/docs/src/themes/index.md
@@ -19,6 +19,7 @@ Icons used to live as a "theme" entry, but as of vuecs 3.x they are configured s
 |-------|---------|--------------|
 | [Tailwind](/themes/tailwind) | `@vuecs/theme-tailwind` | Tailwind v4 utility classes for every component, paired with the design tokens |
 | [Bootstrap](/themes/bootstrap) | `@vuecs/theme-bootstrap` | Bootstrap 5.x classes + optional `--bs-*` → `--vc-color-*` bridge |
+| [Bulma](/themes/bulma) | `@vuecs/theme-bulma` | Bulma 1.0+ classes + optional `--bulma-*` → `--vc-color-*` bridge |
 
 ## Merge semantics
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,8 +56,10 @@
                 "@vuecs/overlays": "*",
                 "@vuecs/pagination": "*",
                 "@vuecs/theme-bootstrap": "*",
+                "@vuecs/theme-bulma": "*",
                 "@vuecs/theme-tailwind": "*",
                 "@vuecs/timeago": "*",
+                "bulma": "^1.0.4",
                 "tailwindcss": "^4.2.4",
                 "vitepress": "^1.6.3",
                 "vue": "^3.5.33"
@@ -7768,6 +7770,10 @@
             "resolved": "themes/bootstrap",
             "link": true
         },
+        "node_modules/@vuecs/theme-bulma": {
+            "resolved": "themes/bulma",
+            "link": true
+        },
         "node_modules/@vuecs/theme-tailwind": {
             "resolved": "themes/tailwind",
             "link": true
@@ -8984,6 +8990,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/bulma": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/bulma/-/bulma-1.0.4.tgz",
+            "integrity": "sha512-Ffb6YGXDiZYX3cqvSbHWqQ8+LkX6tVoTcZuVB3lm93sbAVXlO0D6QlOTMnV6g18gILpAXqkG2z9hf9z4hCjz2g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/bundle-name": {
             "version": "4.1.0",
@@ -22288,6 +22301,20 @@
             "name": "@vuecs/theme-bootstrap-v5",
             "version": "2.0.1",
             "extraneous": true,
+            "license": "Apache-2.0",
+            "devDependencies": {
+                "@vuecs/core": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=22.0.0"
+            },
+            "peerDependencies": {
+                "@vuecs/core": "^2.0.0"
+            }
+        },
+        "themes/bulma": {
+            "name": "@vuecs/theme-bulma",
+            "version": "0.0.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@vuecs/core": "^2.0.0"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,6 +20,7 @@
         "packages/overlays": {"component": "overlays" },
         "packages/pagination": {"component": "pagination" },
         "themes/bootstrap": {"component": "theme-bootstrap" },
+        "themes/bulma": {"component": "theme-bulma" },
         "themes/tailwind": {"component": "theme-tailwind" },
         "icons/font-awesome": {"component": "icons-font-awesome" },
         "icons/lucide": {"component": "icons-lucide" },

--- a/themes/bulma/CHANGELOG.md
+++ b/themes/bulma/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/themes/bulma/LICENSE
+++ b/themes/bulma/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021-2026 Peter Placzek
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/themes/bulma/README.md
+++ b/themes/bulma/README.md
@@ -1,0 +1,18 @@
+# @vuecs/theme-bulma
+
+[![npm version](https://badge.fury.io/js/@vuecs%2Ftheme-bulma.svg)](https://badge.fury.io/js/@vuecs%2Ftheme-bulma)
+[![main](https://github.com/Tada5hi/vuecs/actions/workflows/main.yml/badge.svg)](https://github.com/Tada5hi/vuecs/actions/workflows/main.yml)
+
+Bulma 1.0+ theme for vuecs components. Ships an optional `--bulma-*` → `--vc-color-*` bridge so `setPalette()` re-tints both vuecs and Bulma-native components in real time.
+
+Full documentation: **[vuecs.dev/themes/bulma](https://vuecs.dev/themes/bulma)**
+
+```bash
+npm install @vuecs/theme-bulma bulma
+```
+
+## License
+
+Made with 💚
+
+Published under [Apache 2.0 License](./LICENSE).

--- a/themes/bulma/assets/index.css
+++ b/themes/bulma/assets/index.css
@@ -321,7 +321,7 @@
 
 .vc-badge-outline {
     background-color: transparent;
-    border: 1px solid currentColor;
+    border: 1px solid currentcolor;
 }
 .vc-badge-outline-primary { border-color: var(--vc-color-primary-600); color: var(--vc-color-primary-700); }
 .vc-badge-outline-neutral { border-color: var(--vc-color-border);      color: var(--vc-color-fg); }
@@ -338,20 +338,58 @@
  * xl=1140) so the same demo content reads consistently across themes;
  * md keeps the unsized default which centers via the theme's
  * `.modal-content` base padding.
+ *
+ * Reka renders the overlay (`DialogOverlay`) and panel (`DialogContent`)
+ * as two standalone portal nodes — there is no surrounding `.modal`
+ * wrapper to provide Bulma's flex-centered layout. Re-implement the
+ * fixed-position centering on the structural `vc-modal-content` class
+ * directly, and pin the overlay full-screen.
  * ──────────────────────────────────────────────────────────────────────── */
+
+.modal-background {
+    position: fixed;
+    inset: 0;
+}
+
+.vc-modal-content {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    margin: 0;
+    /* Bulma's `.modal-content` ships no border-radius (it's intended
+       to be used with `.modal-card`'s rounded chrome instead). Add
+       radius via the design-system token so the modal panel reads as
+       a card. */
+    border-radius: var(--vc-radius-lg);
+}
 
 .vc-modal-content.modal-sm { max-width: 300px;  width: calc(100% - 1rem); }
 .vc-modal-content.modal-lg { max-width: 800px;  width: calc(100% - 1rem); }
 .vc-modal-content.modal-xl { max-width: 1140px; width: calc(100% - 1rem); }
 
-/* Bulma's `.modal-content` ships no border-radius (it's intended to be
-   used with `.modal-card`'s rounded chrome instead). Add radius via the
-   design-system token so the modal panel reads as a card. Tooltip same
-   reasoning — Bulma's `[data-tooltip]` is a CSS pseudo-element on a
-   data attribute, not a class-based panel, so our class-based tooltip
-   needs explicit radius. */
-.vc-modal-content { border-radius: var(--vc-radius-lg); }
+/* Tooltip same border-radius reasoning — Bulma's `[data-tooltip]` is a
+   CSS pseudo-element on a data attribute, not a class-based panel, so
+   our class-based tooltip needs explicit radius. */
 .vc-tooltip-content { border-radius: var(--vc-radius-md); }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * @vuecs/overlays close-icon corner positioning.
+ *
+ * Bulma's `.delete` is `position: relative` by default — fine inline,
+ * wrong for our `closeIcon` slot which is meant to dock the button into
+ * the panel's top-right corner. The structural `vc-modal-close-icon` /
+ * `vc-popover-close-icon` classes (from component defaults) give us a
+ * scoped hook to apply corner-positioning without affecting standalone
+ * `.delete` buttons elsewhere on the page.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.vc-modal-content .vc-modal-close-icon,
+.vc-popover-close-icon {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+}
 
 /* ────────────────────────────────────────────────────────────────────────────
  * @vuecs/navigation Stepper — Bulma class strings can't carry

--- a/themes/bulma/assets/index.css
+++ b/themes/bulma/assets/index.css
@@ -1,0 +1,407 @@
+/*!
+ * @vuecs/theme-bulma — Design-token bridge + structural gap-fills
+ *
+ * Wires Bulma 1.0+'s CSS variables onto vuecs design-system tokens
+ * (`--vc-color-*`), and adds the structural rules vuecs components
+ * need that core Bulma doesn't ship (overlay panel chrome, stepper
+ * data-state visualization, modal sizing, switch / slider colors).
+ *
+ * Import order:
+ *   1. Bulma CSS (provides the default --bulma-* values).
+ *   2. @vuecs/design/index.css (provides --vc-color-*).
+ *   3. This bridge (overrides --bulma-* to reference --vc-color-*).
+ *
+ * What this covers:
+ *   - The global `--bulma-primary` / `-link` / `-info` / `-success` /
+ *     `-warning` / `-danger` tokens — read directly by anything you
+ *     reference via `var(--bulma-primary)` yourself.
+ *   - Resolved colors on every per-variant selector: `.button.is-X`,
+ *     `.tag.is-X`, `.notification.is-X`, `.pagination-link.is-current`.
+ *
+ * Why direct property overrides (not `--bulma-*-background-color`):
+ *
+ *   Bulma 1.0 routes per-variant theming through HSL **channel** vars,
+ *   not the named `--bulma-button-background-color`-style tokens. A
+ *   `.button.is-primary` does NOT set the bg-color var — it sets
+ *   `--bulma-button-h/s/l` and the base `.button` rule resolves
+ *   `background-color: hsl(--bulma-button-h, …)`. Pure CSS can't
+ *   decompose `var(--vc-color-primary-600)` into H/S/L channels, so
+ *   we can't bridge that path. Instead we override the **resolved**
+ *   `background-color` / `border-color` / `color` properties directly
+ *   on each per-variant selector. Specificity 0,2,0 beats Bulma's base
+ *   `.button` (0,1,0); no `!important` needed.
+ *
+ *   Trade-off: Bulma's auto-computed hover/active lightness deltas are
+ *   short-circuited. We re-specify hover (`-700`) and active (`-800`)
+ *   shades manually per variant.
+ *
+ * Limitations:
+ *   - Utility classes that read HSL channels (`.has-background-light`,
+ *     `.has-text-grey`, `.has-background-dark`) keep Bulma's default
+ *     palette — `setPalette()` doesn't reach them. The matrix uses
+ *     these utilities sparingly (avatar bg, stepper indicator default,
+ *     tooltip dark bg) where Bulma's defaults are visually acceptable.
+ *   - Bulma's built-in `prefers-color-scheme: dark` block toggles
+ *     `[data-theme="dark"]` semantics. This bridge uses the `.dark`
+ *     class (vuecs design-system convention); pick one source of truth.
+ */
+
+:root {
+    --bulma-primary: var(--vc-color-primary-500);
+    --bulma-link: var(--vc-color-info-500);
+    --bulma-info: var(--vc-color-info-500);
+    --bulma-success: var(--vc-color-success-500);
+    --bulma-warning: var(--vc-color-warning-500);
+    --bulma-danger: var(--vc-color-error-500);
+
+    /* Bulma's neutral ramp (named "grey") — map to design-system shades. */
+    --bulma-grey-darker:  var(--vc-color-neutral-800);
+    --bulma-grey-dark:    var(--vc-color-neutral-700);
+    --bulma-grey:         var(--vc-color-neutral-600);
+    --bulma-grey-light:   var(--vc-color-neutral-400);
+    --bulma-grey-lighter: var(--vc-color-neutral-200);
+    --bulma-grey-lightest: var(--vc-color-neutral-100);
+
+    --bulma-light: var(--vc-color-neutral-100);
+    --bulma-dark:  var(--vc-color-neutral-900);
+
+    /* Page chrome */
+    --bulma-scheme-main:     var(--vc-color-bg);
+    --bulma-scheme-main-bis: var(--vc-color-bg-muted);
+    --bulma-scheme-main-ter: var(--vc-color-bg-elevated);
+    --bulma-background:      var(--vc-color-bg-muted);
+    --bulma-text:            var(--vc-color-fg);
+    --bulma-text-strong:     var(--vc-color-fg);
+    --bulma-text-light:      var(--vc-color-fg-muted);
+    --bulma-text-weak:       var(--vc-color-fg-muted);
+    --bulma-border:          var(--vc-color-border);
+    --bulma-border-weak:     var(--vc-color-border-muted);
+    --bulma-body-background-color: var(--vc-color-bg);
+    --bulma-body-color:      var(--vc-color-fg);
+}
+
+.dark {
+    /* Only the per-color shades flip — semantic aliases (`--vc-color-fg`,
+       `--vc-color-bg`, `--vc-color-border`, …) flip themselves in
+       @vuecs/design's `.dark` block, so the scheme/text/border bindings
+       in :root above already track dark mode. We just bump the active
+       color shade to `-400` (matching the design-system's own
+       `--vc-color-ring` dark-mode flip — gives a brighter primary on
+       dark bg). */
+    --bulma-primary: var(--vc-color-primary-400);
+    --bulma-link:    var(--vc-color-info-400);
+    --bulma-info:    var(--vc-color-info-400);
+    --bulma-success: var(--vc-color-success-400);
+    --bulma-warning: var(--vc-color-warning-400);
+    --bulma-danger:  var(--vc-color-error-400);
+
+    --bulma-light: var(--vc-color-neutral-800);
+    --bulma-dark:  var(--vc-color-neutral-100);
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Per-variant button overrides.
+ *
+ * Critical Bulma 1.0 cascade detail: `.button.is-<color>` does NOT use
+ * `--bulma-button-background-color`. Bulma defines the modifier as
+ *
+ *     .button.is-primary {
+ *         --bulma-button-h: var(--bulma-primary-h);
+ *         --bulma-button-s: var(--bulma-primary-s);
+ *         --bulma-button-l: var(--bulma-primary-l);
+ *     }
+ *
+ * and the base `.button` rule resolves bg/border/color via
+ *     background-color: hsl(var(--bulma-button-h), …, calc(var(--bulma-button-l) + …));
+ *
+ * So overriding `--bulma-button-background-color` is a no-op — Bulma
+ * recomputes the color from HSL channels. The viable approaches are
+ * either (a) override the HSL channel vars (requires per-shade HSL
+ * decomposition that we can't compute in pure CSS), or (b) override the
+ * resolved properties directly. We pick (b): set `background-color` /
+ * `border-color` / `color` on each `.is-<color>` selector. Specificity
+ * 0,2,0 beats Bulma's `.button` (0,1,0) so no `!important` is needed.
+ *
+ * Trade-off: Bulma's auto-computed hover/active lightness deltas no
+ * longer apply; we re-specify them explicitly with `-700`/`-800` shades.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/* solid */
+.button.is-primary { background-color: var(--vc-color-primary-600); border-color: var(--vc-color-primary-600); color: var(--vc-color-on-primary); }
+.button.is-info    { background-color: var(--vc-color-info-600);    border-color: var(--vc-color-info-600);    color: var(--vc-color-on-info); }
+.button.is-success { background-color: var(--vc-color-success-600); border-color: var(--vc-color-success-600); color: var(--vc-color-on-success); }
+.button.is-warning { background-color: var(--vc-color-warning-600); border-color: var(--vc-color-warning-600); color: var(--vc-color-on-warning); }
+.button.is-danger  { background-color: var(--vc-color-error-600);   border-color: var(--vc-color-error-600);   color: var(--vc-color-on-error); }
+
+.button.is-primary:hover, .button.is-primary.is-hovered { background-color: var(--vc-color-primary-700); border-color: var(--vc-color-primary-700); }
+.button.is-info:hover,    .button.is-info.is-hovered    { background-color: var(--vc-color-info-700);    border-color: var(--vc-color-info-700); }
+.button.is-success:hover, .button.is-success.is-hovered { background-color: var(--vc-color-success-700); border-color: var(--vc-color-success-700); }
+.button.is-warning:hover, .button.is-warning.is-hovered { background-color: var(--vc-color-warning-700); border-color: var(--vc-color-warning-700); }
+.button.is-danger:hover,  .button.is-danger.is-hovered  { background-color: var(--vc-color-error-700);   border-color: var(--vc-color-error-700); }
+
+.button.is-primary:active, .button.is-primary.is-active { background-color: var(--vc-color-primary-800); border-color: var(--vc-color-primary-800); }
+.button.is-info:active,    .button.is-info.is-active    { background-color: var(--vc-color-info-800);    border-color: var(--vc-color-info-800); }
+.button.is-success:active, .button.is-success.is-active { background-color: var(--vc-color-success-800); border-color: var(--vc-color-success-800); }
+.button.is-warning:active, .button.is-warning.is-active { background-color: var(--vc-color-warning-800); border-color: var(--vc-color-warning-800); }
+.button.is-danger:active,  .button.is-danger.is-active  { background-color: var(--vc-color-error-800);   border-color: var(--vc-color-error-800); }
+
+/* `.is-light` shade modifier on a colored button — tinted bg, colored
+   text. Matches BS5's `*-subtle` / `*-emphasis` token pair. The 0,3,0
+   specificity beats both `.button` and `.button.is-<color>`. */
+.button.is-primary.is-light { background-color: var(--vc-color-primary-100); border-color: transparent; color: var(--vc-color-primary-700); }
+.button.is-info.is-light    { background-color: var(--vc-color-info-100);    border-color: transparent; color: var(--vc-color-info-700); }
+.button.is-success.is-light { background-color: var(--vc-color-success-100); border-color: transparent; color: var(--vc-color-success-700); }
+.button.is-warning.is-light { background-color: var(--vc-color-warning-100); border-color: transparent; color: var(--vc-color-warning-700); }
+.button.is-danger.is-light  { background-color: var(--vc-color-error-100);   border-color: transparent; color: var(--vc-color-error-700); }
+
+.button.is-primary.is-light:hover { background-color: var(--vc-color-primary-200); }
+.button.is-info.is-light:hover    { background-color: var(--vc-color-info-200); }
+.button.is-success.is-light:hover { background-color: var(--vc-color-success-200); }
+.button.is-warning.is-light:hover { background-color: var(--vc-color-warning-200); }
+.button.is-danger.is-light:hover  { background-color: var(--vc-color-error-200); }
+
+/* `.is-outlined` — transparent bg, colored text + border, fills on hover. */
+.button.is-primary.is-outlined { background-color: transparent; border-color: var(--vc-color-primary-600); color: var(--vc-color-primary-700); }
+.button.is-info.is-outlined    { background-color: transparent; border-color: var(--vc-color-info-600);    color: var(--vc-color-info-700); }
+.button.is-success.is-outlined { background-color: transparent; border-color: var(--vc-color-success-600); color: var(--vc-color-success-700); }
+.button.is-warning.is-outlined { background-color: transparent; border-color: var(--vc-color-warning-600); color: var(--vc-color-warning-700); }
+.button.is-danger.is-outlined  { background-color: transparent; border-color: var(--vc-color-error-600);   color: var(--vc-color-error-700); }
+
+.button.is-primary.is-outlined:hover { background-color: var(--vc-color-primary-600); color: var(--vc-color-on-primary); }
+.button.is-info.is-outlined:hover    { background-color: var(--vc-color-info-600);    color: var(--vc-color-on-info); }
+.button.is-success.is-outlined:hover { background-color: var(--vc-color-success-600); color: var(--vc-color-on-success); }
+.button.is-warning.is-outlined:hover { background-color: var(--vc-color-warning-600); color: var(--vc-color-on-warning); }
+.button.is-danger.is-outlined:hover  { background-color: var(--vc-color-error-600);   color: var(--vc-color-on-error); }
+
+/* `.is-light` and `.is-dark` as standalone color modifiers — used by
+   our matrix for `<VCButton variant="soft" color="neutral">` and
+   `<VCBadge variant="solid" color="neutral">`. Bulma's defaults
+   compute these via `--bulma-light-*` / `--bulma-dark-*` HSL channels;
+   override with neutral shades so they read consistently in light and
+   dark mode (the design tokens flip themselves). */
+.button.is-light:not(.is-primary):not(.is-info):not(.is-success):not(.is-warning):not(.is-danger):not(.is-dark) {
+    background-color: var(--vc-color-bg-elevated);
+    border-color: var(--vc-color-border);
+    color: var(--vc-color-fg);
+}
+.button.is-light:not(.is-primary):not(.is-info):not(.is-success):not(.is-warning):not(.is-danger):not(.is-dark):hover {
+    background-color: var(--vc-color-bg-muted);
+}
+.button.is-dark {
+    background-color: var(--vc-color-neutral-800);
+    border-color: var(--vc-color-neutral-800);
+    color: var(--vc-color-on-neutral);
+}
+.button.is-dark:hover { background-color: var(--vc-color-neutral-900); border-color: var(--vc-color-neutral-900); }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Tag + notification per-variant overrides.
+ * Same HSL-channel architecture as `.button` — direct property
+ * overrides are required (the `--bulma-X-background-color` named vars
+ * are unread).
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.tag.is-primary { background-color: var(--vc-color-primary-600); color: var(--vc-color-on-primary); }
+.tag.is-info    { background-color: var(--vc-color-info-600);    color: var(--vc-color-on-info); }
+.tag.is-success { background-color: var(--vc-color-success-600); color: var(--vc-color-on-success); }
+.tag.is-warning { background-color: var(--vc-color-warning-600); color: var(--vc-color-on-warning); }
+.tag.is-danger  { background-color: var(--vc-color-error-600);   color: var(--vc-color-on-error); }
+
+.tag.is-primary.is-light { background-color: var(--vc-color-primary-100); color: var(--vc-color-primary-700); }
+.tag.is-info.is-light    { background-color: var(--vc-color-info-100);    color: var(--vc-color-info-700); }
+.tag.is-success.is-light { background-color: var(--vc-color-success-100); color: var(--vc-color-success-700); }
+.tag.is-warning.is-light { background-color: var(--vc-color-warning-100); color: var(--vc-color-warning-700); }
+.tag.is-danger.is-light  { background-color: var(--vc-color-error-100);   color: var(--vc-color-error-700); }
+
+/* `.is-light` and `.is-dark` standalone — used by `<VCBadge>`'s
+   `(soft, neutral)` and `(solid, neutral)` cells. Bulma's defaults rely
+   on `--bulma-light-h/s/l/invert-l` HSL channels, which we don't
+   re-derive when overriding `--bulma-light` to a hex token at `:root`
+   — so the resolved color is broken. Override the resolved properties
+   directly using the `bg-elevated` / `fg` alias pair so BOTH halves
+   flip together under `.dark` (a `neutral-100` bg + `fg` text would
+   give white-on-white in dark mode because `neutral-100` doesn't flip
+   but `fg` does). */
+.tag.is-light:not(.is-primary):not(.is-info):not(.is-success):not(.is-warning):not(.is-danger):not(.is-dark) {
+    background-color: var(--vc-color-bg-elevated);
+    color: var(--vc-color-fg);
+}
+.tag.is-dark {
+    background-color: var(--vc-color-neutral-800);
+    color: var(--vc-color-on-neutral);
+}
+
+.notification.is-primary { background-color: var(--vc-color-primary-600); color: var(--vc-color-on-primary); }
+.notification.is-info    { background-color: var(--vc-color-info-600);    color: var(--vc-color-on-info); }
+.notification.is-success { background-color: var(--vc-color-success-600); color: var(--vc-color-on-success); }
+.notification.is-warning { background-color: var(--vc-color-warning-600); color: var(--vc-color-on-warning); }
+.notification.is-danger  { background-color: var(--vc-color-error-600);   color: var(--vc-color-on-error); }
+
+.notification.is-primary.is-light { background-color: var(--vc-color-primary-100); color: var(--vc-color-primary-700); }
+.notification.is-info.is-light    { background-color: var(--vc-color-info-100);    color: var(--vc-color-info-700); }
+.notification.is-success.is-light { background-color: var(--vc-color-success-100); color: var(--vc-color-success-700); }
+.notification.is-warning.is-light { background-color: var(--vc-color-warning-100); color: var(--vc-color-warning-800); }
+.notification.is-danger.is-light  { background-color: var(--vc-color-error-100);   color: var(--vc-color-error-700); }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * `has-background-*` / `has-text-*` utilities.
+ * Bulma 1.0 reads these from `var(--bulma-<color>)` directly, so the
+ * :root rebinding above already propagates. We also redeclare here so
+ * the resolved value matches the design palette's `-600` shade
+ * (the :root rebinding uses `-500` for visual consistency with Bulma
+ * default brightness).
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.has-background-primary { background-color: var(--vc-color-primary-600); }
+.has-background-info    { background-color: var(--vc-color-info-600); }
+.has-background-success { background-color: var(--vc-color-success-600); }
+.has-background-warning { background-color: var(--vc-color-warning-600); }
+.has-background-danger  { background-color: var(--vc-color-error-600); }
+
+.has-text-primary { color: var(--vc-color-primary-600); }
+.has-text-info    { color: var(--vc-color-info-600); }
+.has-text-success { color: var(--vc-color-success-600); }
+.has-text-warning { color: var(--vc-color-warning-600); }
+.has-text-danger  { color: var(--vc-color-error-600); }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Form controls — `.input`, `.textarea`, `.select`.
+ * Bulma's focus state reads `var(--bulma-input-focus-border-color)`,
+ * which defaults to `var(--bulma-link)`. Rebind to primary so vuecs
+ * inputs land on the design-system primary on focus.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.input,
+.textarea,
+.select select {
+    --bulma-input-focus-border-color: var(--vc-color-primary-500);
+    --bulma-input-focus-shadow-alpha: 0.25;
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Pagination — `.pagination-link.is-current` reads `--bulma-link`;
+ * rebind to primary for visual consistency with the rest of the theme.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.pagination-link.is-current,
+.pagination-link.is-selected {
+    /* Direct property override — Bulma uses HSL channels here too. */
+    background-color: var(--vc-color-primary-600);
+    border-color: var(--vc-color-primary-600);
+    color: var(--vc-color-on-primary);
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Progress bar — same primary-600 alignment.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.progress {
+    --bulma-progress-value-background-color: var(--vc-color-primary-600);
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * @vuecs/list shorthand-mode wrappers — same as the BS bridge: hide
+ * empty wrappers so the layout doesn't sprout extra rows.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.vc-list-header:empty,
+.vc-list-body:empty,
+.vc-list-footer:empty {
+    display: none;
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * @vuecs/elements Badge — outline variant.
+ * Bulma 1.0 has no `.tag.is-outlined` in core. The variant matrix tags
+ * outline cells with the marker classes `vc-badge-outline` +
+ * `vc-badge-outline-<color>`; this block paints them via design-system
+ * tokens. Borders use `-600` (matches solid bg saturation), text uses
+ * `-700` for emphasis.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.vc-badge-outline {
+    background-color: transparent;
+    border: 1px solid currentColor;
+}
+.vc-badge-outline-primary { border-color: var(--vc-color-primary-600); color: var(--vc-color-primary-700); }
+.vc-badge-outline-neutral { border-color: var(--vc-color-border);      color: var(--vc-color-fg); }
+.vc-badge-outline-success { border-color: var(--vc-color-success-600); color: var(--vc-color-success-700); }
+.vc-badge-outline-warning { border-color: var(--vc-color-warning-600); color: var(--vc-color-warning-700); }
+.vc-badge-outline-error   { border-color: var(--vc-color-error-600);   color: var(--vc-color-error-700); }
+.vc-badge-outline-info    { border-color: var(--vc-color-info-600);    color: var(--vc-color-info-700); }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * @vuecs/overlays Modal — Bulma's `.modal-content` accepts no native
+ * size modifiers (unlike Bootstrap's `.modal-dialog` family). Re-implement
+ * the width tier so the theme's size variants take effect on our
+ * compound shape. Defaults match Bootstrap's tiers (sm=300, lg=800,
+ * xl=1140) so the same demo content reads consistently across themes;
+ * md keeps the unsized default which centers via the theme's
+ * `.modal-content` base padding.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.vc-modal-content.modal-sm { max-width: 300px;  width: calc(100% - 1rem); }
+.vc-modal-content.modal-lg { max-width: 800px;  width: calc(100% - 1rem); }
+.vc-modal-content.modal-xl { max-width: 1140px; width: calc(100% - 1rem); }
+
+/* Bulma's `.modal-content` ships no border-radius (it's intended to be
+   used with `.modal-card`'s rounded chrome instead). Add radius via the
+   design-system token so the modal panel reads as a card. Tooltip same
+   reasoning — Bulma's `[data-tooltip]` is a CSS pseudo-element on a
+   data attribute, not a class-based panel, so our class-based tooltip
+   needs explicit radius. */
+.vc-modal-content { border-radius: var(--vc-radius-lg); }
+.vc-tooltip-content { border-radius: var(--vc-radius-md); }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * @vuecs/navigation Stepper — Bulma class strings can't carry
+ * `[data-state=…]` attribute selectors, so the theme's
+ * `.has-background-light` / `.has-text-grey` apply uniformly to every
+ * step. Differentiate active + completed states here. Both use primary
+ * so the trail-of-progress reads as one continuous run (matches the
+ * Tailwind theme).
+ *
+ * No `!important` needed: Bulma 1.0 dropped most `!important` flooding
+ * from utility classes (unlike Bootstrap's `.bg-light` etc.), so plain
+ * attribute-selector specificity wins against the utility classes the
+ * theme strings emit.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.vc-stepper-item[data-state="active"] .vc-stepper-indicator,
+.vc-stepper-item[data-state="completed"] .vc-stepper-indicator {
+    background-color: var(--vc-color-primary-600);
+    border-color: var(--vc-color-primary-600);
+    color: var(--vc-color-on-primary);
+}
+
+.vc-stepper-item[data-state="active"] .vc-stepper-title,
+.vc-stepper-item[data-state="completed"] .vc-stepper-title {
+    color: var(--vc-color-fg);
+}
+
+.vc-stepper-separator[data-state="completed"] {
+    background-color: var(--vc-color-primary-600);
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * @vuecs/forms FormNumber — Bulma's `.button` class ships with
+ * `border: 1px solid …` and a fixed `height: var(--bulma-control-height)`.
+ * Our `<VCFormNumber>` decrement / increment slots receive `class="button"`
+ * from the theme so the visual reads "buttoned up", but the structural
+ * `.vc-form-number-{decrement,increment}` rules deliberately drop borders
+ * (the parent `.vc-form-number` carries the single outer border + radius
+ * + overflow:hidden). Bulma's per-class border ends up showing as a
+ * vertical hairline against the input — strip it back here. Height also
+ * needs to flex with the input, not lock to control-height.
+ *
+ * Same rationale for `.vc-form-number-input` carrying `.input` — its
+ * border + height fight the structural shell.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.vc-form-number .button,
+.vc-form-number .input {
+    border: 0;
+    box-shadow: none;
+    height: auto;
+    border-radius: 0;
+}

--- a/themes/bulma/package.json
+++ b/themes/bulma/package.json
@@ -1,0 +1,57 @@
+{
+    "name": "@vuecs/theme-bulma",
+    "version": "0.0.0",
+    "type": "module",
+    "description": "Bulma theme for vuecs components. Targets Bulma 1.0+ (CSS-variable-based theming); the version number tracks vuecs theme breaking changes, not Bulma's.",
+    "exports": {
+        "./package.json": "./package.json",
+        ".": {
+            "types": "./dist/index.d.ts",
+            "style": "./assets/index.css",
+            "import": "./dist/index.mjs"
+        },
+        "./index.css": "./assets/index.css",
+        "./assets/index.css": "./assets/index.css"
+    },
+    "style": "./assets/index.css",
+    "files": [
+        "dist",
+        "assets"
+    ],
+    "sideEffects": [
+        "./assets/*.css"
+    ],
+    "keywords": [
+        "vuecs",
+        "theme",
+        "bulma"
+    ],
+    "author": {
+        "name": "Peter Placzek",
+        "email": "contact@tada5hi.net",
+        "url": "https://tada5hi.net"
+    },
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/tada5hi/vuecs.git",
+        "directory": "themes/bulma"
+    },
+    "scripts": {
+        "build:js": "tsdown",
+        "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
+        "build": "rimraf dist && npm run build:js && npm run build:types"
+    },
+    "devDependencies": {
+        "@vuecs/core": "^2.0.0"
+    },
+    "peerDependencies": {
+        "@vuecs/core": "^2.0.0"
+    },
+    "engines": {
+        "node": ">=22.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/themes/bulma/src/index.ts
+++ b/themes/bulma/src/index.ts
@@ -1,0 +1,648 @@
+import type { Theme } from '@vuecs/core';
+
+/**
+ * Bulma theme for vuecs components.
+ *
+ * Targets Bulma 1.0+ (CSS-variable-based theming). The companion
+ * `assets/index.css` bridges `--bulma-*` onto `--vc-color-*` so palette
+ * switches propagate to native Bulma elements alongside vuecs ones.
+ *
+ * Two notable mapping decisions vs. the Bootstrap theme:
+ *   - **`ghost` / `link` variants are reversed.** Bulma's `is-ghost`
+ *     ships an underlined hyperlink-style button (matching our `link`);
+ *     Bulma's `is-text` ships a borderless transparent button
+ *     (matching our `ghost`). The mapping here looks inverted at a
+ *     glance, but it's the natural reading once you know Bulma's
+ *     vocabulary.
+ *   - **DropdownMenu / FormSelect content uses `.dropdown-content`,
+ *     not `.dropdown-menu`.** Bulma gates `.dropdown-menu` visibility
+ *     on the parent `.dropdown.is-active` wrapper. Reka renders the
+ *     content via portal — there is no parent — so we apply
+ *     `.dropdown-content` (the inner box-styled element) directly,
+ *     which is unconditionally visible.
+ */
+export default function bulmaTheme(): Theme {
+    return {
+        elements: {
+            formGroup: {
+                classes: {
+                    root: 'field',
+                    label: 'label',
+                    hint: 'help',
+                    validationError: 'help is-danger',
+                    validationWarning: 'help is-warning',
+                },
+            },
+            formInput: {
+                classes: {
+                    root: 'input',
+                    group: 'field has-addons',
+                    groupAppend: 'control',
+                    groupPrepend: 'control',
+                },
+                // Bulma's `.input` size modifiers are `is-small` / `is-medium` /
+                // `is-large`. `md` is the unmodified default.
+                variants: {
+                    size: {
+                        sm: { root: 'is-small' },
+                        md: { root: '' },
+                        lg: { root: 'is-large' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            formTextarea: {
+                classes: { root: 'textarea' },
+                variants: {
+                    size: {
+                        sm: { root: 'is-small' },
+                        md: { root: '' },
+                        lg: { root: 'is-large' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            // Reka renders the checkbox / radio / switch as `<button role="…">`,
+            // not native `<input>`. Bulma's `.checkbox` / `.radio` / `.switch`
+            // selectors target inputs, so they don't apply. Lean entirely on
+            // the structural `vc-form-*` classes from @vuecs/forms (shape +
+            // border + sizing) and let the bridge CSS paint the
+            // `data-state="checked"` colors.
+            formCheckbox: {
+                classes: {
+                    // Bulma utility chrome layered on top of the structural
+                    // `vc-form-checkbox` rule. We deliberately omit Bulma's
+                    // border utilities — they would beat the structural
+                    // `data-state="checked"` border-color rule and flatten
+                    // the checked-state visual diff.
+                    root: 'has-background-white',
+                    indicator: 'has-text-white',
+                    label: '',
+                    group: 'is-inline-flex is-align-items-center',
+                },
+                variants: {
+                    size: {
+                        sm: { root: 'vc-form-checkbox-sm', label: 'is-size-7' },
+                        md: { root: '' },
+                        lg: { root: 'vc-form-checkbox-lg', label: 'is-size-5' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            // Bulma 1.0 doesn't ship gap utilities; use `mr-2` on the items
+            // via the wrapper. The structural `vc-form-checkbox-group` rule
+            // owns the flex direction.
+            formCheckboxGroup: { classes: { root: 'is-flex is-flex-direction-column' } },
+            formSwitch: {
+                classes: {
+                    root: '',
+                    thumb: 'has-background-white',
+                    label: '',
+                    group: 'is-inline-flex is-align-items-center',
+                },
+                variants: {
+                    size: {
+                        sm: { root: 'vc-form-switch-sm', label: 'is-size-7' },
+                        md: { root: '' },
+                        lg: { root: 'vc-form-switch-lg', label: 'is-size-5' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            formRadio: {
+                classes: {
+                    root: 'has-background-white',
+                    indicator: '',
+                    label: '',
+                    group: 'is-inline-flex is-align-items-center',
+                },
+                variants: {
+                    size: {
+                        sm: { root: 'vc-form-radio-sm', label: 'is-size-7' },
+                        md: { root: '' },
+                        lg: { root: 'vc-form-radio-lg', label: 'is-size-5' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            formRadioGroup: { classes: { root: 'is-flex is-flex-direction-column' } },
+            // FormSelect (Reka-backed compound) — we deliberately don't use
+            // Bulma's `.select` because that styles a `<div>` wrapper around a
+            // real `<select>`. Build the trigger from `.input` + flex
+            // utilities. Content uses `.dropdown-content` (NOT `.dropdown-menu`,
+            // which is parent-gated — see header comment).
+            formSelect: {
+                classes: {
+                    trigger: 'input is-flex is-align-items-center is-justify-content-space-between',
+                    value: 'is-flex-grow-1',
+                    icon: 'has-text-grey',
+                    content: 'dropdown-content',
+                    viewport: 'p-1',
+                    item: 'dropdown-item',
+                    itemIndicator: '',
+                    group: '',
+                    groupLabel: 'has-text-weight-semibold is-size-7 has-text-grey',
+                    separator: 'dropdown-divider',
+                },
+                variants: {
+                    size: {
+                        sm: { trigger: 'is-small' },
+                        md: { trigger: '' },
+                        lg: { trigger: 'is-large' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            formSelectSearch: {
+                classes: {
+                    root: 'is-relative',
+                    input: 'input',
+                    // No parent `.dropdown.is-active` to gate `.dropdown-menu`,
+                    // so apply `.dropdown-content` directly.
+                    content: 'dropdown-content',
+                    item: 'dropdown-item is-flex is-flex-direction-column',
+                    itemActive: 'is-active',
+                    itemCurrent: 'has-background-light',
+                    itemDescription: 'is-size-7 has-text-grey',
+                    selected: 'is-flex is-flex-wrap-wrap mt-2',
+                    selectedItem: 'tag is-light is-rounded',
+                    selectedItemRemove: 'has-text-weight-bold',
+                },
+            },
+            // PinInputInput renders a real `<input>`; `.input` would give it
+            // `width: 100%` which collapses every cell. Use Bulma utility
+            // classes that mirror the input look (border + bg + shadow)
+            // without the width hint. Structural CSS keeps per-cell sizing.
+            formPin: {
+                classes: {
+                    root: 'is-inline-flex is-align-items-center',
+                    input: 'has-background-white has-text-centered has-text-weight-semibold',
+                },
+            },
+            // Reka Slider renders `<span>` elements, not `<input type="range">`.
+            // Bulma's `.slider` (extension) targets inputs anyway. Hand-roll
+            // the visual via the structural `vc-form-slider-*` classes; bridge
+            // CSS paints the primary range fill.
+            formSlider: {
+                classes: {
+                    root: '',
+                    track: '',
+                    range: '',
+                    thumb: '',
+                },
+            },
+            formNumber: {
+                classes: {
+                    root: 'field has-addons',
+                    input: 'input has-text-centered',
+                    decrement: 'button',
+                    increment: 'button',
+                },
+                variants: {
+                    size: {
+                        sm: {
+                            input: 'is-small',
+                            decrement: 'is-small',
+                            increment: 'is-small',
+                        },
+                        md: { input: '' },
+                        lg: {
+                            input: 'is-large',
+                            decrement: 'is-large',
+                            increment: 'is-large',
+                        },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            formTags: {
+                classes: {
+                    root: 'input is-flex is-flex-wrap-wrap is-align-items-center',
+                    item: 'tag is-primary is-rounded is-flex is-align-items-center',
+                    itemText: '',
+                    // Plain styled cross button. Bulma's `.delete` element
+                    // injects its own × glyph via CSS pseudo-elements — paired
+                    // with the slot's literal "×" text it would double-render.
+                    itemDelete: 'is-inline-flex is-align-items-center is-justify-content-center has-background-transparent has-text-white p-0 ml-1',
+                    input: 'is-flex-grow-1 has-background-transparent',
+                },
+                variants: {
+                    size: {
+                        sm: { root: 'is-small', item: 'is-size-7' },
+                        md: { root: '' },
+                        lg: { root: 'is-large', item: 'is-size-6' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            button: {
+                classes: { root: 'button is-inline-flex is-align-items-center is-justify-content-center' },
+                variants: {
+                    size: {
+                        sm: { root: 'is-small' },
+                        md: { root: '' },
+                        lg: { root: 'is-large' },
+                    },
+                },
+                // Bulma's `.is-light` is the soft variant (tinted bg + colored
+                // text). `.is-outlined` swaps to colored border + transparent
+                // fill. `.is-text` (vuecs `ghost`) is borderless transparent;
+                // `.is-ghost` (vuecs `link`) is anchor-like with underline. We
+                // map `neutral` to bare `.button` (Bulma's default grey) for
+                // the cleanest look.
+                compoundVariants: [
+                    // solid
+                    { variants: { variant: 'solid', color: 'primary' }, class: { root: 'is-primary' } },
+                    { variants: { variant: 'solid', color: 'neutral' }, class: { root: '' } },
+                    { variants: { variant: 'solid', color: 'success' }, class: { root: 'is-success' } },
+                    { variants: { variant: 'solid', color: 'warning' }, class: { root: 'is-warning' } },
+                    { variants: { variant: 'solid', color: 'error' }, class: { root: 'is-danger' } },
+                    { variants: { variant: 'solid', color: 'info' }, class: { root: 'is-info' } },
+                    // soft (= Bulma is-light shade modifier)
+                    { variants: { variant: 'soft', color: 'primary' }, class: { root: 'is-primary is-light' } },
+                    { variants: { variant: 'soft', color: 'neutral' }, class: { root: 'is-light' } },
+                    { variants: { variant: 'soft', color: 'success' }, class: { root: 'is-success is-light' } },
+                    { variants: { variant: 'soft', color: 'warning' }, class: { root: 'is-warning is-light' } },
+                    { variants: { variant: 'soft', color: 'error' }, class: { root: 'is-danger is-light' } },
+                    { variants: { variant: 'soft', color: 'info' }, class: { root: 'is-info is-light' } },
+                    // outline
+                    { variants: { variant: 'outline', color: 'primary' }, class: { root: 'is-primary is-outlined' } },
+                    { variants: { variant: 'outline', color: 'neutral' }, class: { root: 'is-outlined' } },
+                    { variants: { variant: 'outline', color: 'success' }, class: { root: 'is-success is-outlined' } },
+                    { variants: { variant: 'outline', color: 'warning' }, class: { root: 'is-warning is-outlined' } },
+                    { variants: { variant: 'outline', color: 'error' }, class: { root: 'is-danger is-outlined' } },
+                    { variants: { variant: 'outline', color: 'info' }, class: { root: 'is-info is-outlined' } },
+                    // ghost — Bulma's `is-text` (borderless transparent)
+                    { variants: { variant: 'ghost', color: 'primary' }, class: { root: 'is-text has-text-primary' } },
+                    { variants: { variant: 'ghost', color: 'neutral' }, class: { root: 'is-text' } },
+                    { variants: { variant: 'ghost', color: 'success' }, class: { root: 'is-text has-text-success' } },
+                    { variants: { variant: 'ghost', color: 'warning' }, class: { root: 'is-text has-text-warning' } },
+                    { variants: { variant: 'ghost', color: 'error' }, class: { root: 'is-text has-text-danger' } },
+                    { variants: { variant: 'ghost', color: 'info' }, class: { root: 'is-text has-text-info' } },
+                    // link — Bulma's `is-ghost` (anchor-like, underlined)
+                    { variants: { variant: 'link', color: 'primary' }, class: { root: 'is-ghost has-text-primary' } },
+                    { variants: { variant: 'link', color: 'neutral' }, class: { root: 'is-ghost' } },
+                    { variants: { variant: 'link', color: 'success' }, class: { root: 'is-ghost has-text-success' } },
+                    { variants: { variant: 'link', color: 'warning' }, class: { root: 'is-ghost has-text-warning' } },
+                    { variants: { variant: 'link', color: 'error' }, class: { root: 'is-ghost has-text-danger' } },
+                    { variants: { variant: 'link', color: 'info' }, class: { root: 'is-ghost has-text-info' } },
+                ],
+                defaultVariants: {
+                    variant: 'solid',
+                    color: 'primary',
+                    size: 'md',
+                },
+            },
+            list: {
+                classes: { root: 'is-flex is-flex-direction-column' },
+                variants: {
+                    density: {
+                        compact: { root: '' },
+                        normal: { root: '' },
+                        spacious: { root: '' },
+                    },
+                },
+                defaultVariants: { density: 'normal' },
+            },
+            listHeader: { classes: { root: 'is-flex is-align-items-center' } },
+            listBody: { classes: { root: 'm-0 p-0' } },
+            // <VCListItem> owns the row's flex layout. <VCListItemText> takes
+            // `is-flex-grow-1` so it consumes available space and pushes
+            // trailing <VCListItemActions> to the right edge.
+            listItem: {
+                classes: { root: 'is-flex is-flex-direction-row is-align-items-center' },
+                variants: {
+                    density: {
+                        compact: { root: 'py-0' },
+                        normal: { root: 'py-1' },
+                        spacious: { root: 'py-3' },
+                    },
+                },
+                defaultVariants: { density: 'normal' },
+            },
+            listItemText: { classes: { root: 'is-inline-flex is-flex-direction-column is-flex-grow-1' } },
+            listItemActions: { classes: { root: 'is-inline-flex is-align-items-center' } },
+            listFooter: { classes: { root: 'is-flex is-align-items-center' } },
+            listLoading: { classes: { root: 'py-2 has-text-centered has-text-grey is-size-7' } },
+            // Bulma `.notification.is-warning.is-light` matches the BS theme's
+            // `.alert.alert-warning` look.
+            listEmpty: { classes: { root: 'notification is-warning is-light is-size-7 p-2' } },
+            navigation: {
+                classes: {
+                    group: 'menu-list',
+                    link: '',
+                },
+                variants: {
+                    size: {
+                        sm: { link: 'is-size-7' },
+                        md: { link: '' },
+                        lg: { link: 'is-size-6' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            // Reka encodes orientation as `data-orientation`; Bulma's `<hr>`
+            // styling is limited (no built-in vertical rule). Structural CSS
+            // does both axes; we just trim default margins so consumers
+            // control spacing via parent flex gaps.
+            separator: { classes: { root: 'm-0' } },
+            tag: {
+                classes: {
+                    root: 'tag is-primary is-rounded is-flex is-align-items-center',
+                    icon: 'is-inline-flex is-align-items-center',
+                    // Plain styled cross button (see formTags.itemDelete for
+                    // the same rationale — `.delete` injects its own glyph).
+                    remove: 'is-inline-flex is-align-items-center is-justify-content-center has-background-transparent has-text-white p-0',
+                },
+                // Bulma's `.tag` size modifiers are `is-medium` / `is-large`;
+                // there is no `is-small` (the default IS the smallest size).
+                // Mapping our `sm` to the bare default keeps `.tag` small;
+                // `md` lifts to `is-medium` and `lg` to `is-large`.
+                variants: {
+                    size: {
+                        sm: { root: '' },
+                        md: { root: 'is-medium' },
+                        lg: { root: 'is-large' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            tags: {
+                classes: {
+                    root: 'tags',
+                    item: '',
+                },
+                variants: {
+                    size: {
+                        sm: { root: '' },
+                        md: { root: 'are-medium' },
+                        lg: { root: 'are-large' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            avatar: {
+                classes: {
+                    root: 'is-inline-flex is-align-items-center is-justify-content-center has-background-light has-text-grey-dark',
+                    image: 'is-flex-grow-1',
+                    fallback: 'is-inline-flex is-align-items-center is-justify-content-center has-text-weight-medium is-size-7',
+                },
+                // Bulma's `.image is-32x32` family relies on fixed size scales
+                // — for our sm/md/lg axis we use the structural
+                // `vc-avatar-{sm,lg}` helpers (defined in @vuecs/elements).
+                variants: {
+                    size: {
+                        sm: { root: 'vc-avatar-sm' },
+                        md: { root: '' },
+                        lg: { root: 'vc-avatar-lg' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            aspectRatio: { classes: { root: 'is-block' } },
+            // VCGravatar wraps VCAvatar — sizing comes from the structural
+            // `vc-gravatar` class. Theme adds Bulma aesthetics; override
+            // visual size via per-instance `themeClass`.
+            gravatar: { classes: { root: 'is-inline-block' } },
+            // Bulma has NO core `.badge` class. Use `.tag` as the host
+            // (consistent with how Bulma docs recommend chip-style badges)
+            // plus the same color × variant matrix structure as button.
+            // Outline variant has no native Bulma class — bridge CSS adds
+            // `.vc-badge.vc-badge-outline.tag.is-<color>` rules.
+            badge: {
+                classes: { root: 'tag is-rounded vc-badge' },
+                variants: {
+                    size: {
+                        sm: { root: '' },
+                        md: { root: 'is-medium' },
+                        lg: { root: 'is-large' },
+                    },
+                },
+                compoundVariants: [
+                    // solid — `.tag.is-<color>`
+                    { variants: { variant: 'solid', color: 'primary' }, class: { root: 'is-primary' } },
+                    { variants: { variant: 'solid', color: 'neutral' }, class: { root: 'is-dark' } },
+                    { variants: { variant: 'solid', color: 'success' }, class: { root: 'is-success' } },
+                    { variants: { variant: 'solid', color: 'warning' }, class: { root: 'is-warning' } },
+                    { variants: { variant: 'solid', color: 'error' }, class: { root: 'is-danger' } },
+                    { variants: { variant: 'solid', color: 'info' }, class: { root: 'is-info' } },
+                    // soft — `.tag.is-<color>.is-light`
+                    { variants: { variant: 'soft', color: 'primary' }, class: { root: 'is-primary is-light' } },
+                    { variants: { variant: 'soft', color: 'neutral' }, class: { root: 'is-light' } },
+                    { variants: { variant: 'soft', color: 'success' }, class: { root: 'is-success is-light' } },
+                    { variants: { variant: 'soft', color: 'warning' }, class: { root: 'is-warning is-light' } },
+                    { variants: { variant: 'soft', color: 'error' }, class: { root: 'is-danger is-light' } },
+                    { variants: { variant: 'soft', color: 'info' }, class: { root: 'is-info is-light' } },
+                    // outline — gap-fill rule in assets/index.css does the
+                    // colored border + transparent fill. The marker class
+                    // `vc-badge-outline` carries the per-color rule.
+                    { variants: { variant: 'outline', color: 'primary' }, class: { root: 'vc-badge-outline vc-badge-outline-primary' } },
+                    { variants: { variant: 'outline', color: 'neutral' }, class: { root: 'vc-badge-outline vc-badge-outline-neutral' } },
+                    { variants: { variant: 'outline', color: 'success' }, class: { root: 'vc-badge-outline vc-badge-outline-success' } },
+                    { variants: { variant: 'outline', color: 'warning' }, class: { root: 'vc-badge-outline vc-badge-outline-warning' } },
+                    { variants: { variant: 'outline', color: 'error' }, class: { root: 'vc-badge-outline vc-badge-outline-error' } },
+                    { variants: { variant: 'outline', color: 'info' }, class: { root: 'vc-badge-outline vc-badge-outline-info' } },
+                ],
+                defaultVariants: {
+                    variant: 'soft',
+                    color: 'neutral',
+                    size: 'md',
+                },
+            },
+            pagination: {
+                classes: {
+                    root: 'pagination is-centered',
+                    item: 'pagination-list',
+                    link: 'pagination-link',
+                    linkActive: 'is-current',
+                    ellipsis: 'pagination-ellipsis',
+                },
+                variants: {
+                    variant: {
+                        outline: { link: '' },
+                        soft: { link: 'is-light' },
+                        ghost: { link: 'is-text' },
+                    },
+                    size: {
+                        sm: { root: 'is-small' },
+                        md: { root: '' },
+                        lg: { root: 'is-large' },
+                    },
+                },
+                defaultVariants: { variant: 'outline', size: 'md' },
+            },
+            // Reka primitives drive open/close via `data-state="open|closed"`,
+            // not Bulma's `.is-active` class. Theme strings reference Bulma
+            // classes for chrome (border, padding, typography); enter+exit
+            // animations come from vuecs's dual-state helpers in
+            // @vuecs/design's animations.css (`vc-overlay-anim`,
+            // `vc-overlay-fade-anim`, `vc-tooltip-anim`).
+            modal: {
+                classes: {
+                    overlay: 'modal-background vc-overlay-fade-anim',
+                    // `.modal-content` is Bulma's centered panel host. Use
+                    // it directly (skipping `.modal-card`); width sizing is
+                    // wired in the bridge CSS for `.modal-sm/lg/xl`.
+                    content: 'modal-content has-background-white p-5 vc-overlay-anim',
+                    header: 'is-flex is-flex-direction-column',
+                    title: 'title is-5',
+                    description: 'subtitle is-size-7 has-text-grey',
+                    body: 'is-flex is-flex-direction-column',
+                    footer: 'is-flex is-align-items-center is-justify-content-flex-end',
+                    trigger: '',
+                    close: '',
+                    closeIcon: 'delete is-medium',
+                    back: 'button is-small is-ghost',
+                },
+                variants: {
+                    size: {
+                        sm: { content: 'modal-sm' },
+                        md: { content: '' },
+                        lg: { content: 'modal-lg' },
+                        xl: { content: 'modal-xl' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            popover: {
+                classes: {
+                    trigger: '',
+                    // No native popover compound — `box` ships the panel
+                    // chrome (bg, border-radius, shadow, padding).
+                    content: 'box vc-overlay-anim',
+                    arrow: '',
+                    close: '',
+                    closeIcon: 'delete',
+                },
+                variants: {
+                    size: {
+                        sm: { content: 'is-size-7 p-2' },
+                        md: { content: '' },
+                        lg: { content: 'is-size-6 p-5' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            hoverCard: {
+                classes: {
+                    trigger: '',
+                    content: 'box vc-overlay-anim',
+                    arrow: '',
+                },
+                variants: {
+                    size: {
+                        sm: { content: 'is-size-7 p-2' },
+                        md: { content: '' },
+                        lg: { content: 'is-size-6 p-5' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            tooltip: {
+                classes: {
+                    trigger: '',
+                    // Bulma's `[data-tooltip]` is data-attribute-driven and
+                    // doesn't fit Reka's class-based tooltip. Use `box` +
+                    // dark-bg utilities for a tooltip-like panel.
+                    content: 'has-background-dark has-text-light vc-tooltip-anim',
+                    arrow: '',
+                },
+                variants: {
+                    size: {
+                        sm: { content: 'is-size-7 px-2 py-1' },
+                        md: { content: 'px-3 py-1' },
+                        lg: { content: 'is-size-6 px-3 py-2' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            dropdownMenu: {
+                classes: {
+                    trigger: '',
+                    // `.dropdown-content` instead of `.dropdown-menu` — see
+                    // file header for rationale (parent-state-gated).
+                    content: 'dropdown-content vc-overlay-anim',
+                    item: 'dropdown-item',
+                    checkboxItem: 'dropdown-item',
+                    radioItem: 'dropdown-item',
+                    radioGroup: '',
+                    itemIndicator: '',
+                    label: 'dropdown-item has-text-weight-semibold has-text-grey',
+                    separator: 'dropdown-divider',
+                    group: '',
+                    subTrigger: 'dropdown-item is-flex is-justify-content-space-between',
+                    subContent: 'dropdown-content vc-overlay-anim',
+                    arrow: '',
+                },
+                variants: {
+                    size: {
+                        sm: { content: 'is-size-7' },
+                        md: { content: '' },
+                        lg: { content: 'is-size-6' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            contextMenu: {
+                classes: {
+                    trigger: '',
+                    content: 'dropdown-content vc-overlay-anim',
+                    item: 'dropdown-item',
+                    checkboxItem: 'dropdown-item',
+                    radioItem: 'dropdown-item',
+                    radioGroup: '',
+                    itemIndicator: '',
+                    label: 'dropdown-item has-text-weight-semibold has-text-grey',
+                    separator: 'dropdown-divider',
+                    group: '',
+                    subTrigger: 'dropdown-item is-flex is-justify-content-space-between',
+                    subContent: 'dropdown-content vc-overlay-anim',
+                },
+                variants: {
+                    size: {
+                        sm: { content: 'is-size-7' },
+                        md: { content: '' },
+                        lg: { content: 'is-size-6' },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+            // Bulma has no core stepper compound. Layout (size, radius,
+            // gaps) lives in @vuecs/navigation's structural CSS; this entry
+            // only paints colors. data-state="active|completed" drives the
+            // bg/text/border flip via attribute selectors in the bridge CSS.
+            stepper: {
+                classes: {
+                    root: '',
+                    item: '',
+                    trigger: 'button is-text',
+                    indicator: 'has-background-light has-text-grey has-text-weight-semibold',
+                    // No size class on title/description by default — let the
+                    // size variants control. `is-size-{1..7}` are equal-
+                    // specificity class selectors; Bulma's source order
+                    // would make a default size impossible to override per
+                    // variant without `!important`.
+                    title: 'has-text-weight-medium',
+                    description: 'has-text-grey',
+                    separator: 'has-background-grey-lighter',
+                },
+                variants: {
+                    size: {
+                        sm: {
+                            indicator: 'vc-stepper-indicator-sm', 
+                            title: 'is-size-7', 
+                            description: 'is-size-7', 
+                        },
+                        md: { indicator: '' },
+                        lg: {
+                            indicator: 'vc-stepper-indicator-lg', 
+                            title: 'is-size-5', 
+                            description: 'is-size-6', 
+                        },
+                    },
+                },
+                defaultVariants: { size: 'md' },
+            },
+        },
+    };
+}

--- a/themes/bulma/src/index.ts
+++ b/themes/bulma/src/index.ts
@@ -236,7 +236,11 @@ export default function bulmaTheme(): Theme {
                 defaultVariants: { size: 'md' },
             },
             button: {
-                classes: { root: 'button is-inline-flex is-align-items-center is-justify-content-center' },
+                // Bulma 1.x ships `is-gap-*` flex/grid spacing utilities;
+                // `is-gap-2` (0.5rem) matches the gap baked into the
+                // Tailwind / Bootstrap themes so leading icon / label /
+                // trailing icon don't sit flush against each other.
+                classes: { root: 'button is-inline-flex is-align-items-center is-justify-content-center is-gap-2' },
                 variants: {
                     size: {
                         sm: { root: 'is-small' },
@@ -450,9 +454,24 @@ export default function bulmaTheme(): Theme {
                 },
             },
             pagination: {
+                // Bulma's pagination canonical structure is
+                // `<nav class="pagination">` containing standalone
+                // `.pagination-previous` / `-next` siblings PLUS a
+                // `<ul class="pagination-list">` wrapping the `.pagination-link`
+                // page items. <VCPagination> only renders one `<ul>` with
+                // uniform `<li>` children for every control (first / prev /
+                // page items / next / last) — there's no mid-render hook to
+                // differentiate item types in the theme today. As a
+                // pragmatic mapping: apply `.pagination-list` to the
+                // outer `<ul>` so its flex layout takes effect, and use
+                // `.pagination-link` uniformly for all controls (Bulma's
+                // edge-control styling — `.pagination-previous`/`-next` —
+                // is very close to `.pagination-link`'s anyway, just
+                // wider on small viewports). Visual parity with the
+                // Tailwind / Bootstrap themes is preserved.
                 classes: {
-                    root: 'pagination is-centered',
-                    item: 'pagination-list',
+                    root: 'pagination-list is-flex is-justify-content-center',
+                    item: '',
                     link: 'pagination-link',
                     linkActive: 'is-current',
                     ellipsis: 'pagination-ellipsis',
@@ -491,6 +510,13 @@ export default function bulmaTheme(): Theme {
                     footer: 'is-flex is-align-items-center is-justify-content-flex-end',
                     trigger: '',
                     close: '',
+                    // `.delete` paints the X glyph (Bulma's pseudo-element +
+                    // `font-size: 0` recipe — the slot's literal "×"
+                    // fallback is collapsed to zero size, so no
+                    // double-render). Bulma's `.delete` is `position:
+                    // relative` by default; the bridge CSS adds
+                    // corner-positioning by targeting the structural
+                    // `vc-modal-close-icon` class (from component defaults).
                     closeIcon: 'delete is-medium',
                     back: 'button is-small is-ghost',
                 },
@@ -512,6 +538,9 @@ export default function bulmaTheme(): Theme {
                     content: 'box vc-overlay-anim',
                     arrow: '',
                     close: '',
+                    // Same `.delete` rationale as `modal.closeIcon` —
+                    // bridge CSS positions the structural
+                    // `vc-popover-close-icon` class in the corner.
                     closeIcon: 'delete',
                 },
                 variants: {

--- a/themes/bulma/tsconfig.build.json
+++ b/themes/bulma/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "declarationDir": "./dist",
+        "skipLibCheck": true
+    },
+    "exclude": ["node_modules", "dist"],
+    "include": ["src/**/*.ts"]
+}

--- a/themes/bulma/tsconfig.json
+++ b/themes/bulma/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "skipLibCheck": true,
+        "paths": {
+            "@vuecs/core": [
+                "./packages/core/src"
+            ],
+            "@vuecs/core/*": [
+                "./packages/core/src/*"
+            ]
+        }
+    },
+    "include": [
+        "src/**/*.ts"
+    ]
+}

--- a/themes/bulma/tsdown.config.ts
+++ b/themes/bulma/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+    entry: 'src/index.ts',
+    format: 'esm',
+    dts: false,
+    sourcemap: true,
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,6 +49,8 @@
             "@vuecs/timeago/*": ["./packages/timeago/src/*"],
             "@vuecs/theme-bootstrap": ["./themes/bootstrap/src"],
             "@vuecs/theme-bootstrap/*": ["./themes/bootstrap/src/*"],
+            "@vuecs/theme-bulma": ["./themes/bulma/src"],
+            "@vuecs/theme-bulma/*": ["./themes/bulma/src/*"],
             "@vuecs/theme-tailwind": ["./themes/tailwind/src"],
             "@vuecs/theme-tailwind/*": ["./themes/tailwind/src/*"],
             "@vuecs/icons-font-awesome": ["./icons/font-awesome/src"],


### PR DESCRIPTION
New `@vuecs/theme-bulma` package — Bulma 1.0+ class mappings for every component plus a `--bulma-*` → `--vc-color-*` design-token bridge. The bridge overrides resolved properties (background-color, border-color, color) directly on per-variant selectors because Bulma 1.0 routes its theming through HSL channel vars (`--bulma-button-h/s/l`) rather than named bg-color tokens — pure CSS can't decompose hex tokens into HSL channels, so the named-var override path is a no-op. Direct property override matches the visual but loses Bulma's auto-derived hover/active lightness deltas; the bridge re-specifies them with -700/-800 shades.

Extends `docs/src/guide/design-tokens.md` with a complete `--vc-*` CSS variable reference (66 color tokens, semantic aliases with light/dark flips, on-* foregrounds, radii) and a 6-step "Bridging another CSS framework" guide. Bulma + Bootstrap bridges are cited as concrete worked examples covering both the named-CSS-var pattern (BS) and the direct-property-override pattern (Bulma).

Wires Bulma into the demo theme picker: extends the union to `'tailwind' | 'bootstrap' | 'bulma'`, adds `<link disabled>` Bulma CDN entries to all 33 demo HTML shells, refactors `setDemoTheme` to toggle the right framework `<link>` per active theme.

Three design findings tracked in `.agents/plans/014-theme-system- design-findings.md` (gitignored): outline-badge per-theme duplication, modal sizing per-theme rules, stepper data-state per-theme rules. User decision: keep per-theme bridge CSS for all three (matches the "structural = shape only, color is theme territory" principle in @vuecs/elements/assets/badge.css).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `@vuecs/theme-bulma` — a new Bulma 1.0+ theme package that maps Bulma CSS variables to vuecs design tokens, enabling real-time palette switching and component styling.
  * Demo pages now support Bulma theme selection alongside existing Tailwind and Bootstrap options via a theme switcher.
  * All component demos updated to display Bulma styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->