### PR TITLE
feat(design,themes): generic useColorPalette dispatcher 

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -364,6 +364,54 @@ overload-based slot/expose/generic-component inference machinery
 (~3 lines per component beyond the helpers) didn't justify the risk
 of `vue-tsc` inference regressions.
 
+### Theme-configurable runtime hooks (`Theme.colorMode` / `Theme.palette`, plan 021)
+
+The `Theme` type carries two optional runtime-hook slots that themes
+use to attach framework-specific side effects to color-mode and
+palette switching. Both slots are no-ops by default — themes opt in
+when they need framework-specific mirroring.
+
+```ts
+type Theme = {
+    elements: Partial<ThemeElements>;
+    classesMergeFn?: ClassesMergeFn;
+    colorMode?: { apply(doc: Document, mode: 'light' | 'dark'): void };
+    palette?: {
+        render(palette: Record<string, string>): string;
+        names?: readonly string[];
+    };
+};
+```
+
+**`colorMode.apply`** fires after `useColorMode` toggles `.dark` /
+`.light` on `<html>`. theme-bootstrap declares it to mirror the
+resolved mode onto `data-bs-theme` (so Bootstrap 5.3+ chrome flips
+alongside vuecs's `--vc-color-*`); theme-bulma declares it for
+`data-theme`. theme-tailwind doesn't declare it — Tailwind reads
+`.dark` directly. Multiple hooks compose: every layer's `apply` runs
+in install order on every change.
+
+**`palette.{render, names}`** is the declarative half of runtime
+palette switching. Each theme exposes its renderer (the function
+that converts a palette config into a CSS string) plus the catalog
+of names it accepts. theme-tailwind and theme-bulma both declare
+this against the shared 22-name Tailwind palette catalog. (The
+generic dispatcher in `@vuecs/design` that consumes these hooks is
+the next slice of plan 021; for now, the per-theme `useColorPalette`
+exports keep wiring rendering directly.)
+
+The hooks bridge across packages without coupling `@vuecs/design` to
+`@vuecs/core`: both packages reference the same
+`Symbol.for('VCThemeManager')` registry key, and `@vuecs/design`'s
+`useThemeRuntimeManager()` looks the manager up via `inject()` with
+a structural projection of the slots it needs. No runtime dep, no
+type dep — just shared symbol convention.
+
+Net effect: BS / Bulma example apps no longer need per-app
+`watchEffect` mirrors for `data-bs-theme` / `data-theme`. The pattern
+that previously repeated for every consumer now lives in the theme
+exactly once.
+
 ## Global Behavioral Defaults (#1491)
 
 Alongside the theme system, `@vuecs/core` exposes a parallel `DefaultsManager` for

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -395,10 +395,26 @@ in install order on every change.
 palette switching. Each theme exposes its renderer (the function
 that converts a palette config into a CSS string) plus the catalog
 of names it accepts. theme-tailwind and theme-bulma both declare
-this against the shared 22-name Tailwind palette catalog. (The
-generic dispatcher in `@vuecs/design` that consumes these hooks is
-the next slice of plan 021; for now, the per-theme `useColorPalette`
-exports keep wiring rendering directly.)
+this against the shared 22-name Tailwind palette catalog.
+
+`@vuecs/design`'s `useColorPalette()` walks installed themes and
+**concatenates** every theme's `palette.render` output into the
+`<style id="vc-color-palette">` block. The per-theme
+`useColorPalette` exports in `@vuecs/theme-tailwind` and
+`@vuecs/theme-bulma` are now thin wrappers that pass the
+theme-specific sanitizer + types through to the generic dispatcher.
+
+Concat (rather than last-wins) is the doctrinal semantic: when an
+app stacks multiple palette-aware themes (the docs-site case where
+Tailwind and Bulma components share the same picker UI), each
+theme's renderer emits its own non-overlapping CSS rules — Tailwind
+rebinds `--vc-color-*`, Bulma writes per-variant HSL channel vars
++ explicit selectors. The CSS cascade resolves any incidental
+overlap with later-rule-wins semantics, so concat behaves like
+last-wins for overlapping properties AND emits both themes' unique
+properties. Walking `manager.themes` inside the `watchEffect`
+subscribes to `setThemes()`, so runtime theme swaps automatically
+re-render the `<style>` block.
 
 The hooks bridge across packages without coupling `@vuecs/design` to
 `@vuecs/core`: both packages reference the same

--- a/examples/bootstrap/src/App.vue
+++ b/examples/bootstrap/src/App.vue
@@ -1,28 +1,14 @@
 <script setup lang="ts">
 import { sharedRoutes } from '@vuecs-examples/shared/routes';
 import { useColorMode } from '@vuecs/design';
-import { onMounted, watchEffect } from 'vue';
 import { RouterLink, RouterView } from 'vue-router';
 
-const { resolved, toggle } = useColorMode();
-
 /*
- * The vuecs design-system toggles `.dark` on <html>. The
- * theme-bootstrap bridge uses that class as the source of truth for
- * `--vc-color-*` flips, but Bootstrap 5.3 components (navbar text,
- * dropdown chrome, form-control bg, etc.) read `--bs-*` vars that
- * Bootstrap itself only flips under `[data-bs-theme="dark"]`. Mirror
- * the resolved color mode onto that attribute so Bootstrap's own
- * dark-mode chain fires alongside vuecs's. Note: `useColorMode`
- * exposes the *resolved* mode (so `system` becomes `light` or `dark`).
+ * The `data-bs-theme` attribute is mirrored automatically by
+ * theme-bootstrap's `colorMode.apply` runtime hook (plan 021). No
+ * per-app `watchEffect` mirror is needed.
  */
-const syncBootstrapTheme = () => {
-    if (typeof globalThis.document === 'undefined') return;
-    globalThis.document.documentElement.setAttribute('data-bs-theme', resolved.value);
-};
-
-onMounted(syncBootstrapTheme);
-watchEffect(syncBootstrapTheme);
+const { resolved, toggle } = useColorMode();
 </script>
 
 <template>

--- a/examples/bulma/src/App.vue
+++ b/examples/bulma/src/App.vue
@@ -1,26 +1,14 @@
 <script setup lang="ts">
 import { sharedRoutes } from '@vuecs-examples/shared/routes';
 import { useColorMode } from '@vuecs/design';
-import { onMounted, watchEffect } from 'vue';
 import { RouterLink, RouterView } from 'vue-router';
 
-const { resolved, toggle } = useColorMode();
-
 /*
- * The vuecs design-system toggles `.dark` on <html>; the
- * theme-bulma bridge uses that class as the source of truth for
- * `--vc-color-*` flips. Bulma 1.0 itself flips its own component
- * variables only under `[data-theme="dark"]`, so mirror the resolved
- * mode onto the attribute so Bulma's own dark-mode chain (navbar text,
- * inputs, menu) fires alongside vuecs's.
+ * The `data-theme` attribute is mirrored automatically by theme-bulma's
+ * `colorMode.apply` runtime hook (plan 021). No per-app `watchEffect`
+ * mirror is needed.
  */
-const syncBulmaTheme = () => {
-    if (typeof globalThis.document === 'undefined') return;
-    globalThis.document.documentElement.setAttribute('data-theme', resolved.value);
-};
-
-onMounted(syncBulmaTheme);
-watchEffect(syncBulmaTheme);
+const { resolved, toggle } = useColorMode();
 </script>
 
 <template>

--- a/packages/design/src/composables/index.ts
+++ b/packages/design/src/composables/index.ts
@@ -1,2 +1,3 @@
 export * from './use-color-mode';
+export * from './use-color-palette';
 export * from './use-theme-runtime';

--- a/packages/design/src/composables/index.ts
+++ b/packages/design/src/composables/index.ts
@@ -1,1 +1,2 @@
 export * from './use-color-mode';
+export * from './use-theme-runtime';

--- a/packages/design/src/composables/use-color-mode.ts
+++ b/packages/design/src/composables/use-color-mode.ts
@@ -99,21 +99,23 @@ export function bindColorMode(
     /*
      * Theme-configurable dispatch (plan 021): each installed theme that
      * declares a `colorMode.apply` hook gets called with the resolved
-     * mode. Themes use this to mirror frame-specific dark-mode markers
-     * (theme-bootstrap → `data-bs-theme`, theme-bulma → `data-theme`)
-     * so framework chrome flips alongside vuecs's own `.dark` class
-     * without per-app `watchEffect` mirrors.
+     * mode. Themes use this to mirror framework-specific dark-mode
+     * markers (theme-bootstrap → `data-bs-theme`, theme-bulma →
+     * `data-theme`) so framework chrome flips alongside vuecs's own
+     * `.dark` class without per-app `watchEffect` mirrors.
      *
-     * Reading `manager.themes` inside the watcher subscribes to theme
-     * swaps via `ThemeManager.setThemes()` — so re-installing themes at
-     * runtime re-fires the dispatch with the new theme list.
+     * The watch source is a tuple `[resolved, () => manager?.themes]`
+     * because Vue's `watch(source, callback)` only tracks reactive
+     * dependencies accessed inside the source — callback reads do NOT
+     * subscribe. Including the themes getter in the source means
+     * `ThemeManager.setThemes()` (which mutates the underlying
+     * `shallowRef`) re-fires the dispatch with the new theme list.
      */
     const manager = useThemeRuntimeManager();
     if (typeof document !== 'undefined') {
         watch(
-            resolved,
-            (value) => {
-                const themes = manager?.themes;
+            [resolved, () => manager?.themes],
+            ([value, themes]) => {
                 if (!themes) return;
                 for (const theme of themes) {
                     theme.colorMode?.apply(document, value);

--- a/packages/design/src/composables/use-color-mode.ts
+++ b/packages/design/src/composables/use-color-mode.ts
@@ -1,6 +1,7 @@
 import { createSharedComposable, usePreferredDark, useStorage } from '@vueuse/core';
 import { computed, ref, watch } from 'vue';
 import type { ComputedRef, Ref, WritableComputedRef } from 'vue';
+import { useThemeRuntimeManager } from './use-theme-runtime';
 
 export type ColorMode = 'light' | 'dark' | 'system';
 
@@ -90,6 +91,33 @@ export function bindColorMode(
             (value) => {
                 document.documentElement.classList.toggle('dark', value === 'dark');
                 document.documentElement.classList.toggle('light', value === 'light');
+            },
+            { immediate: true },
+        );
+    }
+
+    /*
+     * Theme-configurable dispatch (plan 021): each installed theme that
+     * declares a `colorMode.apply` hook gets called with the resolved
+     * mode. Themes use this to mirror frame-specific dark-mode markers
+     * (theme-bootstrap → `data-bs-theme`, theme-bulma → `data-theme`)
+     * so framework chrome flips alongside vuecs's own `.dark` class
+     * without per-app `watchEffect` mirrors.
+     *
+     * Reading `manager.themes` inside the watcher subscribes to theme
+     * swaps via `ThemeManager.setThemes()` — so re-installing themes at
+     * runtime re-fires the dispatch with the new theme list.
+     */
+    const manager = useThemeRuntimeManager();
+    if (typeof document !== 'undefined') {
+        watch(
+            resolved,
+            (value) => {
+                const themes = manager?.themes;
+                if (!themes) return;
+                for (const theme of themes) {
+                    theme.colorMode?.apply(document, value);
+                }
             },
             { immediate: true },
         );

--- a/packages/design/src/composables/use-color-palette.ts
+++ b/packages/design/src/composables/use-color-palette.ts
@@ -43,7 +43,18 @@ export interface UseColorPaletteOptions<T extends Record<string, unknown>> {
 }
 
 function passthroughSanitize<T>(value: unknown): T {
-    return (value ?? {}) as T;
+    /*
+     * Reject primitives and arrays: `JSON.parse('"blue"')` is valid and
+     * returns a string. Without this guard a corrupted localStorage entry
+     * would forward the primitive to `theme.palette.render`, which
+     * expects an object and would emit broken CSS. Themes that need a
+     * stricter shape pass their own `sanitize` (e.g. theme-tailwind
+     * filters to known palette names).
+     */
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return {} as T;
+    }
+    return value as T;
 }
 
 const shallowMerge = <T extends Record<string, unknown>>(current: T, partial: Partial<T>): T => ({

--- a/packages/design/src/composables/use-color-palette.ts
+++ b/packages/design/src/composables/use-color-palette.ts
@@ -1,0 +1,151 @@
+import { createSharedComposable, useStorage } from '@vueuse/core';
+import {
+    computed,
+    ref,
+    watchEffect,
+} from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import { applyColorPaletteCss } from '../palette';
+import type { UseColorPaletteReturn } from '../palette';
+import { useThemeRuntimeManager } from './use-theme-runtime';
+
+const DEFAULT_STORAGE_KEY = 'vc-color-palette';
+
+/**
+ * Options for the generic theme-aware `useColorPalette()` dispatcher.
+ *
+ * `useColorPalette` is wrapped with `createSharedComposable`, so these
+ * options are honored **only on the first call**. Subsequent invocations
+ * from anywhere in the app receive the cached instance with the original
+ * options — passing a different `storageKey`, `sanitize`, or `extend` is
+ * a silent no-op. For per-call configuration with custom storage,
+ * compose `bindColorPalette()` directly with your own ref.
+ */
+export interface UseColorPaletteOptions<T extends Record<string, unknown>> {
+    /** Initial palette when no persisted value exists. Default: `{}` (cast to `T`). */
+    initial?: T;
+    /** Persist via localStorage (`useStorage` from `@vueuse/core`). Default: `true`. */
+    persist?: boolean;
+    /** Storage key for the default backend. Default: `'vc-color-palette'`. */
+    storageKey?: string;
+    /**
+     * Theme-aware sanitizer for serialized values. Themes pass their own
+     * (e.g. `@vuecs/theme-tailwind` filters to known semantic scales +
+     * Tailwind palette names). Default: pass-through cast.
+     */
+    sanitize?: (raw: unknown) => T;
+    /**
+     * Override the default shallow-merge semantics of `extend()`. Default:
+     * `{ ...current, ...partial }`. Themes with structured non-object
+     * shapes supply their own.
+     */
+    extend?: (current: T, partial: Partial<T>) => T;
+}
+
+function passthroughSanitize<T>(value: unknown): T {
+    return (value ?? {}) as T;
+}
+
+const shallowMerge = <T extends Record<string, unknown>>(current: T, partial: Partial<T>): T => ({
+    ...current,
+    ...partial,
+} as T);
+
+/**
+ * Theme-aware reactive palette state — un-shared variant.
+ *
+ * Concatenates every installed theme's `palette.render` output into the
+ * `<style id="vc-color-palette">` element. Walking the installed themes
+ * each render means runtime theme swaps via `setThemes()` automatically
+ * pick up the new renderer chain.
+ *
+ * Concat (rather than last-wins) is the doctrinal semantic: when an app
+ * stacks multiple palette-aware themes (the docs-site case where
+ * Tailwind components and Bulma components share the same picker UI),
+ * each theme's renderer emits its own non-overlapping CSS rules —
+ * Tailwind rebinds `--vc-color-*`, Bulma writes per-variant HSL channel
+ * vars. The CSS cascade resolves any incidental overlap with
+ * later-rule-wins semantics, so concat behaves like last-wins for
+ * overlapping properties AND emits both themes' unique properties.
+ *
+ * Production callers should use `useColorPalette` (the shared variant
+ * below). This un-shared form is exposed primarily for testing — every
+ * call creates a fresh `watchEffect` and palette state.
+ */
+export function useColorPaletteUnshared<
+    T extends Record<string, unknown> = Record<string, string>,
+>(options: UseColorPaletteOptions<T> = {}): UseColorPaletteReturn<T> {
+    const {
+        initial = {} as T,
+        persist = true,
+        storageKey = DEFAULT_STORAGE_KEY,
+        sanitize = passthroughSanitize<T>,
+        extend = shallowMerge,
+    } = options;
+
+    const manager = useThemeRuntimeManager();
+
+    const storage: Ref<T> = persist ?
+        useStorage<T>(storageKey, sanitize(initial), undefined, {
+            serializer: {
+                read: (raw): T => {
+                    try {
+                        return sanitize(JSON.parse(raw));
+                    } catch {
+                        return sanitize({});
+                    }
+                },
+                write: (value) => JSON.stringify(value),
+            },
+        }) :
+        ref<T>(sanitize(initial)) as Ref<T>;
+
+    const renderConcatenated = (palette: T): string => {
+        const themes = manager?.themes;
+        if (!themes || themes.length === 0) return '';
+        const parts: string[] = [];
+        for (const theme of themes) {
+            const render = theme.palette?.render;
+            if (!render) continue;
+            const out = render(palette as Record<string, string>);
+            if (out) parts.push(out);
+        }
+        return parts.join('\n');
+    };
+
+    if (typeof document !== 'undefined') {
+        /*
+         * Reactive on both storage AND theme swaps: reading
+         * `manager.themes` (a shallowRef-backed getter) inside the
+         * effect subscribes to `setThemes()`. Reading `storage.value`
+         * subscribes to palette changes. Either trigger re-renders the
+         * `<style>` block.
+         */
+        watchEffect(() => {
+            applyColorPaletteCss(renderConcatenated(storage.value));
+        });
+    }
+
+    return {
+        current: computed(() => storage.value) as ComputedRef<T>,
+        set(palette) {
+            storage.value = palette;
+        },
+        extend(partial) {
+            storage.value = extend(storage.value, partial);
+        },
+    };
+}
+
+/**
+ * Theme-aware reactive palette state with localStorage persistence
+ * (plan 021 slice 2).
+ *
+ * Wrapped with `createSharedComposable` so every call site shares the
+ * same ref + watcher. For SSR-aware cookie-backed storage (Nuxt), the
+ * matching Nuxt module ships its own composable that calls
+ * `bindColorPalette()` directly with a cookie-backed ref.
+ */
+export const useColorPalette = createSharedComposable(useColorPaletteUnshared);
+
+export type { UseColorPaletteReturn } from '../palette';

--- a/packages/design/src/composables/use-theme-runtime.ts
+++ b/packages/design/src/composables/use-theme-runtime.ts
@@ -1,0 +1,56 @@
+import { inject } from 'vue';
+
+/**
+ * Bridge between `@vuecs/design` and `@vuecs/core`'s `ThemeManager`
+ * without a hard runtime dep. Both packages reference the same
+ * `Symbol.for('VCThemeManager')` so the ThemeManager provided by
+ * `installThemeManager(app)` (in `@vuecs/core`) is reachable from
+ * design composables that need to walk installed themes' runtime hooks.
+ *
+ * `inject()` returns `undefined` if no ThemeManager is installed —
+ * design composables use that as the "no theme dispatch" fallback so
+ * they keep working in standalone apps that import `@vuecs/design`
+ * without `@vuecs/core`.
+ */
+const THEME_MANAGER_SYMBOL = Symbol.for('VCThemeManager');
+
+/**
+ * Minimal structural projection of `@vuecs/core`'s `ThemeManager`.
+ * Only the surface design composables actually need is declared
+ * locally — keeps the bridge a runtime-only contract.
+ */
+export interface ThemeRuntimeColorModeHook {
+    apply(doc: Document, mode: 'light' | 'dark'): void;
+}
+
+export interface ThemeRuntimePaletteHook {
+    render(palette: Record<string, string>): string;
+    names?: readonly string[];
+}
+
+export interface ThemeRuntimeEntry {
+    colorMode?: ThemeRuntimeColorModeHook;
+    palette?: ThemeRuntimePaletteHook;
+}
+
+export interface ThemeRuntimeManager {
+    /**
+     * Reactive list of installed themes (reads through `ThemeManager`'s
+     * `shallowRef`, so accessing this inside a `watch` callback tracks
+     * theme swaps via `setThemes()`).
+     */
+    readonly themes: readonly ThemeRuntimeEntry[];
+}
+
+/**
+ * Look up the ThemeManager installed by `app.use(vuecs)` (or
+ * `installThemeManager(app)`). Returns `undefined` if no manager is
+ * provided in the current setup context — design composables fall back
+ * to no-dispatch behaviour in that case.
+ *
+ * Must be called during `setup()` or another composable's setup phase
+ * (Vue's `inject()` requirement).
+ */
+export function useThemeRuntimeManager(): ThemeRuntimeManager | undefined {
+    return inject<ThemeRuntimeManager | undefined>(THEME_MANAGER_SYMBOL, undefined);
+}

--- a/packages/design/test/unit/composables/use-color-palette.spec.ts
+++ b/packages/design/test/unit/composables/use-color-palette.spec.ts
@@ -1,0 +1,278 @@
+// @vitest-environment jsdom
+import {
+    afterEach,
+    describe,
+    expect,
+    it,
+    vi,
+} from 'vitest';
+import {
+    createApp,
+    defineComponent,
+    h,
+    nextTick,
+    ref,
+} from 'vue';
+import { COLOR_PALETTE_STYLE_ELEMENT_ID } from '../../../src/palette';
+import { useColorPaletteUnshared } from '../../../src/composables/use-color-palette';
+import type { ThemeRuntimeEntry } from '../../../src/composables/use-theme-runtime';
+
+const THEME_MANAGER_SYMBOL = Symbol.for('VCThemeManager');
+
+interface MockThemeManager {
+    themes: ThemeRuntimeEntry[];
+}
+
+function mountWithManager(
+    manager: MockThemeManager | undefined,
+    setupFn: () => void,
+): { unmount: () => void } {
+    const app = createApp(defineComponent({
+        setup() {
+            setupFn();
+            return () => h('div');
+        },
+    }));
+    if (manager) {
+        app.provide(THEME_MANAGER_SYMBOL, manager);
+    }
+    const root = document.createElement('div');
+    app.mount(root);
+    return {
+        unmount() {
+            app.unmount();
+            root.remove();
+        },
+    };
+}
+
+function readPaletteStyle(): string {
+    return document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID)?.textContent ?? '';
+}
+
+let nextStorageKey = 0;
+function freshStorageKey(): string {
+    nextStorageKey += 1;
+    return `vc-color-palette-test-${nextStorageKey}`;
+}
+
+describe('useColorPalette (generic dispatcher) — plan 021 slice 2', () => {
+    afterEach(() => {
+        document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID)?.remove();
+        document.documentElement.removeAttribute('data-bs-theme');
+    });
+
+    it('writes nothing when no theme declares palette.render', async () => {
+        const manager: MockThemeManager = { themes: [{}, {}] };
+        const { unmount } = mountWithManager(manager, () => {
+            useColorPaletteUnshared({
+                initial: { primary: 'blue' },
+                persist: false,
+                storageKey: freshStorageKey(),
+            });
+        });
+        await nextTick();
+        expect(readPaletteStyle()).toBe('');
+        unmount();
+    });
+
+    it('writes the renderer output when a theme declares palette.render', async () => {
+        const render = vi.fn((palette: Record<string, string>) => `:root { --primary: ${palette.primary}; }`);
+        const manager: MockThemeManager = { themes: [{ palette: { render } }] };
+
+        const { unmount } = mountWithManager(manager, () => {
+            useColorPaletteUnshared({
+                initial: { primary: 'blue' },
+                persist: false,
+                storageKey: freshStorageKey(),
+            });
+        });
+        await nextTick();
+        expect(render).toHaveBeenCalledWith({ primary: 'blue' });
+        expect(readPaletteStyle()).toContain('--primary: blue');
+        unmount();
+    });
+
+    it('concatenates outputs from every theme that declares palette.render', async () => {
+        const tailwindRender = (p: Record<string, string>) => `/* tailwind */ :root { --tw-primary: ${p.primary}; }`;
+        const bulmaRender = (p: Record<string, string>) => `/* bulma */ :root { --bulma-primary: ${p.primary}; }`;
+        const manager: MockThemeManager = {
+            themes: [
+                { palette: { render: tailwindRender } },
+                { palette: { render: bulmaRender } },
+            ],
+        };
+
+        const { unmount } = mountWithManager(manager, () => {
+            useColorPaletteUnshared({
+                initial: { primary: 'green' },
+                persist: false,
+                storageKey: freshStorageKey(),
+            });
+        });
+        await nextTick();
+        const css = readPaletteStyle();
+        expect(css).toContain('--tw-primary: green');
+        expect(css).toContain('--bulma-primary: green');
+        // Tailwind block precedes Bulma block (install order).
+        expect(css.indexOf('--tw-primary')).toBeLessThan(css.indexOf('--bulma-primary'));
+        unmount();
+    });
+
+    it('skips themes that omit palette.render but include other hooks', async () => {
+        const render = vi.fn((p: Record<string, string>) => `:root { --primary: ${p.primary}; }`);
+        const manager: MockThemeManager = {
+            themes: [
+                { colorMode: { apply: () => {} } }, // colorMode-only, no palette
+                { palette: { render } },
+                {}, // empty
+            ],
+        };
+
+        const { unmount } = mountWithManager(manager, () => {
+            useColorPaletteUnshared({
+                initial: { primary: 'red' },
+                persist: false,
+                storageKey: freshStorageKey(),
+            });
+        });
+        await nextTick();
+        expect(render).toHaveBeenCalledTimes(1);
+        expect(readPaletteStyle()).toBe(':root { --primary: red; }');
+        unmount();
+    });
+
+    it('re-renders when the palette changes via set()', async () => {
+        const render = (p: Record<string, string>) => `:root { --primary: ${p.primary}; }`;
+        const manager: MockThemeManager = { themes: [{ palette: { render } }] };
+
+        let api: ReturnType<typeof useColorPaletteUnshared> | undefined;
+        const { unmount } = mountWithManager(manager, () => {
+            api = useColorPaletteUnshared({
+                initial: { primary: 'blue' },
+                persist: false,
+                storageKey: freshStorageKey(),
+            });
+        });
+        await nextTick();
+        expect(readPaletteStyle()).toContain('--primary: blue');
+
+        api!.set({ primary: 'green' });
+        await nextTick();
+        expect(readPaletteStyle()).toContain('--primary: green');
+        unmount();
+    });
+
+    it('re-renders when extend() is used to merge a partial', async () => {
+        const render = (p: Record<string, string>) => `:root { --primary: ${p.primary}; --neutral: ${p.neutral}; }`;
+        const manager: MockThemeManager = { themes: [{ palette: { render } }] };
+
+        let api: ReturnType<typeof useColorPaletteUnshared> | undefined;
+        const { unmount } = mountWithManager(manager, () => {
+            api = useColorPaletteUnshared({
+                initial: { primary: 'blue', neutral: 'zinc' },
+                persist: false,
+                storageKey: freshStorageKey(),
+            });
+        });
+        await nextTick();
+        expect(readPaletteStyle()).toContain('--primary: blue');
+        expect(readPaletteStyle()).toContain('--neutral: zinc');
+
+        api!.extend({ primary: 'orange' });
+        await nextTick();
+        expect(readPaletteStyle()).toContain('--primary: orange');
+        // Other keys preserved by shallow merge default.
+        expect(readPaletteStyle()).toContain('--neutral: zinc');
+        unmount();
+    });
+
+    it('reactively picks up themes added via setThemes', async () => {
+        const render = vi.fn((p: Record<string, string>) => `:root { --primary: ${p.primary}; }`);
+        const themesRef = ref<ThemeRuntimeEntry[]>([]);
+        const manager = {
+            get themes() {
+                return themesRef.value;
+            },
+        } as unknown as MockThemeManager;
+
+        const { unmount } = mountWithManager(manager, () => {
+            useColorPaletteUnshared({
+                initial: { primary: 'blue' },
+                persist: false,
+                storageKey: freshStorageKey(),
+            });
+        });
+        await nextTick();
+        // No theme installed initially → empty.
+        expect(readPaletteStyle()).toBe('');
+        expect(render).not.toHaveBeenCalled();
+
+        themesRef.value = [{ palette: { render } }];
+        await nextTick();
+        expect(render).toHaveBeenCalledWith({ primary: 'blue' });
+        expect(readPaletteStyle()).toContain('--primary: blue');
+        unmount();
+    });
+
+    it('no-ops gracefully when no ThemeManager is installed', async () => {
+        const { unmount } = mountWithManager(undefined, () => {
+            useColorPaletteUnshared({
+                initial: { primary: 'blue' },
+                persist: false,
+                storageKey: freshStorageKey(),
+            });
+        });
+        await nextTick();
+        expect(readPaletteStyle()).toBe('');
+        unmount();
+    });
+
+    it('applies sanitize to the initial palette', async () => {
+        const render = (p: Record<string, string>) => `:root { --primary: ${p.primary ?? 'unset'}; }`;
+        const sanitize = (raw: unknown): { primary?: string } => {
+            if (!raw || typeof raw !== 'object') return {};
+            const input = raw as Record<string, unknown>;
+            // Only allow specific palette names.
+            if (typeof input.primary === 'string' && ['blue', 'green'].includes(input.primary)) {
+                return { primary: input.primary };
+            }
+            return {};
+        };
+        const manager: MockThemeManager = { themes: [{ palette: { render } }] };
+
+        const { unmount } = mountWithManager(manager, () => {
+            useColorPaletteUnshared<{ primary?: string }>({
+                initial: { primary: 'INVALID' as string },
+                persist: false,
+                storageKey: freshStorageKey(),
+                sanitize,
+            });
+        });
+        await nextTick();
+        // Sanitize stripped the invalid value.
+        expect(readPaletteStyle()).toContain('--primary: unset');
+        unmount();
+    });
+
+    it('exposes current() reactively', async () => {
+        const render = (p: Record<string, string>) => `:root { --primary: ${p.primary}; }`;
+        const manager: MockThemeManager = { themes: [{ palette: { render } }] };
+
+        let api: ReturnType<typeof useColorPaletteUnshared> | undefined;
+        const { unmount } = mountWithManager(manager, () => {
+            api = useColorPaletteUnshared({
+                initial: { primary: 'blue' },
+                persist: false,
+                storageKey: freshStorageKey(),
+            });
+        });
+        await nextTick();
+        expect(api!.current.value).toEqual({ primary: 'blue' });
+
+        api!.set({ primary: 'red' });
+        await nextTick();
+        expect(api!.current.value).toEqual({ primary: 'red' });
+        unmount();
+    });
+});

--- a/packages/design/test/unit/composables/use-theme-runtime.spec.ts
+++ b/packages/design/test/unit/composables/use-theme-runtime.spec.ts
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import {
+    afterEach,
+    describe,
+    expect,
+    it,
+    vi,
+} from 'vitest';
+import {
+    createApp,
+    defineComponent,
+    h,
+    nextTick,
+    ref,
+} from 'vue';
+import { bindColorMode } from '../../../src/composables/use-color-mode';
+import type { ColorMode } from '../../../src/composables/use-color-mode';
+import type { ThemeRuntimeEntry } from '../../../src/composables/use-theme-runtime';
+
+const THEME_MANAGER_SYMBOL = Symbol.for('VCThemeManager');
+
+interface MockThemeManager {
+    themes: ThemeRuntimeEntry[];
+}
+
+function mountWithManager(
+    manager: MockThemeManager | undefined,
+    setupFn: () => void,
+): { unmount: () => void } {
+    const app = createApp(defineComponent({
+        setup() {
+            setupFn();
+            return () => h('div');
+        },
+    }));
+    if (manager) {
+        app.provide(THEME_MANAGER_SYMBOL, manager);
+    }
+    const root = document.createElement('div');
+    app.mount(root);
+    return {
+        unmount() {
+            app.unmount();
+            root.remove();
+        },
+    };
+}
+
+describe('bindColorMode — theme dispatch (plan 021)', () => {
+    afterEach(() => {
+        document.documentElement.classList.remove('dark', 'light');
+        document.documentElement.removeAttribute('data-bs-theme');
+        document.documentElement.removeAttribute('data-theme');
+    });
+
+    it('fires every installed theme\'s colorMode.apply on the initial mount', async () => {
+        const bsApply = vi.fn();
+        const bulmaApply = vi.fn();
+        const manager: MockThemeManager = {
+            themes: [
+                { colorMode: { apply: bsApply } },
+                { colorMode: { apply: bulmaApply } },
+            ],
+        };
+
+        const source = ref<ColorMode>('dark');
+        const { unmount } = mountWithManager(manager, () => {
+            bindColorMode(source);
+        });
+        await nextTick();
+
+        expect(bsApply).toHaveBeenCalledWith(document, 'dark');
+        expect(bulmaApply).toHaveBeenCalledWith(document, 'dark');
+        unmount();
+    });
+
+    it('re-dispatches on mode change', async () => {
+        const apply = vi.fn();
+        const manager: MockThemeManager = { themes: [{ colorMode: { apply } }] };
+
+        const source = ref<ColorMode>('light');
+        const { unmount } = mountWithManager(manager, () => {
+            bindColorMode(source);
+        });
+        await nextTick();
+        expect(apply).toHaveBeenLastCalledWith(document, 'light');
+
+        source.value = 'dark';
+        await nextTick();
+        expect(apply).toHaveBeenLastCalledWith(document, 'dark');
+        unmount();
+    });
+
+    it('fires hooks in install order (left-to-right)', async () => {
+        const calls: string[] = [];
+        const manager: MockThemeManager = {
+            themes: [
+                { colorMode: { apply: () => calls.push('A') } },
+                { colorMode: { apply: () => calls.push('B') } },
+                { colorMode: { apply: () => calls.push('C') } },
+            ],
+        };
+
+        const source = ref<ColorMode>('dark');
+        const { unmount } = mountWithManager(manager, () => {
+            bindColorMode(source);
+        });
+        await nextTick();
+
+        expect(calls).toEqual(['A', 'B', 'C']);
+        unmount();
+    });
+
+    it('skips themes without a colorMode hook', async () => {
+        const apply = vi.fn();
+        const manager: MockThemeManager = {
+            themes: [
+                {}, // no colorMode
+                { colorMode: { apply } },
+                {}, // no colorMode
+            ],
+        };
+
+        const source = ref<ColorMode>('dark');
+        const { unmount } = mountWithManager(manager, () => {
+            bindColorMode(source);
+        });
+        await nextTick();
+
+        expect(apply).toHaveBeenCalledTimes(1);
+        expect(apply).toHaveBeenCalledWith(document, 'dark');
+        unmount();
+    });
+
+    it('no-ops when no ThemeManager is installed', async () => {
+        // No manager provided — nothing to dispatch through. Should not throw.
+        const source = ref<ColorMode>('dark');
+        const { unmount } = mountWithManager(undefined, () => {
+            bindColorMode(source);
+        });
+        await nextTick();
+
+        // The .dark class still toggles (that's the design-system-level behaviour).
+        expect(document.documentElement.classList.contains('dark')).toBe(true);
+        unmount();
+    });
+
+    it('reactively picks up themes added via setThemes', async () => {
+        const apply = vi.fn();
+        const themes = ref<ThemeRuntimeEntry[]>([]);
+        const manager: MockThemeManager = {
+            get themes() {
+                return themes.value;
+            },
+        } as unknown as MockThemeManager;
+
+        const source = ref<ColorMode>('light');
+        const { unmount } = mountWithManager(manager, () => {
+            bindColorMode(source);
+        });
+        await nextTick();
+        expect(apply).not.toHaveBeenCalled();
+
+        // Install a theme at runtime.
+        themes.value = [{ colorMode: { apply } }];
+        // Trigger a mode change so the dispatcher re-walks.
+        source.value = 'dark';
+        await nextTick();
+
+        expect(apply).toHaveBeenCalledWith(document, 'dark');
+        unmount();
+    });
+
+    it('reproduces the data-bs-theme mirror that theme-bootstrap declares', async () => {
+        const manager: MockThemeManager = {
+            themes: [
+                {
+                    colorMode: {
+                        apply(doc, mode) {
+                            doc.documentElement.setAttribute('data-bs-theme', mode);
+                        },
+                    },
+                },
+            ],
+        };
+
+        const source = ref<ColorMode>('dark');
+        const { unmount } = mountWithManager(manager, () => {
+            bindColorMode(source);
+        });
+        await nextTick();
+        expect(document.documentElement.getAttribute('data-bs-theme')).toBe('dark');
+
+        source.value = 'light';
+        await nextTick();
+        expect(document.documentElement.getAttribute('data-bs-theme')).toBe('light');
+        unmount();
+    });
+});

--- a/packages/design/test/unit/composables/use-theme-runtime.spec.ts
+++ b/packages/design/test/unit/composables/use-theme-runtime.spec.ts
@@ -145,7 +145,7 @@ describe('bindColorMode — theme dispatch (plan 021)', () => {
         unmount();
     });
 
-    it('reactively picks up themes added via setThemes', async () => {
+    it('reactively picks up themes added via setThemes (without mode change)', async () => {
         const apply = vi.fn();
         const themes = ref<ThemeRuntimeEntry[]>([]);
         const manager: MockThemeManager = {
@@ -154,17 +154,18 @@ describe('bindColorMode — theme dispatch (plan 021)', () => {
             },
         } as unknown as MockThemeManager;
 
-        const source = ref<ColorMode>('light');
+        const source = ref<ColorMode>('dark');
         const { unmount } = mountWithManager(manager, () => {
             bindColorMode(source);
         });
         await nextTick();
+        // No themes installed yet → no dispatch.
         expect(apply).not.toHaveBeenCalled();
 
-        // Install a theme at runtime.
+        // Install a theme at runtime; the watch source includes a getter
+        // for `manager.themes`, so the swap alone re-fires the watcher.
+        // No mode change required.
         themes.value = [{ colorMode: { apply } }];
-        // Trigger a mode change so the dispatcher re-walks.
-        source.value = 'dark';
         await nextTick();
 
         expect(apply).toHaveBeenCalledWith(document, 'dark');

--- a/themes/bootstrap/src/index.ts
+++ b/themes/bootstrap/src/index.ts
@@ -673,5 +673,18 @@ export default function bootstrapTheme(): Theme {
                 defaultVariants: { size: 'md' },
             },
         },
+        /*
+         * Theme-runtime hook (plan 021): mirror the resolved color mode
+         * onto Bootstrap's `data-bs-theme` attribute so framework chrome
+         * (navbar, dropdown, form-control, etc.) follows vuecs's `.dark`
+         * toggle without a per-app `watchEffect` mirror. Bootstrap 5.3+
+         * reads `data-bs-theme` as its own dark-mode source of truth;
+         * the bridge `assets/index.css` keeps `--vc-color-*` aligned.
+         */
+        colorMode: {
+            apply(doc, mode) {
+                doc.documentElement.setAttribute('data-bs-theme', mode);
+            },
+        },
     };
 }

--- a/themes/bulma/src/index.ts
+++ b/themes/bulma/src/index.ts
@@ -706,10 +706,15 @@ export default function bulmaTheme(): Theme {
         },
         /*
          * Theme-runtime hook (plan 021): declare the Bulma palette
-         * renderer + catalog. Forward-compat for the upcoming generic
-         * `@vuecs/design`-driven dispatcher (plan 021 second half).
-         * Bulma reuses Tailwind's 22-name palette catalog, rendered as
-         * HSL channel vars internally (plan 018).
+         * renderer + catalog. `@vuecs/design`'s `useColorPalette()`
+         * walks installed themes and concatenates each
+         * `palette.render` output, so `@vuecs/theme-bulma`'s
+         * `useColorPalette()` wrapper delegates here. When stacked
+         * alongside theme-tailwind (the docs-site case), both renderers
+         * fire on the same payload and emit non-overlapping CSS rules
+         * into the single `<style id="vc-color-palette">` block. Bulma
+         * reuses Tailwind's 22-name palette catalog, rendered as HSL
+         * channel vars internally (plan 018).
          */
         palette: {
             render: renderColorPaletteStyles as (palette: Record<string, string>) => string,

--- a/themes/bulma/src/index.ts
+++ b/themes/bulma/src/index.ts
@@ -1,4 +1,6 @@
 import type { Theme } from '@vuecs/core';
+import { TAILWIND_COLOR_PALETTES } from './constants';
+import { renderColorPaletteStyles } from './palette';
 
 export { renderColorPaletteStyles, setColorPalette } from './palette';
 export { useColorPalette } from './use-color-palette';
@@ -687,6 +689,31 @@ export default function bulmaTheme(): Theme {
                 },
                 defaultVariants: { size: 'md' },
             },
+        },
+        /*
+         * Theme-runtime hook (plan 021): mirror the resolved color mode
+         * onto Bulma's `data-theme` attribute so framework chrome (navbar
+         * text, form-control bg, etc.) follows vuecs's `.dark` toggle
+         * without a per-app `watchEffect` mirror. Bulma 1.0+ reads
+         * `data-theme` (alongside `prefers-color-scheme`) as its own
+         * dark-mode source of truth; the bridge `assets/index.css` keeps
+         * `--vc-color-*` aligned.
+         */
+        colorMode: {
+            apply(doc, mode) {
+                doc.documentElement.setAttribute('data-theme', mode);
+            },
+        },
+        /*
+         * Theme-runtime hook (plan 021): declare the Bulma palette
+         * renderer + catalog. Forward-compat for the upcoming generic
+         * `@vuecs/design`-driven dispatcher (plan 021 second half).
+         * Bulma reuses Tailwind's 22-name palette catalog, rendered as
+         * HSL channel vars internally (plan 018).
+         */
+        palette: {
+            render: renderColorPaletteStyles as (palette: Record<string, string>) => string,
+            names: TAILWIND_COLOR_PALETTES,
         },
     };
 }

--- a/themes/bulma/src/use-color-palette.ts
+++ b/themes/bulma/src/use-color-palette.ts
@@ -1,10 +1,6 @@
-import { bindColorPalette } from '@vuecs/design';
+import { useColorPalette as useColorPaletteCore } from '@vuecs/design';
 import type { UseColorPaletteReturn } from '@vuecs/design';
-import { createSharedComposable, useStorage } from '@vueuse/core';
-import { ref } from 'vue';
-import type { Ref } from 'vue';
 import { SEMANTIC_SCALES, TAILWIND_COLOR_PALETTES } from './constants';
-import { renderColorPaletteStyles } from './palette';
 import type { ColorPaletteConfig, SemanticScaleName, TailwindColorPaletteName } from './types';
 
 /**
@@ -13,12 +9,10 @@ import type { ColorPaletteConfig, SemanticScaleName, TailwindColorPaletteName } 
  * so consumers can swap themes at the docs / playground level without
  * losing state.
  *
- * `useColorPalette` is wrapped with `createSharedComposable`, so options
- * are honored only on the **first call**. Subsequent invocations from
- * anywhere in the app receive the cached instance with the original
- * options — passing a different `storageKey` or `initial` is a silent
- * no-op. For per-call configuration, call `bindColorPalette()` from
- * `@vuecs/design` directly.
+ * The underlying generic dispatcher (in `@vuecs/design`) is wrapped
+ * with `createSharedComposable`, so options are honored only on the
+ * **first call**. For per-call configuration, call
+ * `bindColorPalette()` from `@vuecs/design` directly.
  */
 export interface UseColorPaletteOptions {
     /** Initial palette when no persisted value exists. Default: `{}`. */
@@ -28,8 +22,6 @@ export interface UseColorPaletteOptions {
     /** Storage key for the default backend. Default: `'vc-color-palette'`. */
     storageKey?: string;
 }
-
-const DEFAULT_STORAGE_KEY = 'vc-color-palette';
 
 const TAILWIND_PALETTE_SET = new Set<string>(TAILWIND_COLOR_PALETTES);
 
@@ -55,43 +47,29 @@ const sanitize = (value: unknown): ColorPaletteConfig => {
 
 /**
  * Reactive Bulma-palette state with localStorage persistence (via
- * VueUse's `useStorage`). Wrapped with `createSharedComposable` so every
- * call site shares the same ref, watcher, and applied DOM state.
+ * VueUse's `useStorage`).
+ *
+ * Thin wrapper over `@vuecs/design`'s generic theme-aware
+ * `useColorPalette()` (plan 021 slice 2): the generic dispatcher walks
+ * installed themes and concatenates each theme's `palette.render`
+ * output. theme-bulma declares its renderer at the theme level, so
+ * importing this hook implicitly opts into the theme-runtime contract
+ * — no direct `bindColorPalette` wiring here anymore.
  *
  * Storage key (`vc-color-palette`) is intentionally shared with
  * `@vuecs/theme-tailwind`'s SPA composable: when an app loads both
- * themes (e.g. the vuecs docs site demos), the same payload drives both
- * — Tailwind components get the Tailwind renderer, Bulma components get
- * the Bulma renderer, and a single picker UI controls both.
+ * themes (e.g. the vuecs docs site demos), the same payload drives
+ * both — Tailwind components get the Tailwind renderer's output, Bulma
+ * components get the Bulma renderer's output, both written into the
+ * same `<style id="vc-color-palette">` block (the dispatcher
+ * concatenates).
  */
-export const useColorPalette = createSharedComposable(
-    (options: UseColorPaletteOptions = {}): UseColorPaletteReturn<ColorPaletteConfig> => {
-        const {
-            initial = {},
-            persist = true,
-            storageKey = DEFAULT_STORAGE_KEY,
-        } = options;
-
-        const storage: Ref<ColorPaletteConfig> = persist ?
-            useStorage<ColorPaletteConfig>(storageKey, sanitize(initial), undefined, {
-                serializer: {
-                    read: (raw): ColorPaletteConfig => {
-                        try {
-                            return sanitize(JSON.parse(raw));
-                        } catch {
-                            return {};
-                        }
-                    },
-                    write: (value) => JSON.stringify(value),
-                },
-            }) :
-            ref<ColorPaletteConfig>(sanitize(initial));
-
-        return bindColorPalette(storage, {
-            render: renderColorPaletteStyles,
-            extend: (current, partial) => ({ ...current, ...partial }),
-        });
-    },
-);
+export function useColorPalette(options: UseColorPaletteOptions = {}): UseColorPaletteReturn<ColorPaletteConfig> {
+    return useColorPaletteCore<ColorPaletteConfig>({
+        ...options,
+        sanitize,
+        extend: (current, partial) => ({ ...current, ...partial }),
+    });
+}
 
 export type { UseColorPaletteReturn } from '@vuecs/design';

--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -54,12 +54,10 @@ export default function tailwindTheme(): Theme {
         classesMergeFn: merge,
         /*
          * Theme-runtime hook (plan 021): declare the Tailwind palette
-         * renderer + catalog so a generic `@vuecs/design`-driven
-         * dispatcher can render `<style id="vc-color-palette">` based on
-         * the active themes' `palette.render`. The current per-theme
-         * `useColorPalette()` export keeps wiring this directly; the
-         * declaration is forward-compat for the upcoming generic
-         * dispatcher (plan 021 second half).
+         * renderer + catalog. `@vuecs/design`'s `useColorPalette()`
+         * walks installed themes and routes through `palette.render`,
+         * so `@vuecs/theme-tailwind`'s `useColorPalette()` wrapper now
+         * delegates here rather than wiring the renderer directly.
          */
         palette: {
             render: renderColorPaletteStyles as (palette: Record<string, string>) => string,

--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -1,6 +1,8 @@
 import type { ClassesMergeFn, Theme } from '@vuecs/core';
 import { twMerge } from 'tailwind-merge';
 import './config';
+import { TAILWIND_COLOR_PALETTES } from './constants';
+import { renderColorPaletteStyles } from './palette';
 
 export { renderColorPaletteStyles, setColorPalette } from './palette';
 export { useColorPalette } from './use-color-palette';
@@ -50,6 +52,19 @@ export const merge: ClassesMergeFn = (base, override) => twMerge(base, override)
 export default function tailwindTheme(): Theme {
     return {
         classesMergeFn: merge,
+        /*
+         * Theme-runtime hook (plan 021): declare the Tailwind palette
+         * renderer + catalog so a generic `@vuecs/design`-driven
+         * dispatcher can render `<style id="vc-color-palette">` based on
+         * the active themes' `palette.render`. The current per-theme
+         * `useColorPalette()` export keeps wiring this directly; the
+         * declaration is forward-compat for the upcoming generic
+         * dispatcher (plan 021 second half).
+         */
+        palette: {
+            render: renderColorPaletteStyles as (palette: Record<string, string>) => string,
+            names: TAILWIND_COLOR_PALETTES,
+        },
         elements: {
             formGroup: {
                 classes: {

--- a/themes/tailwind/src/use-color-palette.ts
+++ b/themes/tailwind/src/use-color-palette.ts
@@ -1,22 +1,19 @@
-import { bindColorPalette } from '@vuecs/design';
+import { useColorPalette as useColorPaletteCore } from '@vuecs/design';
 import type { UseColorPaletteReturn } from '@vuecs/design';
-import { createSharedComposable, useStorage } from '@vueuse/core';
-import { ref } from 'vue';
-import type { Ref } from 'vue';
 import { SEMANTIC_SCALES, TAILWIND_COLOR_PALETTES } from './constants';
-import { renderColorPaletteStyles } from './palette';
 import type { ColorPaletteConfig, SemanticScaleName, TailwindColorPaletteName } from './types';
 
 /**
- * Options for `useColorPalette()`. Note that `useColorPalette` is wrapped with
+ * Options for `useColorPalette()`. Note that the underlying
+ * generic dispatcher (in `@vuecs/design`) is wrapped with
  * `createSharedComposable`, so these options are honored **only on
  * the first call**. Subsequent invocations from anywhere in the app
- * receive the cached instance with the original options — passing a
- * different `storageKey` or `initial` is a silent no-op.
+ * receive the cached instance with the original options.
  *
- * If you need a per-call configuration (e.g. multiple independent
- * palettes, custom storage backend), call `bindColorPalette()` from
- * `@vuecs/design` directly with `renderColorPaletteStyles` and your own ref.
+ * For per-call configuration (e.g. multiple independent palettes,
+ * custom storage backend), call `bindColorPalette()` from
+ * `@vuecs/design` directly with `renderColorPaletteStyles` and your
+ * own ref.
  */
 export interface UseColorPaletteOptions {
     /** Initial palette when no persisted value exists. Default: `{}`. */
@@ -27,15 +24,12 @@ export interface UseColorPaletteOptions {
     storageKey?: string;
 }
 
-const DEFAULT_STORAGE_KEY = 'vc-color-palette';
-
 const TAILWIND_PALETTE_SET = new Set<string>(TAILWIND_COLOR_PALETTES);
 
 /*
  * Defensive sanitizer: localStorage / cookies can hold anything (older
  * library version, hand-edited DevTools value). Drop unknown keys and
- * non-Tailwind palette names rather than passing junk to the renderer,
- * which would emit invalid CSS variable references.
+ * non-Tailwind palette names rather than passing junk to the renderer.
  */
 const sanitize = (value: unknown): ColorPaletteConfig => {
     if (!value || typeof value !== 'object') return {};
@@ -52,44 +46,24 @@ const sanitize = (value: unknown): ColorPaletteConfig => {
 
 /**
  * Reactive Tailwind-palette state with localStorage persistence (via
- * VueUse's `useStorage`). Wrapped with `createSharedComposable` so
- * every call site shares the same ref, watcher, and applied DOM state
- * — picking a palette in one component updates every other consumer
- * instantly.
+ * VueUse's `useStorage`).
+ *
+ * Thin wrapper over `@vuecs/design`'s generic theme-aware
+ * `useColorPalette()` (plan 021 slice 2): the generic dispatcher walks
+ * installed themes and concatenates each theme's `palette.render`
+ * output. theme-tailwind declares its renderer at the theme level, so
+ * importing this hook implicitly opts into the theme-runtime contract
+ * — no direct `bindColorPalette` wiring here anymore.
  *
  * For SSR-aware cookie-backed storage (Nuxt), the
- * `@vuecs/theme-tailwind-nuxt` module ships its own `useColorPalette()`
- * that calls `bindColorPalette()` directly with a cookie-backed ref. Both
- * expose the same `{ current, set, extend }` shape.
+ * `@vuecs/theme-tailwind-nuxt` module ships its own `useColorPalette()`.
  */
-export const useColorPalette = createSharedComposable(
-    (options: UseColorPaletteOptions = {}): UseColorPaletteReturn<ColorPaletteConfig> => {
-        const {
-            initial = {},
-            persist = true,
-            storageKey = DEFAULT_STORAGE_KEY,
-        } = options;
-
-        const storage: Ref<ColorPaletteConfig> = persist ?
-            useStorage<ColorPaletteConfig>(storageKey, sanitize(initial), undefined, {
-                serializer: {
-                    read: (raw): ColorPaletteConfig => {
-                        try {
-                            return sanitize(JSON.parse(raw));
-                        } catch {
-                            return {};
-                        }
-                    },
-                    write: (value) => JSON.stringify(value),
-                },
-            }) :
-            ref<ColorPaletteConfig>(sanitize(initial));
-
-        return bindColorPalette(storage, {
-            render: renderColorPaletteStyles,
-            extend: (current, partial) => ({ ...current, ...partial }),
-        });
-    },
-);
+export function useColorPalette(options: UseColorPaletteOptions = {}): UseColorPaletteReturn<ColorPaletteConfig> {
+    return useColorPaletteCore<ColorPaletteConfig>({
+        ...options,
+        sanitize,
+        extend: (current, partial) => ({ ...current, ...partial }),
+    });
+}
 
 export type { UseColorPaletteReturn } from '@vuecs/design';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Theme-configurable runtime hooks for color mode and palette, enabling automatic cross-theme synchronization
  * Reactive, theme-aware color palette composable with optional persistence and centralized rendering

* **Refactor**
  * Example apps simplified to rely on runtime theme synchronization
  * Theme-specific palette utilities consolidated to use centralized design-system logic
  * Composables re-exported for easier consumption

* **Tests**
  * Added comprehensive unit tests for color palette and theme runtime behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1546)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->