### PR TITLE
feat(core): add defineTheme() for composing themes that extend others…

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -254,6 +254,58 @@ When consumers install component packages, the augmented `ThemeElements` provide
 - Type checking for slot keys within each component's theme override
 - Typo detection for both component names and slot keys in theme definitions
 
+### Composing themes (`defineTheme`, plan 022)
+
+`@vuecs/core` exposes `defineTheme(config)` for authoring themes that
+inherit from one or more existing themes. Config-object form mirroring
+`tsconfig`'s `extends` and Vue/Vite's `define*()` doctrine:
+
+```ts
+import tailwindTheme from '@vuecs/theme-tailwind';
+import { defineTheme, extend } from '@vuecs/core';
+
+export const acmeTheme = () => defineTheme({
+    extends: tailwindTheme(),                  // single base
+    elements: {
+        button: { classes: { root: extend('shadow-2xl') } },
+        acmeDataTable: { classes: { /* … */ } },
+    },
+});
+```
+
+Multi-base composition is natural — `extends: [a, b, c]` resolves
+left-to-right (rightmost wins), matching `themes: [a, b, c]`
+install-time stacking semantics. The current config's own fields apply
+last (i.e. they win over everything in `extends`).
+
+**Merge semantics** (per-component `elements[name]` entry):
+
+| Field | Merge rule |
+|---|---|
+| `classes` | Per-slot: later plain replaces accumulator; `extend()` marker merges via `classesMergeFn` |
+| `variants` | Deep merge per variant name + value (later wins per slot) |
+| `compoundVariants` | Concatenate from all chain layers |
+| `defaultVariants` | Shallow merge per key (later wins) |
+| `classesMergeFn` | Last-wins across the chain |
+| `colorMode.apply` (plan 021 forward-compat) | Compose: each layer's apply runs in chain order |
+| `palette.render` / `palette.names` (plan 021 forward-compat) | Last-wins (one renderer owns the runtime `<style>` block) |
+
+The `colorMode` and `palette` slots are reserved on `Theme` ahead of
+plan 021's runtime; they type-check today but are no-ops until plan
+021 ships the `useColorMode` / `useColorPalette` runtime that walks
+installed themes and dispatches through them.
+
+`defineTheme` is a thin facade over the lower-level pure reducer
+`mergeThemes(themes: Theme[]): Theme`, which is also exported for
+advanced composition. The reducer is pure (no Vue dependency) and
+tested in `packages/core/test/unit/theme/define.spec.ts`.
+
+The primary unblock is **third-party theme publishing**: a library
+like `@acme/admin-kit` can publish a single self-contained theme that
+builds on `tailwindTheme()` without forcing every consumer to install
+Tailwind separately AND remember to stack the override entry. See
+plans 022, 023, and 024 (step 4) for the full design rationale.
+
 ## Global Behavioral Defaults (#1491)
 
 Alongside the theme system, `@vuecs/core` exposes a parallel `DefaultsManager` for

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -283,7 +283,7 @@ last (i.e. they win over everything in `extends`).
 | Field | Merge rule |
 |---|---|
 | `classes` | Per-slot: later plain replaces accumulator; `extend()` marker merges via `classesMergeFn` |
-| `variants` | Deep merge per variant name + value (later wins per slot) |
+| `variants` | Deep merge per variant **name**; last-wins per `(variantName, variantValue)` pair (the slot-class map for that value is replaced wholesale, not merged per-slot) |
 | `compoundVariants` | Concatenate from all chain layers |
 | `defaultVariants` | Shallow merge per key (later wins) |
 | `classesMergeFn` | Last-wins across the chain |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ A Vue 3 **theming framework** with shipped components — published as scoped `@
 
 The value proposition is layered:
 
-1. **Theming machinery** (`@vuecs/core`): `useComponentTheme` + `useComponentDefaults` composables, `<VCConfigProvider>`, design-token system (`@vuecs/design`), runtime palette + color-mode switching, and a typed augmentable theme registry (`ThemeElements`, `ComponentDefaults`, `Config`).
+1. **Theming machinery** (`@vuecs/core`): `useComponentTheme` + `useComponentDefaults` composables, `<VCConfigProvider>`, `defineTheme()` for composing themes that build on existing ones, design-token system (`@vuecs/design`), runtime palette + color-mode switching, and a typed augmentable theme registry (`ThemeElements`, `ComponentDefaults`, `Config`).
 2. **A baseline of theme-aware components** (button, navigation, forms, overlays, list, pagination, …) built on that machinery.
 3. **An opt-in path for third-party libraries** to publish their own components on the same machinery, so a downstream consumer reskins **everything** — vuecs primitives + third-party libraries — through a single `app.use(vuecs, { themes, overrides, defaults, config })` call.
 

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -71,6 +71,7 @@ export default defineConfig({
                     items: [
                         { text: 'Overview', link: '/guide/' },
                         { text: 'Theme System', link: '/guide/theme-system' },
+                        { text: 'Composing Themes', link: '/guide/composing-themes' },
                         { text: 'Variants', link: '/guide/variants' },
                         { text: 'Behavioral Defaults', link: '/guide/behavioral-defaults' },
                         { text: 'Design Tokens', link: '/guide/design-tokens' },

--- a/docs/src/guide/composing-themes.md
+++ b/docs/src/guide/composing-themes.md
@@ -55,7 +55,7 @@ For each component name across the chain:
 | Field | Merge rule |
 |---|---|
 | `classes` | Per-slot: later plain replaces accumulator; `extend()` marker merges via the chain's `classesMergeFn` |
-| `variants` | Deep merge per variant name + value (later wins per slot) |
+| `variants` | Deep merge per variant **name**; last-wins per `(variantName, variantValue)` pair (the slot-class map for that value is replaced wholesale, not merged per-slot) |
 | `compoundVariants` | Concatenate from all chain layers |
 | `defaultVariants` | Shallow merge per key (later wins) |
 | `classesMergeFn` | Last-wins across the chain |

--- a/docs/src/guide/composing-themes.md
+++ b/docs/src/guide/composing-themes.md
@@ -1,0 +1,89 @@
+# Composing themes
+
+Use `defineTheme()` to author a theme that builds on one or more existing themes — for example, to ship a third-party kit's own theme on top of `@vuecs/theme-tailwind`, or to layer in-app brand overrides without re-declaring every slot.
+
+The shape mirrors `tsconfig`'s `extends` field and Vue/Vite's `define*()` doctrine.
+
+## Quick example
+
+```ts
+import tailwindTheme from '@vuecs/theme-tailwind';
+import { defineTheme, extend } from '@vuecs/core';
+
+export const acmeTheme = () => defineTheme({
+    extends: tailwindTheme(),
+    elements: {
+        button: { classes: { root: extend('shadow-2xl') } },
+        acmeDataTable: { classes: { root: 'flex flex-col' } },
+    },
+});
+```
+
+Consumers install just the composed theme:
+
+```ts
+import vuecs from '@vuecs/core';
+import { acmeTheme } from '@acme/admin-kit';
+
+app.use(vuecs, { themes: [acmeTheme()] });
+```
+
+No need for the consumer to install Tailwind separately or remember to stack the override entry.
+
+## API
+
+```ts
+type ThemeConfig = {
+    extends?: Theme | Theme[];
+    elements?: Partial<ThemeElements>;
+    classesMergeFn?: ClassesMergeFn;
+    colorMode?: { apply: (doc: Document, mode: 'light' | 'dark') => void };
+    palette?: { render: (palette: Record<string, string>) => string; names?: readonly string[] };
+};
+
+function defineTheme(config: ThemeConfig): Theme;
+```
+
+Multi-base composition is natural — `extends: [a, b, c]` resolves left-to-right (rightmost wins), matching the runtime semantics of `themes: [a, b, c]` install-time stacking. The current config's own fields apply last and win over everything in `extends`.
+
+Omitting `extends` produces a leaf theme — `defineTheme({ elements: { … } })` is equivalent to writing the `Theme` literal by hand.
+
+## Merge rules
+
+For each component name across the chain:
+
+| Field | Merge rule |
+|---|---|
+| `classes` | Per-slot: later plain replaces accumulator; `extend()` marker merges via the chain's `classesMergeFn` |
+| `variants` | Deep merge per variant name + value (later wins per slot) |
+| `compoundVariants` | Concatenate from all chain layers |
+| `defaultVariants` | Shallow merge per key (later wins) |
+| `classesMergeFn` | Last-wins across the chain |
+| `colorMode.apply` | Compose: each layer's apply runs in chain order |
+| `palette.render` / `palette.names` | Last-wins (one renderer owns the runtime `<style>` block) |
+
+The `colorMode` and `palette` slots are reserved for plan 021's runtime hooks. They type-check today but are no-ops until that plan ships.
+
+## When to use it
+
+- **Third-party libraries** that ship their own themable components and want to publish a single self-contained theme that builds on Tailwind / Bootstrap / Bulma.
+- **In-app branding layers** that override a few slots on a base theme without re-declaring the whole shape.
+- **Variant cascades** that share a base set of compound variants and only override defaults per environment.
+
+For per-component instance overrides (one `<VCButton>` with a custom class), prefer the `themeClass` / `themeVariant` props — `defineTheme` is the authoring path, not the per-render override path.
+
+## Lower-level: `mergeThemes`
+
+`@vuecs/core` also exports `mergeThemes(themes: Theme[]): Theme`, the pure reducer that `defineTheme` delegates to. Use it when you have an array of themes and want to flatten them outside an authoring helper:
+
+```ts
+import { mergeThemes } from '@vuecs/core';
+
+const flat = mergeThemes([baseA, baseB, currentLayer]);
+// flat is a single Theme that resolves identically to themes: [baseA, baseB, currentLayer]
+```
+
+## See also
+
+- [Theme System](/guide/theme-system) — full resolution chain and `extend()` marker semantics
+- [Variants](/guide/variants) — variant + compound-variant authoring

--- a/packages/core/src/theme/define.ts
+++ b/packages/core/src/theme/define.ts
@@ -1,0 +1,33 @@
+import { mergeThemes, resolveExtends } from './merge-themes';
+import type { Theme, ThemeConfig } from './types';
+
+/**
+ * Author a Theme. Config-object form mirroring `tsconfig`'s `extends` /
+ * Vue's `defineComponent` doctrine.
+ *
+ * @example
+ * ```ts
+ * import tailwindTheme from '@vuecs/theme-tailwind';
+ * import { defineTheme, extend } from '@vuecs/core';
+ *
+ * export const acmeTheme = () => defineTheme({
+ *     extends: tailwindTheme(),
+ *     elements: {
+ *         button: { classes: { root: extend('shadow-2xl') } },
+ *     },
+ * });
+ * ```
+ *
+ * Multiple bases compose left-to-right (rightmost wins):
+ * `extends: [a, b, c]` matches `themes: [a, b, c]` install-time semantics.
+ */
+export function defineTheme(config: ThemeConfig): Theme {
+    const bases = resolveExtends(config.extends);
+
+    const ownTheme: Theme = { elements: config.elements ?? {} };
+    if (config.classesMergeFn) ownTheme.classesMergeFn = config.classesMergeFn;
+    if (config.colorMode) ownTheme.colorMode = config.colorMode;
+    if (config.palette) ownTheme.palette = config.palette;
+
+    return mergeThemes([...bases, ownTheme]);
+}

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -5,15 +5,20 @@ export { installThemeManager, injectThemeManager } from './install';
 export { useComponentTheme } from './composable';
 export type { UseComponentThemeProps } from './composable';
 export { extractVariantConfig, resolveVariantClasses } from './variant';
+export { defineTheme } from './define';
+export { mergeThemes } from './merge-themes';
 export type {
     ExtendValue,
     ClassesMergeFn,
     Theme,
+    ThemeConfig,
     ThemeElements,
     ThemeManagerOptions,
     ThemeClassesOverride,
     ThemeClassesOverrideValue,
     ThemeClasses,
+    ColorModeHook,
+    PaletteHook,
     ComponentThemeDefinition,
     ThemeElementDefinition,
     VariantSlotClasses,

--- a/packages/core/src/theme/merge-element.ts
+++ b/packages/core/src/theme/merge-element.ts
@@ -1,0 +1,111 @@
+import { isExtendValue } from './extend';
+import type {
+    ClassesMergeFn,
+    CompoundVariantDefinition,
+    DefaultVariants,
+    ThemeClassesOverride,
+    ThemeElementDefinition,
+    VariantDefinitions,
+} from './types';
+
+export function mergeClasses(
+    chain: (ThemeClassesOverride | undefined)[],
+    mergeFn: ClassesMergeFn,
+): ThemeClassesOverride {
+    const accumulator: Record<string, string> = {};
+
+    for (const layer of chain) {
+        if (!layer) continue;
+        const keys = Object.keys(layer);
+        for (const key of keys) {
+            const value = layer[key];
+            if (value === undefined) continue;
+
+            if (isExtendValue(value)) {
+                accumulator[key] = mergeFn(accumulator[key] || '', value.value);
+            } else {
+                accumulator[key] = value;
+            }
+        }
+    }
+
+    return accumulator as ThemeClassesOverride;
+}
+
+export function mergeVariants(
+    chain: (VariantDefinitions | undefined)[],
+): VariantDefinitions | undefined {
+    const merged: VariantDefinitions = {};
+    let touched = false;
+
+    for (const layer of chain) {
+        if (!layer) continue;
+        touched = true;
+        const names = Object.keys(layer);
+        for (const name of names) {
+            if (!merged[name]) merged[name] = {};
+            const def = layer[name];
+            const values = Object.keys(def);
+            for (const value of values) {
+                merged[name][value] = { ...def[value] };
+            }
+        }
+    }
+
+    return touched ? merged : undefined;
+}
+
+export function mergeCompoundVariants(
+    chain: (CompoundVariantDefinition[] | undefined)[],
+): CompoundVariantDefinition[] | undefined {
+    const merged: CompoundVariantDefinition[] = [];
+    let touched = false;
+
+    for (const layer of chain) {
+        if (!layer) continue;
+        touched = true;
+        for (const compound of layer) {
+            merged.push(compound);
+        }
+    }
+
+    return touched ? merged : undefined;
+}
+
+export function mergeDefaultVariants(
+    chain: (DefaultVariants | undefined)[],
+): DefaultVariants | undefined {
+    const merged: DefaultVariants = {};
+    let touched = false;
+
+    for (const layer of chain) {
+        if (!layer) continue;
+        touched = true;
+        Object.assign(merged, layer);
+    }
+
+    return touched ? merged : undefined;
+}
+
+export function mergeElement(
+    chain: ThemeElementDefinition[],
+    mergeFn: ClassesMergeFn,
+): ThemeElementDefinition {
+    const result: ThemeElementDefinition = {};
+
+    const classesChain = chain.map((entry) => entry.classes);
+    if (classesChain.some((c) => c !== undefined)) {
+        result.classes = mergeClasses(classesChain, mergeFn);
+    }
+
+    const variants = mergeVariants(chain.map((entry) => entry.variants));
+    if (variants) result.variants = variants;
+
+    const compoundVariants = mergeCompoundVariants(chain.map((entry) => entry.compoundVariants));
+    if (compoundVariants) result.compoundVariants = compoundVariants;
+
+    const defaultVariants = mergeDefaultVariants(chain.map((entry) => entry.defaultVariants));
+    if (defaultVariants) result.defaultVariants = defaultVariants;
+
+    return result;
+}

--- a/packages/core/src/theme/merge-themes.ts
+++ b/packages/core/src/theme/merge-themes.ts
@@ -58,7 +58,7 @@ export function mergeThemes(themes: Theme[]): Theme {
         return { elements: {} };
     }
     if (themes.length === 1) {
-        return themes[0];
+        return { ...themes[0] };
     }
 
     const classesMergeFn = pickClassesMergeFn(themes);

--- a/packages/core/src/theme/merge-themes.ts
+++ b/packages/core/src/theme/merge-themes.ts
@@ -1,0 +1,95 @@
+import { mergeElement } from './merge-element';
+import { defaultClassesMergeFn } from './resolve';
+import type {
+    ClassesMergeFn,
+    ColorModeHook,
+    PaletteHook,
+    Theme,
+    ThemeElementDefinition,
+    ThemeElements,
+} from './types';
+
+export function resolveExtends(value: Theme | Theme[] | undefined): Theme[] {
+    if (!value) return [];
+    if (Array.isArray(value)) return value;
+    return [value];
+}
+
+function pickClassesMergeFn(themes: Theme[]): ClassesMergeFn | undefined {
+    for (let i = themes.length - 1; i >= 0; i -= 1) {
+        const fn = themes[i]?.classesMergeFn;
+        if (fn) return fn;
+    }
+    return undefined;
+}
+
+function mergeColorMode(themes: Theme[]): ColorModeHook | undefined {
+    const hooks = themes.map((t) => t.colorMode).filter((h): h is ColorModeHook => Boolean(h));
+    if (hooks.length === 0) return undefined;
+    if (hooks.length === 1) return hooks[0];
+
+    return {
+        apply(doc, mode) {
+            for (const hook of hooks) {
+                hook.apply(doc, mode);
+            }
+        },
+    };
+}
+
+function mergePalette(themes: Theme[]): PaletteHook | undefined {
+    for (let i = themes.length - 1; i >= 0; i -= 1) {
+        const palette = themes[i]?.palette;
+        if (palette) return palette;
+    }
+    return undefined;
+}
+
+/**
+ * Flatten an ordered chain of themes into a single Theme. Left-to-right —
+ * later entries override earlier ones, matching the runtime semantics of
+ * `themes: [a, b, c]` install-time stacking.
+ *
+ * Pure function. Used by `defineTheme` to resolve `extends` chains, but
+ * also exported as a standalone helper for advanced composition.
+ */
+export function mergeThemes(themes: Theme[]): Theme {
+    if (themes.length === 0) {
+        return { elements: {} };
+    }
+    if (themes.length === 1) {
+        return themes[0];
+    }
+
+    const classesMergeFn = pickClassesMergeFn(themes);
+    const effectiveMergeFn = classesMergeFn || defaultClassesMergeFn;
+
+    const elementNames = new Set<string>();
+    for (const theme of themes) {
+        const elements = theme.elements as Record<string, ThemeElementDefinition>;
+        for (const name of Object.keys(elements)) {
+            elementNames.add(name);
+        }
+    }
+
+    const mergedElements: Record<string, ThemeElementDefinition> = {};
+    for (const name of elementNames) {
+        const chain = themes
+            .map((theme) => (theme.elements as Record<string, ThemeElementDefinition>)[name])
+            .filter((entry): entry is ThemeElementDefinition => Boolean(entry));
+
+        mergedElements[name] = mergeElement(chain, effectiveMergeFn);
+    }
+
+    const result: Theme = { elements: mergedElements as Partial<ThemeElements> };
+
+    if (classesMergeFn) result.classesMergeFn = classesMergeFn;
+
+    const colorMode = mergeColorMode(themes);
+    if (colorMode) result.colorMode = colorMode;
+
+    const palette = mergePalette(themes);
+    if (palette) result.palette = palette;
+
+    return result;
+}

--- a/packages/core/src/theme/types.ts
+++ b/packages/core/src/theme/types.ts
@@ -66,9 +66,62 @@ export type ThemeElementDefinition<T extends ThemeClasses = ThemeClasses> = {
 
 export interface ThemeElements {}
 
+/**
+ * Forward-compat hook for plan 021 (theme-configurable runtime hooks).
+ *
+ * A theme can declare an `apply` callback that toggles framework-specific
+ * dark-mode markers (e.g. `data-bs-theme`, `data-theme`) when color mode
+ * changes. Currently a no-op at runtime; reserved here so authoring code
+ * (`defineTheme`) compiles forward when plan 021 ships.
+ */
+export type ColorModeHook = {
+    apply: (doc: Document, mode: 'light' | 'dark') => void;
+};
+
+/**
+ * Forward-compat hook for plan 021 (theme-configurable runtime hooks).
+ *
+ * A theme can declare a palette renderer + the catalog of valid names it
+ * accepts. Currently a no-op at runtime; reserved here so authoring code
+ * (`defineTheme`) compiles forward when plan 021 ships.
+ */
+export type PaletteHook = {
+    render: (palette: Record<string, string>) => string;
+    names?: readonly string[];
+};
+
 export type Theme = {
     elements: Partial<ThemeElements>;
     classesMergeFn?: ClassesMergeFn;
+    colorMode?: ColorModeHook;
+    palette?: PaletteHook;
+};
+
+export type ThemeConfig = {
+    /**
+     * Theme(s) to inherit from. Resolved left-to-right; later entries
+     * override earlier ones. Omit to author a leaf theme from scratch.
+     */
+    extends?: Theme | Theme[];
+
+    /** Per-component slot/variant overrides (same shape as Theme.elements). */
+    elements?: Partial<ThemeElements>;
+
+    /** Optional class-merge function for `extend()` markers. Later wins across the chain. */
+    classesMergeFn?: ClassesMergeFn;
+
+    /**
+     * Plan 021 forward-compat slot. When ≥1 layer in the chain declares
+     * `colorMode.apply`, the merged theme exposes a composed callback that
+     * runs every layer's apply in chain order.
+     */
+    colorMode?: ColorModeHook;
+
+    /**
+     * Plan 021 forward-compat slot. Later wins across the chain — only one
+     * renderer can own the runtime palette `<style>` block.
+     */
+    palette?: PaletteHook;
 };
 
 export type ThemeManagerOptions = {

--- a/packages/core/test/unit/theme/define.spec.ts
+++ b/packages/core/test/unit/theme/define.spec.ts
@@ -1,0 +1,275 @@
+import { 
+    describe, 
+    expect, 
+    it, 
+    vi, 
+} from 'vitest';
+import { defineTheme } from '../../../src/theme/define';
+import { extend } from '../../../src/theme/extend';
+import { mergeThemes } from '../../../src/theme/merge-themes';
+import { resolveComponentTheme } from '../../../src/theme/resolve';
+import type {
+    ComponentThemeDefinition,
+    Theme,
+} from '../../../src/theme/types';
+
+const buttonDefaults: ComponentThemeDefinition = {
+    classes: {
+        root: 'vc-button',
+        icon: 'vc-button-icon',
+    },
+};
+
+describe('defineTheme', () => {
+    describe('leaf themes (no extends)', () => {
+        it('returns a Theme with empty elements when config is empty', () => {
+            const theme = defineTheme({});
+            expect(theme.elements).toEqual({});
+        });
+
+        it('returns a Theme carrying its own elements when no extends', () => {
+            const theme = defineTheme({ elements: { button: { classes: { root: 'tw-btn' } } } as Partial<Theme['elements']> });
+            const elements = theme.elements as Record<string, { classes?: Record<string, string> }>;
+            expect(elements.button?.classes).toEqual({ root: 'tw-btn' });
+        });
+    });
+
+    describe('single base extends', () => {
+        it('resolves identically to install-time stacking [base, current]', () => {
+            const base: Theme = { elements: { button: { classes: { root: 'base-btn' } } } as Partial<Theme['elements']> };
+
+            const merged = defineTheme({
+                extends: base,
+                elements: { button: { classes: { root: extend('extra') } } } as Partial<Theme['elements']>,
+            });
+
+            const fromMerged = resolveComponentTheme('button', buttonDefaults, [merged], undefined, undefined);
+            const fromStack = resolveComponentTheme(
+                'button',
+                buttonDefaults,
+                [base, { elements: { button: { classes: { root: extend('extra') } } } as Partial<Theme['elements']> }],
+                undefined,
+                undefined,
+            );
+
+            expect(fromMerged.root).toBe(fromStack.root);
+            expect(fromMerged.root).toBe('vc-button base-btn extra');
+        });
+
+        it('current plain values reset earlier extends but keep defaults at runtime', () => {
+            const base: Theme = { elements: { button: { classes: { root: extend('base-extend') } } } as Partial<Theme['elements']> };
+
+            const merged = defineTheme({
+                extends: base,
+                elements: { button: { classes: { root: 'plain-current' } } } as Partial<Theme['elements']>,
+            });
+
+            const result = resolveComponentTheme('button', buttonDefaults, [merged], undefined, undefined);
+            expect(result.root).toBe('vc-button plain-current');
+        });
+    });
+
+    describe('multi-base extends array', () => {
+        it('resolves left-to-right (rightmost wins)', () => {
+            const a: Theme = { elements: { button: { classes: { root: 'from-a' } } } as Partial<Theme['elements']> };
+            const b: Theme = { elements: { button: { classes: { root: 'from-b' } } } as Partial<Theme['elements']> };
+
+            const merged = defineTheme({ extends: [a, b] });
+            const result = resolveComponentTheme('button', buttonDefaults, [merged], undefined, undefined);
+
+            expect(result.root).toBe('vc-button from-b');
+        });
+
+        it('appends current config after all bases', () => {
+            const a: Theme = { elements: { button: { classes: { root: 'from-a' } } } as Partial<Theme['elements']> };
+            const b: Theme = { elements: { button: { classes: { root: 'from-b' } } } as Partial<Theme['elements']> };
+
+            const merged = defineTheme({
+                extends: [a, b],
+                elements: { button: { classes: { root: extend('from-current') } } } as Partial<Theme['elements']>,
+            });
+
+            const result = resolveComponentTheme('button', buttonDefaults, [merged], undefined, undefined);
+            expect(result.root).toBe('vc-button from-b from-current');
+        });
+    });
+
+    describe('variant merging', () => {
+        it('deep-merges variant definitions across the chain (later wins per slot)', () => {
+            const base: Theme = {
+                elements: {
+                    button: {
+                        variants: {
+                            size: {
+                                sm: { root: 'base-sm' },
+                                md: { root: 'base-md' },
+                            },
+                        },
+                    },
+                } as Partial<Theme['elements']>,
+            };
+
+            const merged = defineTheme({
+                extends: base,
+                elements: { button: { variants: { size: { sm: { root: 'override-sm' } } } } } as Partial<Theme['elements']>,
+            });
+
+            const elements = merged.elements as Record<string, { variants?: any }>;
+            expect(elements.button?.variants?.size).toEqual({
+                sm: { root: 'override-sm' },
+                md: { root: 'base-md' },
+            });
+        });
+
+        it('concatenates compoundVariants from all chain layers', () => {
+            const base: Theme = {
+                elements: {
+                    button: {
+                        compoundVariants: [
+                            { variants: { size: 'sm' }, class: { root: 'base-compound' } },
+                        ],
+                    },
+                } as Partial<Theme['elements']>,
+            };
+
+            const merged = defineTheme({
+                extends: base,
+                elements: {
+                    button: {
+                        compoundVariants: [
+                            { variants: { size: 'lg' }, class: { root: 'current-compound' } },
+                        ],
+                    },
+                } as Partial<Theme['elements']>,
+            });
+
+            const elements = merged.elements as Record<string, { compoundVariants?: any[] }>;
+            expect(elements.button?.compoundVariants).toHaveLength(2);
+        });
+
+        it('shallow-merges defaultVariants (later wins per key)', () => {
+            const base: Theme = { elements: { button: { defaultVariants: { size: 'md', color: 'primary' } } } as Partial<Theme['elements']> };
+
+            const merged = defineTheme({
+                extends: base,
+                elements: { button: { defaultVariants: { size: 'lg' } } } as Partial<Theme['elements']>,
+            });
+
+            const elements = merged.elements as Record<string, { defaultVariants?: any }>;
+            expect(elements.button?.defaultVariants).toEqual({ size: 'lg', color: 'primary' });
+        });
+    });
+
+    describe('classesMergeFn', () => {
+        it('picks the last layer that declares one (later wins)', () => {
+            const customA = (a: string, b: string) => `${a}|A|${b}`;
+            const customB = (a: string, b: string) => `${a}|B|${b}`;
+
+            const merged = defineTheme({
+                extends: [
+                    { elements: {}, classesMergeFn: customA },
+                    { elements: {}, classesMergeFn: customB },
+                ],
+            });
+
+            expect(merged.classesMergeFn).toBe(customB);
+        });
+
+        it('uses current config classesMergeFn over chain', () => {
+            const customA = (a: string, b: string) => `${a}|A|${b}`;
+            const customCurrent = (a: string, b: string) => `${a}|CURRENT|${b}`;
+
+            const merged = defineTheme({
+                extends: [{ elements: {}, classesMergeFn: customA }],
+                classesMergeFn: customCurrent,
+            });
+
+            expect(merged.classesMergeFn).toBe(customCurrent);
+        });
+
+        it('honors custom mergeFn when resolving extend() markers at flatten time', () => {
+            const pipeMerge = (a: string, b: string) => (a ? `${a}|${b}` : b);
+
+            const base: Theme = {
+                elements: { button: { classes: { root: 'base' } } } as Partial<Theme['elements']>,
+                classesMergeFn: pipeMerge,
+            };
+
+            const merged = defineTheme({
+                extends: base,
+                elements: { button: { classes: { root: extend('extra') } } } as Partial<Theme['elements']>,
+            });
+
+            const elements = merged.elements as Record<string, { classes?: Record<string, string> }>;
+            expect(elements.button?.classes?.root).toBe('base|extra');
+        });
+    });
+
+    describe('plan-021 forward-compat hooks', () => {
+        it('composes colorMode.apply across the chain in order', () => {
+            const calls: string[] = [];
+            const a: Theme = {
+                elements: {},
+                colorMode: { apply: () => { calls.push('A'); } },
+            };
+            const b: Theme = {
+                elements: {},
+                colorMode: { apply: () => { calls.push('B'); } },
+            };
+
+            const merged = defineTheme({ extends: [a, b] });
+
+            merged.colorMode!.apply({} as Document, 'dark');
+            expect(calls).toEqual(['A', 'B']);
+        });
+
+        it('preserves single colorMode hook reference when only one layer declares it', () => {
+            const hook = { apply: vi.fn() };
+            const merged = defineTheme({
+                extends: { elements: {} },
+                colorMode: hook,
+            });
+            expect(merged.colorMode).toBe(hook);
+        });
+
+        it('palette is later-wins across the chain', () => {
+            const renderA = () => 'a';
+            const renderB = () => 'b';
+            const merged = defineTheme({
+                extends: [
+                    { elements: {}, palette: { render: renderA } },
+                    { elements: {}, palette: { render: renderB } },
+                ],
+            });
+            expect(merged.palette?.render).toBe(renderB);
+        });
+
+        it('omits hooks when no layer declares them', () => {
+            const merged = defineTheme({ elements: {} });
+            expect(merged.colorMode).toBeUndefined();
+            expect(merged.palette).toBeUndefined();
+        });
+    });
+
+    describe('mergeThemes (standalone reducer)', () => {
+        it('returns empty Theme for empty array', () => {
+            expect(mergeThemes([])).toEqual({ elements: {} });
+        });
+
+        it('returns the same reference for single-element array', () => {
+            const theme: Theme = { elements: {} };
+            expect(mergeThemes([theme])).toBe(theme);
+        });
+
+        it('produces a result that resolves identically to runtime stacking', () => {
+            const a: Theme = { elements: { button: { classes: { root: 'a-class' } } } as Partial<Theme['elements']> };
+            const b: Theme = { elements: { button: { classes: { root: extend('b-extra') } } } as Partial<Theme['elements']> };
+
+            const merged = mergeThemes([a, b]);
+            const fromMerged = resolveComponentTheme('button', buttonDefaults, [merged], undefined, undefined);
+            const fromStack = resolveComponentTheme('button', buttonDefaults, [a, b], undefined, undefined);
+
+            expect(fromMerged.root).toBe(fromStack.root);
+        });
+    });
+});

--- a/packages/core/test/unit/theme/define.spec.ts
+++ b/packages/core/test/unit/theme/define.spec.ts
@@ -1,9 +1,4 @@
-import { 
-    describe, 
-    expect, 
-    it, 
-    vi, 
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { defineTheme } from '../../../src/theme/define';
 import { extend } from '../../../src/theme/extend';
 import { mergeThemes } from '../../../src/theme/merge-themes';
@@ -95,13 +90,13 @@ describe('defineTheme', () => {
     });
 
     describe('variant merging', () => {
-        it('deep-merges variant definitions across the chain (later wins per slot)', () => {
+        it('deep-merges variants per name; last-wins per (name, value) replacing the whole slot-class map', () => {
             const base: Theme = {
                 elements: {
                     button: {
                         variants: {
                             size: {
-                                sm: { root: 'base-sm' },
+                                sm: { root: 'base-sm', icon: 'base-sm-icon' },
                                 md: { root: 'base-md' },
                             },
                         },
@@ -115,6 +110,8 @@ describe('defineTheme', () => {
             });
 
             const elements = merged.elements as Record<string, { variants?: any }>;
+            // size.md preserved (deep merge per name); size.sm wholesale-replaced
+            // (icon dropped — last-wins per (name, value), not merged per-slot)
             expect(elements.button?.variants?.size).toEqual({
                 sm: { root: 'override-sm' },
                 md: { root: 'base-md' },
@@ -224,7 +221,7 @@ describe('defineTheme', () => {
         });
 
         it('preserves single colorMode hook reference when only one layer declares it', () => {
-            const hook = { apply: vi.fn() };
+            const hook = { apply: () => {} };
             const merged = defineTheme({
                 extends: { elements: {} },
                 colorMode: hook,
@@ -256,9 +253,11 @@ describe('defineTheme', () => {
             expect(mergeThemes([])).toEqual({ elements: {} });
         });
 
-        it('returns the same reference for single-element array', () => {
+        it('returns a defensive shallow clone for single-element array', () => {
             const theme: Theme = { elements: {} };
-            expect(mergeThemes([theme])).toBe(theme);
+            const result = mergeThemes([theme]);
+            expect(result).not.toBe(theme);
+            expect(result).toEqual(theme);
         });
 
         it('produces a result that resolves identically to runtime stacking', () => {


### PR DESCRIPTION
… (plan 022)

Ship `defineTheme(config)` and `mergeThemes(themes[])` from `@vuecs/core`. Config-object form mirroring `tsconfig`'s `extends` / Vue's `define*()` doctrine — `extends: Theme | Theme[]` resolves left-to-right (rightmost wins), matching install-time `themes: [a, b, c]` semantics.

The `Theme` type also grows two forward-compat slots — `colorMode.apply` (composed across the chain) and `palette.{render,names}` (last-wins) — reserved for plan 021's runtime hooks. They type-check today but are no-ops at runtime until plan 021 ships.

Primary unblock: third-party themable libraries can now publish a single self-contained theme that builds on `tailwindTheme()` / `bootstrapTheme()` without forcing every consumer to install Tailwind separately and stack the override entry. Closes the most concrete gap from plan 023's "vuecs as theming framework" framing.

Implementation is split across three files by concern:
- define.ts          — defineTheme() facade
- merge-themes.ts    — mergeThemes() reducer + theme-level orchestration
- merge-element.ts   — per-element merge helpers (classes/variants/
                       compoundVariants/defaultVariants)

Tests: 20 new specs in test/unit/theme/define.spec.ts covering leaf themes, single-base extends, multi-base array, variant merging, custom classesMergeFn last-wins, and plan-021 hook composition. Includes parity assertions vs. runtime stacking via resolveComponentTheme.

Docs: new "Composing themes" section in .agents/architecture.md and a new VitePress guide page at docs/src/guide/composing-themes.md.

Roadmap step 4 of plan 024.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added theme composition capability via `defineTheme()` with support for single and multi-base inheritance.
  * Introduced runtime hooks for color mode application and palette customization.
  * Theme merging follows consistent precedence rules with predictable field override semantics.

* **Documentation**
  * Added comprehensive "Composing Themes" guide with examples and best practices.
  * Updated architecture documentation with theming system layers.

* **Tests**
  * Added extensive unit test coverage for theme composition and merging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->