### PR TITLE
docs: foreground vuecs as a theming framework with shipped components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,15 @@
 
 # vuecs — Agent Guide
 
-A Vue 3 component library monorepo providing reusable UI components (navigation, form controls, pagination, lists, etc.) with TypeScript support, CSS extraction, and themes for Bootstrap and Tailwind. Published as scoped `@vuecs/*` packages on npm.
+A Vue 3 **theming framework** with shipped components — published as scoped `@vuecs/*` packages on npm.
+
+The value proposition is layered:
+
+1. **Theming machinery** (`@vuecs/core`): `useComponentTheme` + `useComponentDefaults` composables, `<VCConfigProvider>`, design-token system (`@vuecs/design`), runtime palette + color-mode switching, and a typed augmentable theme registry (`ThemeElements`, `ComponentDefaults`, `Config`).
+2. **A baseline of theme-aware components** (button, navigation, forms, overlays, list, pagination, …) built on that machinery.
+3. **An opt-in path for third-party libraries** to publish their own components on the same machinery, so a downstream consumer reskins **everything** — vuecs primitives + third-party libraries — through a single `app.use(vuecs, { themes, overrides, defaults, config })` call.
+
+Themes for Tailwind, Bootstrap 5, and Bulma 1.0+ ship today. The theme system, design tokens, and component machinery are independently consumable; pick what you need.
 
 ## Quick Reference
 

--- a/docs/src/.vitepress/theme/components/Hero.vue
+++ b/docs/src/.vitepress/theme/components/Hero.vue
@@ -48,8 +48,10 @@ const toggleDark = () => {
                     <span class="vc-hero-title-grad">vuecs</span>
                 </h1>
                 <p class="vc-hero-tagline">
-                    Themeable Vue 3 component library with design tokens, runtime palette switching,
-                    and SSR-safe Nuxt integration.
+                    Vue 3 theming framework with shipped components.
+                    Design tokens, runtime palette + color-mode switching, SSR-safe Nuxt integration —
+                    plus an opt-in path for third-party libraries to compose their own
+                    components on the same theme system.
                 </p>
                 <div class="vc-hero-actions">
                     <a

--- a/docs/src/getting-started/index.md
+++ b/docs/src/getting-started/index.md
@@ -1,29 +1,29 @@
 # Introduction
 
-**vuecs** is a Vue 3 component library focused on three things:
+**vuecs** is a Vue 3 **theming framework with shipped components**. Reframed: the components are the obvious surface, but the theming machinery underneath them is the value. Three layers:
 
-1. **Themeable, layered class resolution.** Every component reads its CSS classes through a four-layer resolution chain (defaults → themes → overrides → instance props), with structured variants and compound variants. You can drop in a Tailwind, Bootstrap v5, or Bootstrap v4 theme — or write your own — without forking the components.
+1. **Theming machinery** (`@vuecs/core`). Every component reads its CSS classes through a four-layer resolution chain (defaults → themes → overrides → instance props) with structured variants and compound variants. The same machinery is exported for **third-party use** — your own `<MyDataTable>` registers a theme slot via `ThemeElements` declaration merging and resolves through the same manager that vuecs's primitives use. Consumers re-skin everything (vuecs + your library) through one `app.use(vuecs, …)` call.
 
-2. **Design tokens, runtime palette switching (Tailwind).** Colors, radii, and semantic aliases live in CSS custom properties in `@vuecs/design` (concrete OKLCH defaults — works with or without Tailwind). For Tailwind users, `@vuecs/theme-tailwind` adds a one-line `setColorPalette({ primary: 'green' })` that re-tints every component on the page with no Vue re-render.
+2. **Design tokens + runtime palette switching.** Colors, radii, and semantic aliases live in CSS custom properties in `@vuecs/design` (concrete OKLCH defaults — works with or without Tailwind). For Tailwind users, `@vuecs/theme-tailwind` adds a one-line `setColorPalette({ primary: 'green' })` that re-tints every component on the page with no Vue re-render. `@vuecs/theme-bulma` ships the same shape for the Bulma palette catalog.
 
 3. **SSR-safe Nuxt integration.** `@vuecs/nuxt` wires color-mode plumbing into Nuxt's `<head>` on the server, so first paint matches what the client computes — no FOUC, no hydration mismatch. Tailwind apps add `@vuecs/theme-tailwind-nuxt` for the same SSR guarantees on palette switching.
 
 ## Why another component library?
 
-Most Vue libraries make you pick a CSS framework upfront and bake it in. vuecs treats themes as **data**: a theme is a function returning a class-map, merged in array order against component defaults. That means:
+Because vuecs isn't (just) a component library. Most libraries pick a CSS framework upfront and bake it in. vuecs treats themes as **data**: a theme is a function returning a class-map, merged in array order against component defaults. That has two consequences:
 
-- The same component renders correctly under Bootstrap v5, Bootstrap v4, or Tailwind v4 — pick at consume time.
-- Override individual slot classes from `app.use(vuecs, { overrides: ... })` without touching component source.
-- Per-instance overrides via `themeClass` and `themeVariant` props for one-off variations.
+- The same component renders correctly under Tailwind v4, Bootstrap 5, or Bulma 1.0+ — pick at consume time. Override individual slot classes via `app.use(vuecs, { overrides: ... })` or per-instance via `themeClass` / `themeVariant` props.
+- **You can build on the same theme system.** A library author drops `useComponentTheme` into their own components, and downstream consumers reskin the union (vuecs + that library) with one config call. No fork; no parallel theme system.
 
 ## What's in the box
 
-- **Components** — form controls, navigation, pagination, list controls, countdown, gravatar, link, timeago, icon.
-- **Themes** — `@vuecs/theme-tailwind`, `@vuecs/theme-bootstrap`, `@vuecs/theme-bulma`.
+- **Components** — button, navigation (incl. stepper), pagination, forms (checkbox / switch / input / number / pin / radio / select / select-search / slider / tags / textarea), list, overlays (modal / popover / hover-card / tooltip / dropdown-menu / context-menu), elements (separator / tag / avatar / aspect-ratio / visually-hidden / badge), countdown, gravatar, link, timeago, icon.
+- **Themes** — `@vuecs/theme-tailwind`, `@vuecs/theme-bootstrap`, `@vuecs/theme-bulma`. Cosmetic adapters that compose with the design-token layer.
 - **Icons** — `@vuecs/icon` (`<VCIcon>`, Iconify-backed) plus presets (`@vuecs/icons-lucide`, `@vuecs/icons-font-awesome`) that map vuecs's semantic-slot defaults to specific icon vocabularies.
 - **Design tokens** — `@vuecs/design` ships CSS variables + theme-agnostic generic palette primitives.
-- **Tailwind palette runtime** — `@vuecs/theme-tailwind` ships `setColorPalette()` / `useColorPalette()` for Tailwind's catalog.
+- **Runtime palette** — `@vuecs/theme-tailwind` and `@vuecs/theme-bulma` ship `setColorPalette()` / `useColorPalette()` for their respective palette catalogs.
 - **Nuxt modules** — `@vuecs/nuxt` (color mode + tokens) and `@vuecs/theme-tailwind-nuxt` (SSR-safe palette).
+- **Example apps** — one Nuxt + three vanilla Vite + Vue 3 (Tailwind, Bootstrap, Bulma), all consuming a shared private workspace package of demo views. See `examples/` in the repo.
 
 ## Next steps
 

--- a/docs/src/getting-started/index.md
+++ b/docs/src/getting-started/index.md
@@ -4,7 +4,7 @@
 
 1. **Theming machinery** (`@vuecs/core`). Every component reads its CSS classes through a four-layer resolution chain (defaults → themes → overrides → instance props) with structured variants and compound variants. The same machinery is exported for **third-party use** — your own `<MyDataTable>` registers a theme slot via `ThemeElements` declaration merging and resolves through the same manager that vuecs's primitives use. Consumers re-skin everything (vuecs + your library) through one `app.use(vuecs, …)` call.
 
-2. **Design tokens + runtime palette switching.** Colors, radii, and semantic aliases live in CSS custom properties in `@vuecs/design` (concrete OKLCH defaults — works with or without Tailwind). For Tailwind users, `@vuecs/theme-tailwind` adds a one-line `setColorPalette({ primary: 'green' })` that re-tints every component on the page with no Vue re-render. `@vuecs/theme-bulma` ships the same shape for the Bulma palette catalog.
+2. **Design tokens + runtime palette switching.** Colors, radii, and semantic aliases live in CSS custom properties in `@vuecs/design` (concrete OKLCH defaults — works with or without Tailwind). For Tailwind users, `@vuecs/theme-tailwind` adds a one-line `setColorPalette({ primary: 'green' })` that re-tints every component on the page with no Vue re-render. `@vuecs/theme-bulma` ships the same `setColorPalette()` / `useColorPalette()` shape against the **same 22-name palette catalog** — Bulma renders those names as HSL channel vars internally, but the stored payload is interchangeable across themes (so a single picker UI drives both).
 
 3. **SSR-safe Nuxt integration.** `@vuecs/nuxt` wires color-mode plumbing into Nuxt's `<head>` on the server, so first paint matches what the client computes — no FOUC, no hydration mismatch. Tailwind apps add `@vuecs/theme-tailwind-nuxt` for the same SSR guarantees on palette switching.
 
@@ -21,7 +21,7 @@ Because vuecs isn't (just) a component library. Most libraries pick a CSS framew
 - **Themes** — `@vuecs/theme-tailwind`, `@vuecs/theme-bootstrap`, `@vuecs/theme-bulma`. Cosmetic adapters that compose with the design-token layer.
 - **Icons** — `@vuecs/icon` (`<VCIcon>`, Iconify-backed) plus presets (`@vuecs/icons-lucide`, `@vuecs/icons-font-awesome`) that map vuecs's semantic-slot defaults to specific icon vocabularies.
 - **Design tokens** — `@vuecs/design` ships CSS variables + theme-agnostic generic palette primitives.
-- **Runtime palette** — `@vuecs/theme-tailwind` and `@vuecs/theme-bulma` ship `setColorPalette()` / `useColorPalette()` for their respective palette catalogs.
+- **Runtime palette** — `@vuecs/theme-tailwind` and `@vuecs/theme-bulma` ship `setColorPalette()` / `useColorPalette()` against the **shared 22-name Tailwind palette catalog** (Bulma reuses Tailwind's catalog, rendered as HSL channel vars internally — payload is interchangeable, so a single picker UI drives both).
 - **Nuxt modules** — `@vuecs/nuxt` (color mode + tokens) and `@vuecs/theme-tailwind-nuxt` (SSR-safe palette).
 - **Example apps** — one Nuxt + three vanilla Vite + Vue 3 (Tailwind, Bootstrap, Bulma), all consuming a shared private workspace package of demo views. See `examples/` in the repo.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: vuecs
-description: Themeable Vue 3 component library with design tokens, runtime palette switching, and SSR-safe Nuxt integration.
+description: Vue 3 theming framework with shipped components — design tokens, runtime palette + color-mode switching, and an opt-in path for third-party libraries to compose their own components on the same theme system.
 ---
 
 <script setup>


### PR DESCRIPTION
## Summary

Re-frames the project's positioning copy across AGENTS.md + the docs landing surface to lead with the theming machinery, not the component catalog.

The components are the obvious surface; the value proposition that's been implicit since the architecture's earliest days is that the same theme system is consumable by third-party libraries — you build your own components on \`useComponentTheme\` / \`useComponentDefaults\`, augment \`ThemeElements\` via declaration merging, and downstream consumers reskin the union via one \`app.use(vuecs, …)\` call.

## Why now

Captured during the per-theme examples work (#1539). The framing surfaced after seeing how plan 020 (composition kit) and plan 011 (authup migration) both depend on the same "third party builds on vuecs theme system" path — but the docs / AGENTS.md never pitched that path to outside readers.

This is doctrine-first work: settle the framing before designing \`extendTheme()\` (plan 022) or theme-configurable runtime hooks (plan 021), so those plans line up against a deliberate vision rather than each other.

## What changed

- **AGENTS.md opening** — three-layer value chain (machinery, baseline components, third-party authoring path).
- **docs/src/index.md frontmatter** — description.
- **Hero.vue tagline** — visible on the landing page.
- **docs/src/getting-started/index.md** — "Introduction" + "Why another component library?" + "What's in the box" sections refreshed. Also updates the component inventory to reflect what shipped since this page was last touched (overlays, elements, stepper, list redesign, Bulma theme, example apps).

No code changes. Pure positioning + copy.

## Next

- Plan 022 — \`extendTheme()\` ships the smallest concrete enabler for the new framing
- Plan 023 Gap 1 — "Build your own themable component" guide (with a worked example) — validates whether the surface is actually ergonomic
- Plan 021 — theme-configurable runtime hooks — once doctrine is settled, removes the per-app \`watchEffect\` mirrors from the BS / Bulma example apps

## Test plan

- [ ] CI green (lint, build, examples matrix from #1539)
- [ ] Docs site renders cleanly — \`npm run -w @vuecs/docs build\` passes locally
- [ ] Read through the new \`getting-started/index.md\` — copy lands without contradicting any current behaviour
- [ ] Hero tagline reads well at landing-page size

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guide documentation with detailed architecture overview, package references, and workflow commands
  * Improved messaging around theming framework capabilities, shipped components, runtime palette switching, and third-party integration paths
  * Expanded getting-started guide with comprehensive feature positioning and use-case clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->