### PR TITLE
feat(core): themable-component helpers + build-themable-component guide

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -306,6 +306,64 @@ builds on `tailwindTheme()` without forcing every consumer to install
 Tailwind separately AND remember to stack the override entry. See
 plans 022, 023, and 024 (step 4) for the full design rationale.
 
+### Themable-component helpers (`themableProps` / `useThemeProps`, plan 024 step 5b)
+
+`@vuecs/core` ships two small helpers that collapse most of the
+themable-component boilerplate without wrapping Vue's `defineComponent`
+— so slot typing via `SlotsType<...>`, `expose`, `emits` validators,
+generic component types, and `vue-tsc` inference all keep working
+unchanged:
+
+- **`themableProps<T>()`** — returns the standard `themeClass` /
+  `themeVariant` prop declarations, typed against the slot map `T`.
+  Spread into your component's `props` block.
+- **`useThemeProps(props, ...shorthandKeys)`** — returns the reactive
+  `{ themeClass, themeVariant }` getter pair that `useComponentTheme`
+  expects. Folds shorthand variant props (e.g. `color`, `size`,
+  `density`) into `themeVariant` so consumers can write either
+  `<VCBadge color="primary">` or
+  `<VCBadge :theme-variant="{ color: 'primary' }">`.
+
+```ts
+const badgeProps = {
+    color: { type: String as PropType<BadgeColor>, default: undefined },
+    variant: { type: String as PropType<BadgeVariant>, default: undefined },
+    size: { type: String as PropType<BadgeSize>, default: undefined },
+    tag: { type: String, default: 'span' },
+    ...themableProps<BadgeThemeClasses>(),
+};
+
+export default defineComponent({
+    name: 'VCBadge',
+    inheritAttrs: false,
+    props: badgeProps,
+    setup(props, { attrs, slots }) {
+        const theme = useComponentTheme(
+            'badge',
+            useThemeProps(props, 'color', 'variant', 'size'),
+            badgeThemeDefaults,
+        );
+        return () => h(props.tag, mergeProps(attrs, { class: theme.value.root }), slots.default?.());
+    },
+});
+```
+
+Eliminates ~12 mechanical lines per themable component (duplicated
+prop declarations + the `themeProps` reactive-getter object + manual
+shorthand-variant folding) and removes the easy-to-mis-write
+reactive-getter pattern. Authoring stays inside Vue's standard
+`defineComponent`, so all of Vue's typing machinery applies.
+
+`@vuecs/elements`'s `<VCBadge>` is the canonical dogfood site —
+60 lines collapsed to 44, with no behavioural change.
+
+A higher-level `defineThemableComponent` factory was prototyped and
+rejected: wrapping `defineComponent` would require replicating Vue's
+overload-based slot/expose/generic-component inference machinery
+(brittle vs. future Vue versions), and the marginal additional savings
+(~3 lines per component beyond the helpers) didn't justify the risk
+of `vue-tsc` inference regressions.
+
 ## Global Behavioral Defaults (#1491)
 
 Alongside the theme system, `@vuecs/core` exposes a parallel `DefaultsManager` for

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -72,6 +72,7 @@ export default defineConfig({
                         { text: 'Overview', link: '/guide/' },
                         { text: 'Theme System', link: '/guide/theme-system' },
                         { text: 'Composing Themes', link: '/guide/composing-themes' },
+                        { text: 'Build Your Own Themable Component', link: '/guide/build-themable-component' },
                         { text: 'Variants', link: '/guide/variants' },
                         { text: 'Behavioral Defaults', link: '/guide/behavioral-defaults' },
                         { text: 'Design Tokens', link: '/guide/design-tokens' },

--- a/docs/src/guide/build-themable-component.md
+++ b/docs/src/guide/build-themable-component.md
@@ -177,7 +177,7 @@ app.component('MyDataTable', MyDataTable);
 app.mount('#app');
 ```
 
-`extend()` flips replace → merge: `header: extend('bg-muted/50')` keeps both the structural `mdt-header` class AND the theme's contribution AND adds the consumer's class. Without `extend()`, the consumer's value replaces lower layers (preserving structural defaults — see [Theme System](/guide/theme-system) for the full chain).
+`extend()` flips replace → merge: `header: extend('bg-muted/50')` keeps both the structural `mdt-header` class AND the theme's contribution AND adds the consumer's class. Without `extend()`, the consumer's value at the override layer (or the per-instance `themeClass` prop) **fully replaces every lower layer including the structural defaults** — wrap with `extend()` whenever you want the structural classes to survive. Themes (layer 2) are special: they always merge with defaults regardless. See [Theme System](/guide/theme-system) for the full chain.
 
 ### Per-instance override
 
@@ -250,7 +250,7 @@ const brandTheme = () => defineTheme({
 The same declaration-merging pattern extends to two more axes:
 
 - **`ComponentDefaults`** — register non-class behavioral defaults (button text, placeholder strings, icon names) that consumers can override globally for i18n or branding. See [Behavioral Defaults](/guide/behavioral-defaults).
-- **`Config`** — register cross-cutting config keys (CSP nonces, custom direction/locale, etc.) that your component reads via `useConfig()`. See [`<VCConfigProvider>` in architecture.md](/guide/theme-system) for the federated-schema pattern.
+- **`Config`** — register cross-cutting config keys (CSP nonces, custom direction/locale, etc.) that your component reads via `useConfig()`. The federated-schema pattern follows the same `declare module '@vuecs/core' { interface Config { ... } }` shape; subtree-scoped overrides are exposed via `<VCConfigProvider>`.
 
 Both follow the same `declare module '@vuecs/core' { interface ... }` shape as `ThemeElements`.
 

--- a/docs/src/guide/build-themable-component.md
+++ b/docs/src/guide/build-themable-component.md
@@ -1,0 +1,268 @@
+# Build your own themable component
+
+The vuecs theme system isn't reserved for `@vuecs/*` packages — any third-party component can plug into it and inherit the same `app.use(vuecs, ...)` config surface, runtime palette switching, and theme-extends story.
+
+This guide walks through a worked example: an `<MyDataTable>` component that registers its own theme slots, resolves classes via `useComponentTheme`, and lets downstream consumers reskin it through the same override layer that vuecs's primitives use.
+
+## What "themable" means here
+
+A vuecs-themable component is one that:
+
+1. Declares a typed slot map via TypeScript declaration merging on `ThemeElements`.
+2. Resolves classes through vuecs's `ThemeManager`, exposing the standard `themeClass` / `themeVariant` props every vuecs component exposes.
+3. Reads the resolved class strings when rendering.
+
+That's the whole contract. No registration, no plugin, no global state — just a typed slot declaration plus a couple of helper calls inside an ordinary Vue `defineComponent`.
+
+`@vuecs/core` ships two small helpers that collapse most of the boilerplate while leaving Vue's `defineComponent` API untouched (so slot typing, `expose`, generic component types, and `vue-tsc` inference all keep working):
+
+- **`themableProps<T>()`** — returns the standard `themeClass` / `themeVariant` prop declarations, typed against your slot map. Spread into your component's `props` block.
+- **`useThemeProps(props, ...shorthandVariantKeys)`** — returns the reactive `{ themeClass, themeVariant }` getter pair that `useComponentTheme` expects. Folds shorthand variant props (e.g. `color`, `size`, `density`) into `themeVariant`.
+
+Together they replace ~12 mechanical lines per component (the duplicated prop declarations + the hand-rolled reactive-getter object + manual variant folding) without changing the call site's shape — you still write `defineComponent({ ... })`.
+
+## The example: `<MyDataTable>`
+
+We'll build a tiny data table with three theme slots:
+
+| Slot | Element |
+|---|---|
+| `root` | The outer `<div>` wrapping the table |
+| `header` | The header `<thead>` |
+| `row` | Each body `<tr>` |
+
+Plus a single variant axis: `density` ∈ `'compact' | 'normal' | 'spacious'`.
+
+### Step 1 — Declare the theme contract
+
+```ts
+// my-data-table/types.ts
+import type { ThemeElementDefinition } from '@vuecs/core';
+
+export type MyDataTableDensity = 'compact' | 'normal' | 'spacious';
+
+export type MyDataTableThemeClasses = {
+    /** The wrapping container. */
+    root: string;
+    /** The `<thead>` element. */
+    header: string;
+    /** Each body `<tr>`. */
+    row: string;
+};
+
+declare module '@vuecs/core' {
+    interface ThemeElements {
+        myDataTable?: ThemeElementDefinition<MyDataTableThemeClasses>;
+    }
+}
+```
+
+The `declare module '@vuecs/core'` block extends vuecs's `ThemeElements` interface to register your component name (`myDataTable`) alongside vuecs's built-ins. Any consumer importing this file picks up the augmentation automatically — they get autocomplete + type-checking for `myDataTable` in `app.use(vuecs, { overrides: { elements: { /* myDataTable here */ } } })`.
+
+### Step 2 — Define the component's defaults
+
+```ts
+// my-data-table/theme.ts
+import type { ComponentThemeDefinition } from '@vuecs/core';
+import type { MyDataTableThemeClasses } from './types';
+
+export const myDataTableThemeDefaults: ComponentThemeDefinition<MyDataTableThemeClasses> = {
+    classes: {
+        root: 'mdt-root',
+        header: 'mdt-header',
+        row: 'mdt-row',
+    },
+    variants: {
+        density: {
+            compact: { row: 'mdt-row-compact' },
+            normal: { row: 'mdt-row-normal' },
+            spacious: { row: 'mdt-row-spacious' },
+        },
+    },
+    defaultVariants: { density: 'normal' },
+};
+```
+
+These are the **structural** classes — the ones that always apply, regardless of which theme is installed. The convention is to prefix them with your library's namespace (`mdt-` here, like vuecs uses `vc-`). Pair them with a small CSS file that gives `.mdt-*` reasonable structural rules (display, padding, table-layout) — themes layer cosmetic styling on top.
+
+### Step 3 — Build the component
+
+```vue
+<!-- my-data-table/MyDataTable.vue -->
+<script lang="ts">
+import { defineComponent, h } from 'vue';
+import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
+import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
+import { myDataTableThemeDefaults } from './theme';
+import type { MyDataTableDensity, MyDataTableThemeClasses } from './types';
+
+const myDataTableProps = {
+    /** Row data. */
+    rows: { type: Array as PropType<Array<Record<string, unknown>>>, default: () => [] },
+    /** Density variant — resolved by the active theme. */
+    density: { type: String as PropType<MyDataTableDensity>, default: undefined },
+    ...themableProps<MyDataTableThemeClasses>(),
+};
+
+export type MyDataTableProps = ExtractPublicPropTypes<typeof myDataTableProps>;
+
+export default defineComponent({
+    name: 'MyDataTable',
+    props: myDataTableProps,
+    slots: Object as SlotsType<{
+        header?: () => unknown;
+        row?: (props: { row: Record<string, unknown> }) => unknown;
+    }>,
+    setup(props, { slots }) {
+        const theme = useComponentTheme(
+            'myDataTable',
+            useThemeProps(props, 'density'),
+            myDataTableThemeDefaults,
+        );
+
+        return () => h('div', { class: theme.value.root }, [
+            h('table', [
+                h('thead', { class: theme.value.header }, slots.header?.()),
+                h('tbody', props.rows.map((row) => h('tr', { class: theme.value.row }, slots.row?.({ row }) ?? []))),
+            ]),
+        ]);
+    },
+});
+</script>
+```
+
+What the helpers do:
+
+- **`themableProps<MyDataTableThemeClasses>()`** spreads the standard `themeClass` / `themeVariant` prop declarations into your `props` block, typed against your slot map. Consumers can pass `:theme-class="{ root: 'extra' }"` per instance without you re-declaring the prop types yourself.
+- **`useThemeProps(props, 'density')`** returns the reactive `{ themeClass, themeVariant }` getter pair that `useComponentTheme` expects. The shorthand-variant folding means consumers can write either `<MyDataTable density="compact" />` or `<MyDataTable :theme-variant="{ density: 'compact' }" />` — both resolve identically.
+
+Notice this is a plain `defineComponent` call. Slot typing via `SlotsType<...>`, `expose`, `emits` validators, generic component types, and recursive `<Self>` references all keep working — vuecs's helpers don't wrap or replace Vue's authoring API.
+
+That's the whole component. No vuecs install hook, no manager registration.
+
+## Closing the loop: consumer-side override
+
+A consumer of your library installs vuecs once and configures every component — vuecs's primitives **plus your `<MyDataTable>`** — through the same call:
+
+```ts
+// app/main.ts
+import { createApp } from 'vue';
+import vuecs, { extend } from '@vuecs/core';
+import tailwindTheme from '@vuecs/theme-tailwind';
+import { MyDataTable } from 'my-data-table';
+import App from './App.vue';
+
+const app = createApp(App);
+
+app.use(vuecs, {
+    themes: [tailwindTheme()],
+    overrides: {
+        elements: {
+            // Reskin a vuecs primitive
+            button: { classes: { root: 'shadow-lg' } },
+
+            // Reskin your library's component the same way
+            myDataTable: {
+                classes: {
+                    root: 'rounded-xl ring-1 ring-border',
+                    header: extend('bg-muted/50'),
+                    row: extend('hover:bg-muted/30'),
+                },
+            },
+        },
+    },
+});
+
+app.component('MyDataTable', MyDataTable);
+app.mount('#app');
+```
+
+`extend()` flips replace → merge: `header: extend('bg-muted/50')` keeps both the structural `mdt-header` class AND the theme's contribution AND adds the consumer's class. Without `extend()`, the consumer's value replaces lower layers (preserving structural defaults — see [Theme System](/guide/theme-system) for the full chain).
+
+### Per-instance override
+
+The same shape works per-instance via the `themeClass` prop:
+
+```vue
+<template>
+  <MyDataTable
+    :rows="users"
+    density="compact"
+    :theme-class="{ row: extend('cursor-pointer') }"
+  />
+</template>
+```
+
+## Publishing your own theme
+
+If your library has a strong opinion about how its components should look — e.g. a Tailwind-based style baseline that consumers can opt into — you can ship that as a **theme** rather than a per-component overrides bundle. Use [`defineTheme()`](/guide/composing-themes) to build on an existing base:
+
+```ts
+// my-data-table/theme-tailwind.ts
+import tailwindTheme from '@vuecs/theme-tailwind';
+import { defineTheme, extend } from '@vuecs/core';
+
+export const myDataTableTailwindTheme = () => defineTheme({
+    extends: tailwindTheme(),
+    elements: {
+        // Reskin your own component
+        myDataTable: {
+            classes: {
+                root: 'rounded-lg ring-1 ring-border bg-bg',
+                header: 'bg-muted text-fg-muted text-sm font-semibold',
+                row: extend('border-b border-border last:border-0'),
+            },
+            variants: {
+                density: {
+                    compact: { row: 'py-1 text-sm' },
+                    normal: { row: 'py-2' },
+                    spacious: { row: 'py-3 text-base' },
+                },
+            },
+        },
+
+        // Optionally tweak vuecs primitives so your kit feels coherent
+        button: { classes: { root: extend('font-medium') } },
+    },
+});
+```
+
+Consumers get the whole stack — Tailwind base + your data-table styling + your button tweaks — by installing one theme:
+
+```ts
+app.use(vuecs, { themes: [myDataTableTailwindTheme()] });
+```
+
+No need for them to install Tailwind separately or remember to stack the override entry. They can still extend further with their own brand layer:
+
+```ts
+import { defineTheme } from '@vuecs/core';
+import { myDataTableTailwindTheme } from 'my-data-table/theme-tailwind';
+
+const brandTheme = () => defineTheme({
+    extends: myDataTableTailwindTheme(),
+    elements: { button: { classes: { root: extend('rounded-full') } } },
+});
+```
+
+## Variants and behavioral defaults
+
+The same declaration-merging pattern extends to two more axes:
+
+- **`ComponentDefaults`** — register non-class behavioral defaults (button text, placeholder strings, icon names) that consumers can override globally for i18n or branding. See [Behavioral Defaults](/guide/behavioral-defaults).
+- **`Config`** — register cross-cutting config keys (CSP nonces, custom direction/locale, etc.) that your component reads via `useConfig()`. See [`<VCConfigProvider>` in architecture.md](/guide/theme-system) for the federated-schema pattern.
+
+Both follow the same `declare module '@vuecs/core' { interface ... }` shape as `ThemeElements`.
+
+## What you don't have to do
+
+- **No global registration.** Your `<MyDataTable>` is a normal Vue component. Register it however you'd register any third-party component (`app.component(...)`, auto-import, manual import per page).
+- **No theme manager plumbing.** `useComponentTheme` resolves through the `ThemeManager` that `@vuecs/core` already installed. As long as the consumer called `app.use(vuecs, ...)` somewhere, your component picks it up.
+- **No CSS-in-JS or build-time codegen.** Themes are plain functions returning a config object — they're tree-shakeable and serializable.
+
+## See also
+
+- [Theme System](/guide/theme-system) — the four-layer resolution chain and `extend()` semantics
+- [Composing Themes](/guide/composing-themes) — `defineTheme()` for inheriting and overriding
+- [Variants](/guide/variants) — variant + compound-variant authoring
+- [Behavioral Defaults](/guide/behavioral-defaults) — non-class defaults registered via `ComponentDefaults`

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -7,6 +7,7 @@ export type { UseComponentThemeProps } from './composable';
 export { extractVariantConfig, resolveVariantClasses } from './variant';
 export { defineTheme } from './define';
 export { mergeThemes } from './merge-themes';
+export { themableProps, useThemeProps } from './themable';
 export type {
     ExtendValue,
     ClassesMergeFn,

--- a/packages/core/src/theme/themable.ts
+++ b/packages/core/src/theme/themable.ts
@@ -1,0 +1,77 @@
+import type { PropType } from 'vue';
+import type { UseComponentThemeProps } from './composable';
+import type {
+    ThemeClasses,
+    ThemeClassesOverride,
+    VariantValues,
+} from './types';
+
+/**
+ * Standard `themeClass` + `themeVariant` prop declarations every themable
+ * component exposes. Spread into your component's props block:
+ *
+ * ```ts
+ * const myProps = {
+ *     ...themableProps<MyThemeClasses>(),
+ *     rows: { type: Array, default: () => [] },
+ * };
+ * ```
+ *
+ * The generic parameter binds `themeClass`'s value to your component's
+ * slot map, so consumers get autocomplete and typo detection for slot
+ * keys in the override object.
+ */
+export function themableProps<T extends ThemeClasses>() {
+    return {
+        /** Theme-class overrides for this component instance. */
+        themeClass: { type: Object as PropType<ThemeClassesOverride<T>>, default: undefined },
+        /** Theme-variant values for this component instance. */
+        themeVariant: { type: Object as PropType<VariantValues>, default: undefined },
+    };
+}
+
+/**
+ * Build the reactive `themeClass` / `themeVariant` getter object for
+ * `useComponentTheme`. Folds shorthand variant props (e.g. `color`,
+ * `size`, `density`) into the resolved `themeVariant` so consumers can
+ * write either `<MyComp size="sm">` or
+ * `<MyComp :theme-variant="{ size: 'sm' }">`.
+ *
+ * @param props The reactive `props` object from `setup(props)`. Must be
+ *              the live proxy — not a destructured copy — so reactivity
+ *              tracks across changes.
+ * @param shorthandVariantKeys Names of consumer props to fold into
+ *                             `themeVariant`. Pass them as the
+ *                             `defaults.variants` keys.
+ *
+ * @example
+ * ```ts
+ * setup(props) {
+ *     const theme = useComponentTheme(
+ *         'badge',
+ *         useThemeProps(props, 'color', 'variant', 'size'),
+ *         badgeThemeDefaults,
+ *     );
+ * }
+ * ```
+ */
+export function useThemeProps<T extends ThemeClasses>(
+    props: UseComponentThemeProps<T> & Record<string, unknown>,
+    ...shorthandVariantKeys: string[]
+): UseComponentThemeProps<T> {
+    return {
+        get themeClass() {
+            return props.themeClass;
+        },
+        get themeVariant() {
+            const result: VariantValues = { ...(props.themeVariant ?? {}) };
+            for (const key of shorthandVariantKeys) {
+                const value = props[key];
+                if (value !== undefined) {
+                    result[key] = value as string | boolean;
+                }
+            }
+            return result;
+        },
+    };
+}

--- a/packages/core/test/unit/theme/themable.spec.ts
+++ b/packages/core/test/unit/theme/themable.spec.ts
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { defineComponent, h, nextTick } from 'vue';
+import type { PropType } from 'vue';
+import { mount } from '@vue/test-utils';
+import { themableProps, useThemeProps } from '../../../src/theme/themable';
+import { useComponentTheme } from '../../../src/theme/composable';
+import { installThemeManager } from '../../../src/theme/install';
+
+type CardThemeClasses = {
+    root: string;
+    body: string;
+};
+
+const cardDefaults = {
+    classes: { root: 'vc-card', body: 'vc-card-body' },
+    variants: {
+        size: {
+            sm: { root: 'vc-card-sm' },
+            lg: { root: 'vc-card-lg' },
+        },
+        color: {
+            primary: { root: 'vc-card-primary' },
+            danger: { root: 'vc-card-danger' },
+        },
+    },
+};
+
+function withTheme(component: any, options: Parameters<typeof installThemeManager>[1] = {}) {
+    return mount(component, { global: { plugins: [[{ install: (app: any) => installThemeManager(app, options) }]] } });
+}
+
+describe('themableProps', () => {
+    it('returns the standard themeClass + themeVariant prop declarations', () => {
+        const declarations = themableProps<CardThemeClasses>();
+        expect(declarations.themeClass.type).toBe(Object);
+        expect(declarations.themeClass.default).toBeUndefined();
+        expect(declarations.themeVariant.type).toBe(Object);
+        expect(declarations.themeVariant.default).toBeUndefined();
+    });
+
+    it('spreads cleanly into a defineComponent props block', () => {
+        const Card = defineComponent({
+            props: {
+                size: { type: String as PropType<'sm' | 'lg'>, default: undefined },
+                ...themableProps<CardThemeClasses>(),
+            },
+            setup(props) {
+                const theme = useComponentTheme(
+                    'card',
+                    useThemeProps(props, 'size'),
+                    cardDefaults,
+                );
+                return () => h('div', { class: theme.value.root });
+            },
+        });
+
+        const wrapper = withTheme(Card);
+        expect(wrapper.element.outerHTML).toContain('vc-card');
+    });
+});
+
+describe('useThemeProps', () => {
+    it('returns getter pair forwarding themeClass / themeVariant', () => {
+        const props = {
+            themeClass: { root: 'a' },
+            themeVariant: { size: 'sm' },
+        };
+        const out = useThemeProps<CardThemeClasses>(props as any);
+        expect(out.themeClass).toEqual({ root: 'a' });
+        expect(out.themeVariant).toEqual({ size: 'sm' });
+    });
+
+    it('folds shorthand variant props into themeVariant', () => {
+        const props = {
+            color: 'primary',
+            size: 'sm',
+            themeVariant: undefined,
+        } as any;
+        const out = useThemeProps<CardThemeClasses>(props, 'color', 'size');
+        expect(out.themeVariant).toEqual({ color: 'primary', size: 'sm' });
+    });
+
+    it('skips undefined shorthand props', () => {
+        const props = {
+            color: undefined,
+            size: 'lg',
+            themeVariant: undefined,
+        } as any;
+        const out = useThemeProps<CardThemeClasses>(props, 'color', 'size');
+        expect(out.themeVariant).toEqual({ size: 'lg' });
+    });
+
+    it('shorthand props override themeVariant entries with the same key', () => {
+        const props = {
+            color: 'primary',
+            themeVariant: { color: 'danger' },
+        } as any;
+        const out = useThemeProps<CardThemeClasses>(props, 'color');
+        expect(out.themeVariant).toEqual({ color: 'primary' });
+    });
+
+    it('returns a fresh themeVariant object on each access', () => {
+        const props = {
+            color: 'primary',
+            themeVariant: undefined,
+        } as any;
+        const out = useThemeProps<CardThemeClasses>(props, 'color');
+        expect(out.themeVariant).not.toBe(out.themeVariant);
+    });
+
+    it('reactivity holds when used inside a real component setup', async () => {
+        const Card = defineComponent({
+            props: {
+                size: { type: String as PropType<'sm' | 'lg'>, default: undefined },
+                ...themableProps<CardThemeClasses>(),
+            },
+            setup(props) {
+                const theme = useComponentTheme(
+                    'card',
+                    useThemeProps(props, 'size'),
+                    cardDefaults,
+                );
+                return () => h('div', { class: theme.value.root });
+            },
+        });
+
+        const wrapper = withTheme({
+            components: { Card },
+            data: () => ({ size: 'sm' as 'sm' | 'lg' }),
+            template: '<Card :size="size" />',
+        });
+
+        expect(wrapper.element.outerHTML).toContain('vc-card-sm');
+        await wrapper.setData({ size: 'lg' });
+        await nextTick();
+        expect(wrapper.element.outerHTML).toContain('vc-card-lg');
+        expect(wrapper.element.outerHTML).not.toContain('vc-card-sm');
+    });
+});

--- a/packages/elements/src/components/badge/Badge.vue
+++ b/packages/elements/src/components/badge/Badge.vue
@@ -1,12 +1,7 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
 import type { ExtractPublicPropTypes, PropType } from 'vue';
-import { useComponentTheme } from '@vuecs/core';
-import type {
-    ThemeClassesOverride,
-    UseComponentThemeProps,
-    VariantValues,
-} from '@vuecs/core';
+import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
 import { badgeThemeDefaults } from './theme';
 import type {
     BadgeColor,
@@ -24,10 +19,7 @@ const badgeProps = {
     size: { type: String as PropType<BadgeSize>, default: undefined },
     /** HTML tag to render. */
     tag: { type: String, default: 'span' },
-    /** Theme-class overrides for this component instance. */
-    themeClass: { type: Object as PropType<ThemeClassesOverride<BadgeThemeClasses>>, default: undefined },
-    /** Theme-variant values for this component instance. */
-    themeVariant: { type: Object as PropType<VariantValues>, default: undefined },
+    ...themableProps<BadgeThemeClasses>(),
 };
 
 export type BadgeProps = ExtractPublicPropTypes<typeof badgeProps>;
@@ -37,20 +29,11 @@ export default defineComponent({
     inheritAttrs: false,
     props: badgeProps,
     setup(props, { attrs, slots }) {
-        const themeProps: UseComponentThemeProps<BadgeThemeClasses> = {
-            get themeClass() {
-                return props.themeClass;
-            },
-            get themeVariant() {
-                return {
-                    ...(props.themeVariant ?? {}),
-                    ...(props.color !== undefined ? { color: props.color } : {}),
-                    ...(props.variant !== undefined ? { variant: props.variant } : {}),
-                    ...(props.size !== undefined ? { size: props.size } : {}),
-                };
-            },
-        };
-        const theme = useComponentTheme('badge', themeProps, badgeThemeDefaults);
+        const theme = useComponentTheme(
+            'badge',
+            useThemeProps(props, 'color', 'variant', 'size'),
+            badgeThemeDefaults,
+        );
         return () => h(
             props.tag,
             mergeProps(attrs, { class: theme.value.root || undefined }),


### PR DESCRIPTION
Plan 023 Gaps 1+2, plan 024 steps 5+5b.

Two new helpers in @vuecs/core that collapse the boilerplate every themable component otherwise repeats, without wrapping Vue's `defineComponent`:

- `themableProps<T>()` — returns the standard `themeClass` / `themeVariant` prop declarations typed against the slot map `T`. Spread into your component's `props` block.
- `useThemeProps(props, ...shorthandKeys)` — returns the reactive `{ themeClass, themeVariant }` getter pair that `useComponentTheme` expects. Folds shorthand variant props (e.g. `color`, `size`, `density`) into `themeVariant` so consumers can write `<VCBadge color="primary" />` or `<VCBadge :theme-variant="{ color: 'primary' }" />` interchangeably.

Authoring stays inside Vue's standard `defineComponent`, so slot typing via `SlotsType<...>`, `expose`, `emits` validators, generic component types, and `vue-tsc` slot inference all keep working.

A higher-level `defineThemableComponent` factory was prototyped and rejected: wrapping `defineComponent` would require replicating Vue's overload-based slot/expose/generic-component inference (brittle vs. future Vue versions), and the marginal additional savings (~3 lines per component) didn't justify the risk of vue-tsc inference regressions.

VCBadge migrated as the canonical dogfood site (60 → 44 lines, no behavioural change). 8 new tests in
packages/core/test/unit/theme/themable.spec.ts cover both helpers including end-to-end reactivity and the spread-into-defineComponent contract.

Also adds `docs/src/guide/build-themable-component.md` — a worked-example walkthrough demonstrating the third-party-author path end-to-end: ThemeElements declaration merging, helper-driven theme resolution, consumer-side override snippet, per-instance themeClass prop, and a "publishing your own theme" section showing how to compose on top of tailwindTheme() via defineTheme().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide on building themable Vue components and a documentation section describing the theming helpers and patterns.

* **New Features**
  * Published reusable theming helpers to standardize theme props and resolution for components.

* **Refactor**
  * Simplified the Badge component to use the new theming helpers, reducing prop boilerplate.

* **Tests**
  * Added unit tests covering theming prop behavior and reactive updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1545)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->