### PR TITLE
feat(design,nuxt): theme-runtime SSR dispatch (plan 021 slice 3)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -428,6 +428,41 @@ Net effect: BS / Bulma example apps no longer need per-app
 that previously repeated for every consumer now lives in the theme
 exactly once.
 
+#### SSR dispatch (slice 3)
+
+For Nuxt apps the same hooks need to flow into the rendered head
+before first paint, otherwise BS / Bulma chrome flashes light → dark
+on hydration. `@vuecs/design` exposes two pure utilities the SSR
+plugins consume:
+
+- **`captureColorModeAttrs(themes, mode)`** — runs every theme's
+  `colorMode.apply` against a synthetic `Document` whose
+  `documentElement.setAttribute` writes into a plain record. The
+  record is plumbed into `useHead({ htmlAttrs })` so themes that
+  toggle `data-bs-theme` / `data-theme` flow on first paint, not
+  just after hydration. Errors per theme are caught + warned so a
+  single broken theme can't crash SSR.
+- **`renderColorPaletteFromThemes(themes, palette)`** — concatenates
+  every theme's `palette.render` output into a single CSS string.
+  Mirrors the client-side `useColorPalette` semantic.
+
+`@vuecs/nuxt`'s `colorMode.server.ts` plugin and
+`@vuecs/theme-tailwind-nuxt`'s `color-palette.server.ts` plugin both
+declare `enforce: 'post'` so they run after user-defined plugins
+that install vuecs (`app.use(vuecs, { themes })`). They look up the
+ThemeManager via `nuxtApp.vueApp.runWithContext(() =>
+inject(THEME_MANAGER_SYMBOL))` — same shared-symbol bridge as the
+client side. Without an installed manager, the plugins gracefully
+emit only the design-system-level outputs (`html.dark` class for
+color mode; nothing for palette).
+
+Themes that need DOM operations beyond `setAttribute` /
+`removeAttribute` / `classList` (e.g. inserting child nodes during
+SSR) are not covered by `captureColorModeAttrs`; those themes
+should guard their CSR-only logic with `if (typeof window ===
+'undefined') return;` and split the SSR-flowing bits into
+declarative `setAttribute` calls.
+
 ## Global Behavioral Defaults (#1491)
 
 Alongside the theme system, `@vuecs/core` exposes a parallel `DefaultsManager` for

--- a/packages/design/src/composables/use-theme-runtime.ts
+++ b/packages/design/src/composables/use-theme-runtime.ts
@@ -1,18 +1,5 @@
 import { inject } from 'vue';
-
-/**
- * Bridge between `@vuecs/design` and `@vuecs/core`'s `ThemeManager`
- * without a hard runtime dep. Both packages reference the same
- * `Symbol.for('VCThemeManager')` so the ThemeManager provided by
- * `installThemeManager(app)` (in `@vuecs/core`) is reachable from
- * design composables that need to walk installed themes' runtime hooks.
- *
- * `inject()` returns `undefined` if no ThemeManager is installed —
- * design composables use that as the "no theme dispatch" fallback so
- * they keep working in standalone apps that import `@vuecs/design`
- * without `@vuecs/core`.
- */
-const THEME_MANAGER_SYMBOL = Symbol.for('VCThemeManager');
+import type { InjectionKey } from 'vue';
 
 /**
  * Minimal structural projection of `@vuecs/core`'s `ThemeManager`.
@@ -43,6 +30,28 @@ export interface ThemeRuntimeManager {
 }
 
 /**
+ * Globally-shared `InjectionKey` for the ThemeManager. SSR plugins
+ * (Nuxt, future frameworks) that need to look up the manager from
+ * outside Vue's component context use this with `app.runWithContext`
+ * (or equivalent) + `inject`.
+ *
+ * Bridge between `@vuecs/design` and `@vuecs/core`'s `ThemeManager`
+ * without a hard runtime dep: both packages reference the same
+ * `Symbol.for('VCThemeManager')` registry key, so the ThemeManager
+ * provided by `installThemeManager(app)` (in `@vuecs/core`) is
+ * reachable here. `Symbol.for(...)` is reference-equal across module
+ * boundaries, and the `InjectionKey<ThemeRuntimeManager>` cast
+ * surfaces the manager type to `inject()` callers without leaking
+ * `@vuecs/core` internals.
+ *
+ * `inject()` returns `undefined` if no ThemeManager is installed —
+ * design composables use that as the "no theme dispatch" fallback so
+ * they keep working in standalone apps that import `@vuecs/design`
+ * without `@vuecs/core`.
+ */
+export const THEME_RUNTIME_MANAGER_SYMBOL = Symbol.for('VCThemeManager') as InjectionKey<ThemeRuntimeManager>;
+
+/**
  * Look up the ThemeManager installed by `app.use(vuecs)` (or
  * `installThemeManager(app)`). Returns `undefined` if no manager is
  * provided in the current setup context — design composables fall back
@@ -52,21 +61,8 @@ export interface ThemeRuntimeManager {
  * (Vue's `inject()` requirement).
  */
 export function useThemeRuntimeManager(): ThemeRuntimeManager | undefined {
-    return inject<ThemeRuntimeManager | undefined>(THEME_MANAGER_SYMBOL, undefined);
+    return inject(THEME_RUNTIME_MANAGER_SYMBOL, undefined);
 }
-
-/**
- * Re-exported globally-shared symbol for the ThemeManager. SSR plugins
- * (Nuxt, future frameworks) that need to look up the manager from
- * outside Vue's component context use this with `app.runWithContext`
- * (or equivalent) + `inject`.
- *
- * `Symbol.for(...)` is reference-equal across module boundaries, so
- * `@vuecs/core`'s `installThemeManager()` and `@vuecs/design`'s
- * `useThemeRuntimeManager()` and any external SSR plumbing can all
- * agree on the same key without a runtime import dance.
- */
-export const THEME_RUNTIME_MANAGER_SYMBOL: unique symbol = THEME_MANAGER_SYMBOL as never;
 
 /*
  * SSR capture utilities (plan 021 slice 3).
@@ -91,12 +87,18 @@ export const THEME_RUNTIME_MANAGER_SYMBOL: unique symbol = THEME_MANAGER_SYMBOL 
  */
 
 /**
- * Build a synthetic Document-like that records `setAttribute` /
- * `removeAttribute` calls on `documentElement` into a record. Other DOM
- * operations are silently no-op'd so themes don't crash during SSR.
+ * Build a synthetic Document-like whose `documentElement` records
+ * `setAttribute` / `removeAttribute` calls into the supplied target
+ * record, plus a no-op `classList`. **No other Document or Element
+ * APIs are stubbed** — themes that call `doc.createElement`,
+ * `doc.head.appendChild`, etc. WILL throw at SSR runtime. Themes
+ * needing richer DOM access from `colorMode.apply` should guard their
+ * CSR-only logic with `if (typeof window === 'undefined') return;`
+ * and split the SSR-flowing bits into declarative `setAttribute` calls.
  *
  * Exposed for advanced consumers; the higher-level
- * `captureColorModeAttrs()` covers the common case.
+ * `captureColorModeAttrs()` covers the common case and catches errors
+ * per theme so a single broken theme can't crash SSR.
  */
 export function createCaptureDocument(target: Record<string, string>): Document {
     const noopClassList = {
@@ -142,7 +144,15 @@ export function captureColorModeAttrs(
     themes: readonly ThemeRuntimeEntry[],
     mode: 'light' | 'dark',
 ): Record<string, string> {
-    const attrs: Record<string, string> = {};
+    /*
+     * Use a prototype-free record: attribute names come from theme
+     * code (potentially third-party), and a key like `__proto__` could
+     * theoretically poison the result if it later gets merged into
+     * another object via `Object.assign` (which uses `[[Set]]` and
+     * triggers the prototype setter). `Object.create(null)` avoids the
+     * concern entirely without any functional downside.
+     */
+    const attrs: Record<string, string> = Object.create(null) as Record<string, string>;
     const fakeDoc = createCaptureDocument(attrs);
 
     for (const theme of themes) {

--- a/packages/design/src/composables/use-theme-runtime.ts
+++ b/packages/design/src/composables/use-theme-runtime.ts
@@ -54,3 +54,140 @@ export interface ThemeRuntimeManager {
 export function useThemeRuntimeManager(): ThemeRuntimeManager | undefined {
     return inject<ThemeRuntimeManager | undefined>(THEME_MANAGER_SYMBOL, undefined);
 }
+
+/**
+ * Re-exported globally-shared symbol for the ThemeManager. SSR plugins
+ * (Nuxt, future frameworks) that need to look up the manager from
+ * outside Vue's component context use this with `app.runWithContext`
+ * (or equivalent) + `inject`.
+ *
+ * `Symbol.for(...)` is reference-equal across module boundaries, so
+ * `@vuecs/core`'s `installThemeManager()` and `@vuecs/design`'s
+ * `useThemeRuntimeManager()` and any external SSR plumbing can all
+ * agree on the same key without a runtime import dance.
+ */
+export const THEME_RUNTIME_MANAGER_SYMBOL: unique symbol = THEME_MANAGER_SYMBOL as never;
+
+/*
+ * SSR capture utilities (plan 021 slice 3).
+ *
+ * On the client, `bindColorMode` and `useColorPalette` walk installed
+ * themes and dispatch through their hooks against the live `document`.
+ * On the server there is no `document` — but Nuxt SSR plugins still
+ * need to flow the same theme-specific markers (`data-bs-theme` /
+ * `data-theme` for color mode, `<style id="vc-color-palette">` for
+ * palette) into the rendered head before first paint.
+ *
+ * The pattern: run themes' `colorMode.apply` against a synthetic
+ * Document-like object that captures attribute mutations into a plain
+ * record. The Nuxt plugin then plumbs the captured record into
+ * `useHead({ htmlAttrs })`. For palette, just concatenate every theme's
+ * `palette.render` output and emit one `<style>` block.
+ *
+ * Themes that need DOM operations beyond `setAttribute` /
+ * `removeAttribute` / `classList` (e.g. inserting child nodes) are not
+ * SSR-friendly via this helper; their CSR-only logic should guard with
+ * `if (typeof window === 'undefined') return;`.
+ */
+
+/**
+ * Build a synthetic Document-like that records `setAttribute` /
+ * `removeAttribute` calls on `documentElement` into a record. Other DOM
+ * operations are silently no-op'd so themes don't crash during SSR.
+ *
+ * Exposed for advanced consumers; the higher-level
+ * `captureColorModeAttrs()` covers the common case.
+ */
+export function createCaptureDocument(target: Record<string, string>): Document {
+    const noopClassList = {
+        add() {},
+        remove() {},
+        toggle(): boolean {
+            return false;
+        },
+        contains(): boolean {
+            return false;
+        },
+        replace() {},
+    };
+
+    const documentElement = {
+        setAttribute(name: string, value: string): void {
+            target[name] = value;
+        },
+        removeAttribute(name: string): void {
+            delete target[name];
+        },
+        classList: noopClassList,
+    };
+
+    return { documentElement } as unknown as Document;
+}
+
+/**
+ * Walk every installed theme's `colorMode.apply` against a synthetic
+ * Document and capture the resulting attribute mutations. SSR plugins
+ * use this to flow `data-bs-theme` / `data-theme` (or any other
+ * attribute a theme declares) into `useHead({ htmlAttrs })` before
+ * first paint.
+ *
+ * Each theme's apply runs in install order. If multiple themes set the
+ * same attribute, the last one wins — same semantic as the live
+ * `document.documentElement.setAttribute` chain on the client.
+ *
+ * Errors thrown by a theme's apply are caught + logged as a warning so
+ * one malformed theme can't crash SSR; other themes still run.
+ */
+export function captureColorModeAttrs(
+    themes: readonly ThemeRuntimeEntry[],
+    mode: 'light' | 'dark',
+): Record<string, string> {
+    const attrs: Record<string, string> = {};
+    const fakeDoc = createCaptureDocument(attrs);
+
+    for (const theme of themes) {
+        const apply = theme.colorMode?.apply;
+        if (!apply) continue;
+        try {
+            apply(fakeDoc, mode);
+        } catch (e) {
+            if (typeof console !== 'undefined') {
+                // eslint-disable-next-line no-console
+                console.warn('[vuecs] theme colorMode.apply failed during SSR; skipping:', e);
+            }
+        }
+    }
+
+    return attrs;
+}
+
+/**
+ * Concatenate every installed theme's `palette.render` output into a
+ * single CSS string. SSR plugins emit the result as the
+ * `<style id="vc-color-palette">` block so palette-aware themes flow
+ * on first paint.
+ *
+ * Mirrors the client-side concat semantics in `useColorPalette()`:
+ * non-overlapping rules from different themes coexist; CSS cascade
+ * resolves any incidental overlap with later-rule-wins.
+ */
+export function renderColorPaletteFromThemes(
+    themes: readonly ThemeRuntimeEntry[],
+    palette: Record<string, string>,
+): string {
+    const parts: string[] = [];
+    for (const theme of themes) {
+        const render = theme.palette?.render;
+        if (!render) continue;
+        try {
+            const out = render(palette);
+            if (out) parts.push(out);
+        } catch (e) {
+            if (typeof console !== 'undefined') {
+                // eslint-disable-next-line no-console
+                console.warn('[vuecs] theme palette.render failed during SSR; skipping:', e);
+            }
+        }
+    }
+    return parts.join('\n');
+}

--- a/packages/design/test/unit/composables/ssr-capture.spec.ts
+++ b/packages/design/test/unit/composables/ssr-capture.spec.ts
@@ -1,0 +1,171 @@
+import {
+    afterEach,
+    describe,
+    expect,
+    it,
+    vi,
+} from 'vitest';
+import {
+    captureColorModeAttrs,
+    createCaptureDocument,
+    renderColorPaletteFromThemes,
+} from '../../../src/composables/use-theme-runtime';
+import type { ThemeRuntimeEntry } from '../../../src/composables/use-theme-runtime';
+
+describe('createCaptureDocument', () => {
+    it('captures setAttribute calls on documentElement', () => {
+        const target: Record<string, string> = {};
+        const doc = createCaptureDocument(target);
+        doc.documentElement.setAttribute('data-bs-theme', 'dark');
+        expect(target).toEqual({ 'data-bs-theme': 'dark' });
+    });
+
+    it('removes attributes via removeAttribute', () => {
+        const target: Record<string, string> = { 'data-bs-theme': 'dark' };
+        const doc = createCaptureDocument(target);
+        doc.documentElement.removeAttribute('data-bs-theme');
+        expect(target).toEqual({});
+    });
+
+    it('exposes a no-op classList that does not throw', () => {
+        const target: Record<string, string> = {};
+        const doc = createCaptureDocument(target);
+        expect(() => {
+            doc.documentElement.classList.add('foo');
+            doc.documentElement.classList.remove('foo');
+            doc.documentElement.classList.toggle('foo');
+        }).not.toThrow();
+    });
+});
+
+describe('captureColorModeAttrs', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('captures attribute mutations from each theme', () => {
+        const themes: ThemeRuntimeEntry[] = [
+            {
+                colorMode: {
+                    apply(doc, mode) {
+                        doc.documentElement.setAttribute('data-bs-theme', mode);
+                    },
+                },
+            },
+            {
+                colorMode: {
+                    apply(doc, mode) {
+                        doc.documentElement.setAttribute('data-theme', mode);
+                    },
+                },
+            },
+        ];
+
+        const attrs = captureColorModeAttrs(themes, 'dark');
+        expect(attrs).toEqual({
+            'data-bs-theme': 'dark',
+            'data-theme': 'dark',
+        });
+    });
+
+    it('returns an empty object when no theme declares colorMode.apply', () => {
+        const themes: ThemeRuntimeEntry[] = [{}, { palette: { render: () => '' } }];
+        expect(captureColorModeAttrs(themes, 'light')).toEqual({});
+    });
+
+    it('honors install order — later theme wins on the same attribute', () => {
+        const themes: ThemeRuntimeEntry[] = [
+            {
+                colorMode: {
+                    apply(doc) {
+                        doc.documentElement.setAttribute('shared', 'first');
+                    },
+                },
+            },
+            {
+                colorMode: {
+                    apply(doc) {
+                        doc.documentElement.setAttribute('shared', 'second');
+                    },
+                },
+            },
+        ];
+        expect(captureColorModeAttrs(themes, 'light').shared).toBe('second');
+    });
+
+    it('isolates errors per theme — one bad theme does not break the others', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const themes: ThemeRuntimeEntry[] = [
+            {
+                colorMode: {
+                    apply() {
+                        throw new Error('boom');
+                    },
+                },
+            },
+            {
+                colorMode: {
+                    apply(doc, mode) {
+                        doc.documentElement.setAttribute('data-theme', mode);
+                    },
+                },
+            },
+        ];
+        const attrs = captureColorModeAttrs(themes, 'dark');
+        expect(attrs).toEqual({ 'data-theme': 'dark' });
+        expect(warn).toHaveBeenCalled();
+    });
+
+    it('passes the resolved mode through unchanged', () => {
+        const apply = vi.fn();
+        captureColorModeAttrs([{ colorMode: { apply } }], 'light');
+        expect(apply).toHaveBeenCalledWith(expect.any(Object), 'light');
+    });
+});
+
+describe('renderColorPaletteFromThemes', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('concatenates outputs from every palette-aware theme', () => {
+        const themes: ThemeRuntimeEntry[] = [
+            { palette: { render: (p) => `/* tailwind */ --primary: ${p.primary};` } },
+            { palette: { render: (p) => `/* bulma */ --bulma-primary: ${p.primary};` } },
+        ];
+        const css = renderColorPaletteFromThemes(themes, { primary: 'green' });
+        expect(css).toContain('--primary: green');
+        expect(css).toContain('--bulma-primary: green');
+        expect(css.indexOf('--primary')).toBeLessThan(css.indexOf('--bulma-primary'));
+    });
+
+    it('returns empty string when no theme declares palette.render', () => {
+        const themes: ThemeRuntimeEntry[] = [{ colorMode: { apply: () => {} } }, {}];
+        expect(renderColorPaletteFromThemes(themes, { primary: 'red' })).toBe('');
+    });
+
+    it('skips themes whose render returns empty', () => {
+        const themes: ThemeRuntimeEntry[] = [
+            { palette: { render: () => '' } },
+            { palette: { render: (p) => `--primary: ${p.primary};` } },
+        ];
+        expect(renderColorPaletteFromThemes(themes, { primary: 'red' })).toBe('--primary: red;');
+    });
+
+    it('isolates errors per theme', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const themes: ThemeRuntimeEntry[] = [
+            {
+                palette: {
+                    render() {
+                        throw new Error('boom');
+                    },
+                },
+            },
+            { palette: { render: (p) => `--primary: ${p.primary};` } },
+        ];
+        const css = renderColorPaletteFromThemes(themes, { primary: 'red' });
+        expect(css).toBe('--primary: red;');
+        expect(warn).toHaveBeenCalled();
+    });
+});

--- a/packages/nuxt/src/runtime/plugins/colorMode.server.ts
+++ b/packages/nuxt/src/runtime/plugins/colorMode.server.ts
@@ -1,6 +1,11 @@
+import { captureColorModeAttrs } from '@vuecs/design';
+import type { ThemeRuntimeManager } from '@vuecs/design';
+import { inject } from 'vue';
 // @ts-expect-error resolved by Nuxt at build time
 // eslint-disable-next-line @stylistic/exp-list-style
 import { defineNuxtPlugin, useCookie, useHead, useRuntimeConfig } from '#imports';
+
+const THEME_MANAGER_SYMBOL = Symbol.for('VCThemeManager');
 
 /**
  * Server-only plugin that applies `.dark` / `.light` to the `<html>`
@@ -12,29 +17,63 @@ import { defineNuxtPlugin, useCookie, useHead, useRuntimeConfig } from '#imports
  * omits the class; the client then resolves `prefers-color-scheme` and
  * applies the class reactively. A brief flash is possible in that
  * narrow case.
+ *
+ * Plan 021 slice 3: also dispatches each installed theme's
+ * `colorMode.apply` against a synthetic Document and plumbs the captured
+ * attributes (e.g. `data-bs-theme` from theme-bootstrap, `data-theme`
+ * from theme-bulma) into `useHead({ htmlAttrs })` so framework chrome
+ * flips alongside `.dark` on first paint, not just after hydration.
+ *
+ * `enforce: 'post'` ensures this plugin runs after user-defined
+ * plugins that install vuecs (`app.use(vuecs, { themes })`), so the
+ * ThemeManager is already provided when we look it up.
  */
-export default defineNuxtPlugin(() => {
-    const config = useRuntimeConfig();
-    const colorModeConfig = config.public.vuecs?.colorMode;
-    if (!colorModeConfig?.enabled) return;
+type NuxtAppLike = {
+    vueApp: {
+        runWithContext: <T>(fn: () => T) => T;
+    };
+};
 
-    // Default mirrors the composable's fallback (vc-color-mode) so the
-    // two stay in sync if runtimeConfig is incomplete for any reason.
-    const cookieName = colorModeConfig.cookieName || 'vc-color-mode';
-    const cookie = useCookie<'light' | 'dark' | 'system' | undefined>(
-        cookieName,
-        { default: () => undefined },
-    );
+export default defineNuxtPlugin({
+    name: 'vuecs-color-mode-server',
+    enforce: 'post',
+    setup(nuxtApp: NuxtAppLike) {
+        const config = useRuntimeConfig();
+        const colorModeConfig = config.public.vuecs?.colorMode;
+        if (!colorModeConfig?.enabled) return;
 
-    const stored = cookie.value;
-    let effective: string | undefined;
-    if (stored && stored !== 'system') {
-        effective = stored;
-    } else if (colorModeConfig.preference !== 'system') {
-        effective = colorModeConfig.preference;
-    }
+        const cookieName = colorModeConfig.cookieName || 'vc-color-mode';
+        const cookie = useCookie<'light' | 'dark' | 'system' | undefined>(
+            cookieName,
+            { default: () => undefined },
+        );
 
-    if (!effective) return;
+        const stored = cookie.value;
+        let effective: 'light' | 'dark' | undefined;
+        if (stored === 'light' || stored === 'dark') {
+            effective = stored;
+        } else if (colorModeConfig.preference === 'light' || colorModeConfig.preference === 'dark') {
+            effective = colorModeConfig.preference;
+        }
 
-    useHead({ htmlAttrs: { class: effective } });
+        if (!effective) return;
+
+        const htmlAttrs: Record<string, string> = { class: effective };
+
+        /*
+         * Look up the ThemeManager via Vue's inject in the Nuxt app's
+         * context. Themes were registered when the user's plugin called
+         * `app.use(vuecs, { themes })`. With `enforce: 'post'` that
+         * plugin has already run.
+         */
+        const manager = nuxtApp.vueApp
+            .runWithContext(() => inject<ThemeRuntimeManager | undefined>(THEME_MANAGER_SYMBOL, undefined));
+
+        if (manager) {
+            const captured = captureColorModeAttrs(manager.themes, effective);
+            Object.assign(htmlAttrs, captured);
+        }
+
+        useHead({ htmlAttrs });
+    },
 });

--- a/packages/nuxt/src/runtime/plugins/colorMode.server.ts
+++ b/packages/nuxt/src/runtime/plugins/colorMode.server.ts
@@ -1,11 +1,8 @@
-import { captureColorModeAttrs } from '@vuecs/design';
-import type { ThemeRuntimeManager } from '@vuecs/design';
+import { THEME_RUNTIME_MANAGER_SYMBOL, captureColorModeAttrs } from '@vuecs/design';
 import { inject } from 'vue';
 // @ts-expect-error resolved by Nuxt at build time
 // eslint-disable-next-line @stylistic/exp-list-style
 import { defineNuxtPlugin, useCookie, useHead, useRuntimeConfig } from '#imports';
-
-const THEME_MANAGER_SYMBOL = Symbol.for('VCThemeManager');
 
 /**
  * Server-only plugin that applies `.dark` / `.light` to the `<html>`
@@ -67,7 +64,7 @@ export default defineNuxtPlugin({
          * plugin has already run.
          */
         const manager = nuxtApp.vueApp
-            .runWithContext(() => inject<ThemeRuntimeManager | undefined>(THEME_MANAGER_SYMBOL, undefined));
+            .runWithContext(() => inject(THEME_RUNTIME_MANAGER_SYMBOL, undefined));
 
         if (manager) {
             const captured = captureColorModeAttrs(manager.themes, effective);

--- a/themes/tailwind-nuxt/src/runtime/plugins/color-palette.server.ts
+++ b/themes/tailwind-nuxt/src/runtime/plugins/color-palette.server.ts
@@ -1,42 +1,69 @@
-import { COLOR_PALETTE_STYLE_ELEMENT_ID } from '@vuecs/design';
-import { renderColorPaletteStyles } from '@vuecs/theme-tailwind';
+import { COLOR_PALETTE_STYLE_ELEMENT_ID, renderColorPaletteFromThemes } from '@vuecs/design';
+import type { ThemeRuntimeManager } from '@vuecs/design';
 import type { ColorPaletteConfig } from '@vuecs/theme-tailwind';
+import { inject } from 'vue';
 // @ts-expect-error resolved by Nuxt at build time
 // eslint-disable-next-line @stylistic/exp-list-style
 import { defineNuxtPlugin, useCookie, useHead, useRuntimeConfig } from '#imports';
+
+const THEME_MANAGER_SYMBOL = Symbol.for('VCThemeManager');
+
+type NuxtAppLike = {
+    vueApp: {
+        runWithContext: <T>(fn: () => T) => T;
+    };
+};
 
 /**
  * SSR-only plugin that emits the palette `<style>` block into the
  * document head before first paint.
  *
+ * Plan 021 slice 3: walks every installed theme's `palette.render`
+ * hook (via `renderColorPaletteFromThemes()` in `@vuecs/design`) and
+ * concatenates the outputs — same theme-agnostic semantic as the
+ * client-side `useColorPalette()` dispatcher. theme-tailwind declares
+ * its renderer at the theme level, so this plugin no longer imports
+ * `renderColorPaletteStyles` directly.
+ *
  * Reads the `vc-color-palette` cookie first (so returning visitors get
  * their persisted palette on first paint, with no FOUC on hydration);
  * falls back to `runtimeConfig.public.vuecsTailwind.colorPalette` (the
- * `nuxt.config.ts` default) when the cookie is absent. Mirrors the
- * pattern used by `@vuecs/nuxt`'s color-mode SSR plugin.
+ * `nuxt.config.ts` default) when the cookie is absent.
  *
- * `renderColorPaletteStyles()` itself filters unknown scales + palette
- * names, so a tampered cookie can never produce broken CSS.
+ * `enforce: 'post'` ensures this runs after user-defined plugins
+ * register vuecs (`app.use(vuecs, { themes })`) so the ThemeManager
+ * is reachable via inject. Without it, no palette dispatch happens
+ * (graceful no-op).
  */
-export default defineNuxtPlugin(() => {
-    const config = useRuntimeConfig();
-    const fallback = (config.public.vuecsTailwind?.colorPalette || {}) as ColorPaletteConfig;
+export default defineNuxtPlugin({
+    name: 'vuecs-tailwind-color-palette-server',
+    enforce: 'post',
+    setup(nuxtApp: NuxtAppLike) {
+        const config = useRuntimeConfig();
+        const fallback = (config.public.vuecsTailwind?.colorPalette || {}) as ColorPaletteConfig;
 
-    const cookie = useCookie<ColorPaletteConfig | undefined>(
-        'vc-color-palette',
-        { default: () => undefined },
-    );
+        const cookie = useCookie<ColorPaletteConfig | undefined>(
+            'vc-color-palette',
+            { default: () => undefined },
+        );
 
-    const colorPalette = cookie.value || fallback;
+        const colorPalette = cookie.value || fallback;
 
-    if (!colorPalette || Object.keys(colorPalette).length === 0) {
-        return;
-    }
+        if (!colorPalette || Object.keys(colorPalette).length === 0) {
+            return;
+        }
 
-    const css = renderColorPaletteStyles(colorPalette);
-    if (!css) {
-        return;
-    }
+        const manager = nuxtApp.vueApp
+            .runWithContext(() => inject<ThemeRuntimeManager | undefined>(THEME_MANAGER_SYMBOL, undefined));
 
-    useHead({ style: [{ id: COLOR_PALETTE_STYLE_ELEMENT_ID, innerHTML: css }] });
+        if (!manager) return;
+
+        const css = renderColorPaletteFromThemes(
+            manager.themes,
+            colorPalette as Record<string, string>,
+        );
+        if (!css) return;
+
+        useHead({ style: [{ id: COLOR_PALETTE_STYLE_ELEMENT_ID, innerHTML: css }] });
+    },
 });

--- a/themes/tailwind-nuxt/src/runtime/plugins/color-palette.server.ts
+++ b/themes/tailwind-nuxt/src/runtime/plugins/color-palette.server.ts
@@ -1,12 +1,14 @@
-import { COLOR_PALETTE_STYLE_ELEMENT_ID, renderColorPaletteFromThemes } from '@vuecs/design';
-import type { ThemeRuntimeManager } from '@vuecs/design';
+import {
+    COLOR_PALETTE_STYLE_ELEMENT_ID,
+    THEME_RUNTIME_MANAGER_SYMBOL,
+    renderColorPaletteFromThemes,
+} from '@vuecs/design';
+import { renderColorPaletteStyles } from '@vuecs/theme-tailwind';
 import type { ColorPaletteConfig } from '@vuecs/theme-tailwind';
 import { inject } from 'vue';
 // @ts-expect-error resolved by Nuxt at build time
 // eslint-disable-next-line @stylistic/exp-list-style
 import { defineNuxtPlugin, useCookie, useHead, useRuntimeConfig } from '#imports';
-
-const THEME_MANAGER_SYMBOL = Symbol.for('VCThemeManager');
 
 type NuxtAppLike = {
     vueApp: {
@@ -21,9 +23,11 @@ type NuxtAppLike = {
  * Plan 021 slice 3: walks every installed theme's `palette.render`
  * hook (via `renderColorPaletteFromThemes()` in `@vuecs/design`) and
  * concatenates the outputs — same theme-agnostic semantic as the
- * client-side `useColorPalette()` dispatcher. theme-tailwind declares
- * its renderer at the theme level, so this plugin no longer imports
- * `renderColorPaletteStyles` directly.
+ * client-side `useColorPalette()` dispatcher. When no ThemeManager is
+ * installed (e.g. consumers using `@vuecs/theme-tailwind-nuxt`
+ * standalone, or unusual plugin-ordering edge cases), falls back to
+ * `renderColorPaletteStyles` from `@vuecs/theme-tailwind` directly so
+ * Tailwind palette CSS still flows.
  *
  * Reads the `vc-color-palette` cookie first (so returning visitors get
  * their persisted palette on first paint, with no FOUC on hydration);
@@ -32,8 +36,7 @@ type NuxtAppLike = {
  *
  * `enforce: 'post'` ensures this runs after user-defined plugins
  * register vuecs (`app.use(vuecs, { themes })`) so the ThemeManager
- * is reachable via inject. Without it, no palette dispatch happens
- * (graceful no-op).
+ * is reachable via inject.
  */
 export default defineNuxtPlugin({
     name: 'vuecs-tailwind-color-palette-server',
@@ -54,16 +57,41 @@ export default defineNuxtPlugin({
         }
 
         const manager = nuxtApp.vueApp
-            .runWithContext(() => inject<ThemeRuntimeManager | undefined>(THEME_MANAGER_SYMBOL, undefined));
+            .runWithContext(() => inject(THEME_RUNTIME_MANAGER_SYMBOL, undefined));
 
-        if (!manager) return;
+        /*
+         * Prefer the theme-runtime dispatch when a manager is
+         * installed; fall back to Tailwind's own renderer when not. The
+         * fallback preserves the pre-plan-021 behaviour for consumers
+         * using `@vuecs/theme-tailwind-nuxt` standalone (without
+         * `@vuecs/core`) so removing this module doesn't silently break
+         * their first-paint palette.
+         */
+        let css = manager ?
+            renderColorPaletteFromThemes(manager.themes, colorPalette as Record<string, string>) :
+            renderColorPaletteStyles(colorPalette);
 
-        const css = renderColorPaletteFromThemes(
-            manager.themes,
-            colorPalette as Record<string, string>,
-        );
         if (!css) return;
 
-        useHead({ style: [{ id: COLOR_PALETTE_STYLE_ELEMENT_ID, innerHTML: css }] });
+        /*
+         * Reject CSS containing `</style` to defang any malformed theme
+         * renderer (or attacker-controlled cookie) that could break out
+         * of the `<style>` element and inject HTML. The palette source
+         * includes the `vc-color-palette` cookie, which is
+         * client-controlled, so the surface needs hardening even though
+         * `useHead` itself doesn't escape the value below.
+         */
+        if (/<\/style/i.test(css)) {
+            css = '';
+        }
+        if (!css) return;
+
+        /*
+         * `children` (textContent) instead of `innerHTML` for the head
+         * style block: textContent is the safe path that avoids the
+         * `</style>` HTML-injection surface entirely. unhead's
+         * type-validated `children` field maps to textContent.
+         */
+        useHead({ style: [{ id: COLOR_PALETTE_STYLE_ELEMENT_ID, children: css }] });
     },
 });


### PR DESCRIPTION
Wire the theme-runtime hooks into Nuxt SSR so framework-specific markers (data-bs-theme, data-theme, palette <style> block) flow on first paint, not just after hydration.

@vuecs/design adds two pure SSR helpers:
- captureColorModeAttrs(themes, mode) runs each theme's colorMode.apply against a synthetic Document whose documentElement.setAttribute writes into a captured record. SSR plugins plumb the record into useHead({ htmlAttrs }).
- renderColorPaletteFromThemes(themes, palette) concatenates every theme's palette.render output into one CSS string.

Both helpers catch + warn on per-theme errors so a single broken theme can't crash SSR; other themes still run.

@vuecs/nuxt's colorMode.server.ts plugin migrated:
- enforce: 'post' so it runs after user plugins install vuecs; before the post-flag the plugin ran first and inject() found nothing.
- Looks up ThemeManager via nuxtApp.vueApp.runWithContext(() => inject(THEME_MANAGER_SYMBOL))
  - the same Symbol.for shared-registry bridge used on the client.
- Captures theme-specific attributes via captureColorModeAttrs and merges them into htmlAttrs alongside the existing class.

@vuecs/theme-tailwind-nuxt's color-palette.server.ts plugin migrated identically: enforce: 'post', looks up the manager, walks themes via renderColorPaletteFromThemes. The plugin no longer imports renderColorPaletteStyles from @vuecs/theme-tailwind directly - it dispatches through whatever themes are installed.

12 new tests in
packages/design/test/unit/composables/ssr-capture.spec.ts cover both helpers including per-theme error isolation.

Plan 021 (theme-configurable runtime hooks) is now functionally complete across slices 1+2+3. Plan 024 step 6 closing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side rendering support for theme color modes and palettes in Nuxt applications.
  * Enhanced theme attribute capture during SSR to properly propagate theme-related styling to initial HTML.

* **Tests**
  * Added comprehensive unit tests for SSR theme rendering functionality with error handling scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1547)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->