### PR TITLE
feat(core): add auditTheme() coverage probe (plan 015 P5 / plan 024 s…

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -463,6 +463,64 @@ should guard their CSR-only logic with `if (typeof window ===
 'undefined') return;` and split the SSR-flowing bits into
 declarative `setAttribute` calls.
 
+### Theme audit (`auditTheme`, plan 015 P5 / plan 024 step 7)
+
+`@vuecs/core` exports a pure `auditTheme(theme, expected): AuditResult`
+function that compares a `Theme` against an expected catalog of
+component defaults. Designed for CI use — drift fails loudly so a
+future PR that drops a slot (or adds a typo) doesn't sneak past
+review.
+
+```ts
+type AuditResult = {
+    missingElements: string[];     // expected component names not in theme
+    unknownElements: string[];     // theme component names not in expected
+    missingSlots: Record<string, string[]>;     // per-element drift
+    unknownSlots: Record<string, string[]>;     // per-element typos
+    redundantStructural: Record<string, string[]>;  // theme value === default (no value-add; missed extend())
+};
+```
+
+The expected catalog is `Record<string, ComponentThemeDefinition>` —
+the same shape each component package's `*ThemeDefaults` export
+already has. Tests build the catalog by importing defaults from each
+component package directly:
+
+```ts
+import { auditTheme, isAuditClean, formatAuditResult } from '@vuecs/core';
+import { badgeThemeDefaults } from '@vuecs/elements';
+import { buttonThemeDefaults } from '@vuecs/button';
+import tailwindTheme from '@vuecs/theme-tailwind';
+
+const result = auditTheme(tailwindTheme(), {
+    badge: badgeThemeDefaults,
+    button: buttonThemeDefaults,
+    // …
+});
+if (!isAuditClean(result)) {
+    throw new Error(formatAuditResult(result, { title: 'theme-tailwind audit' }));
+}
+```
+
+Companion APIs:
+- **`isAuditClean(result)`** — predicate; `true` only when every
+  category is empty.
+- **`formatAuditResult(result, { title?, skip? })`** — pretty-prints
+  the report for test assertions and CI logs. Empty string when
+  clean. The `skip` option suppresses categories during in-progress
+  migrations (e.g. accept `redundantStructural` warnings while
+  rolling out a refactor).
+
+The audit checks `theme.elements[name].classes` only — variants and
+compound variants are out of scope for v1. Slots wrapped in
+`extend()` markers are never flagged as `redundantStructural` (the
+marker signals deliberate augmentation, not redefinition).
+
+Per-theme audit tests (`themes/{tailwind,bootstrap,bulma}/test/`)
+that wire vitest into the theme packages are deferred as a follow-up
+slice; the audit function is shipped first so consumers can already
+build their own audits against vuecs's components.
+
 ## Global Behavioral Defaults (#1491)
 
 Alongside the theme system, `@vuecs/core` exposes a parallel `DefaultsManager` for

--- a/packages/core/src/theme/audit.ts
+++ b/packages/core/src/theme/audit.ts
@@ -1,0 +1,224 @@
+import { isExtendValue } from './extend';
+import type {
+    ComponentThemeDefinition,
+    Theme,
+    ThemeElementDefinition,
+} from './types';
+
+/**
+ * Result of `auditTheme()` — a structured drift report. All four
+ * record fields are keyed by component name; the value is the list of
+ * slots that drifted. Top-level arrays cover element-level drift
+ * (missing or unknown component names).
+ */
+export type AuditResult = {
+    /** Component names present in `expected` but missing from `theme.elements`. */
+    missingElements: string[];
+    /** Component names present in `theme.elements` but absent from `expected` (typos / unsupported slots). */
+    unknownElements: string[];
+    /** Per-component slot keys present in `expected.classes` but missing from the theme entry. */
+    missingSlots: Record<string, string[]>;
+    /** Per-component slot keys present in the theme entry but absent from `expected.classes`. */
+    unknownSlots: Record<string, string[]>;
+    /**
+     * Per-component slot keys whose theme value is identical to the
+     * structural default (i.e. the theme adds nothing — likely a
+     * copy-paste mistake; `defaults` are merged automatically). Slots
+     * marked with `extend()` are never flagged here.
+     */
+    redundantStructural: Record<string, string[]>;
+};
+
+/**
+ * The shape `auditTheme()` audits against. Maps component name →
+ * `ComponentThemeDefinition` (the same `defaults` value each component
+ * package exports for its `useComponentTheme` call). Pass the
+ * defaults verbatim — the audit only reads `classes` keys + values.
+ */
+export type ExpectedThemeCatalog = Record<string, ComponentThemeDefinition>;
+
+/**
+ * Audit a theme against an expected catalog of component defaults.
+ * Pure function — no Vue dependency, no DOM access.
+ *
+ * The catalog is typically built by importing each component package's
+ * exported `*ThemeDefaults` and assembling them into a record:
+ *
+ * ```ts
+ * import { auditTheme } from '@vuecs/core';
+ * import { badgeThemeDefaults } from '@vuecs/elements';
+ * import { buttonThemeDefaults } from '@vuecs/button';
+ * import tailwindTheme from '@vuecs/theme-tailwind';
+ *
+ * const result = auditTheme(tailwindTheme(), {
+ *     badge: badgeThemeDefaults,
+ *     button: buttonThemeDefaults,
+ *     // …
+ * });
+ * if (!isAuditClean(result)) {
+ *     throw new Error(formatAuditResult(result));
+ * }
+ * ```
+ *
+ * Designed to run in CI per shipping theme so a future PR that drops
+ * a slot fails loudly. Cheap protection against theme drift —
+ * especially under plan 023's framing where multiple theme authors
+ * (vuecs's own + third-party) target the same component catalog.
+ */
+export function auditTheme(theme: Theme, expected: ExpectedThemeCatalog): AuditResult {
+    const themeElements = theme.elements as Record<string, ThemeElementDefinition | undefined>;
+    const result: AuditResult = {
+        missingElements: [],
+        unknownElements: [],
+        missingSlots: {},
+        unknownSlots: {},
+        redundantStructural: {},
+    };
+
+    const expectedNames = Object.keys(expected);
+    const themeNames = Object.keys(themeElements).filter((name) => themeElements[name] !== undefined);
+
+    for (const name of expectedNames) {
+        if (!themeElements[name]) {
+            result.missingElements.push(name);
+        }
+    }
+
+    for (const name of themeNames) {
+        if (!(name in expected)) {
+            result.unknownElements.push(name);
+        }
+    }
+
+    for (const name of expectedNames) {
+        const expectedDef = expected[name];
+        const themeDef = themeElements[name];
+        if (!themeDef) continue;
+
+        const expectedClasses = expectedDef.classes as Record<string, string>;
+        const themeClasses = (themeDef.classes ?? {}) as Record<string, unknown>;
+
+        const expectedSlots = Object.keys(expectedClasses);
+        const themeSlots = Object.keys(themeClasses);
+
+        for (const slot of expectedSlots) {
+            const themeValue = themeClasses[slot];
+            if (themeValue === undefined) {
+                /*
+                 * Theme didn't declare this slot. That's fine in the
+                 * stacking model — defaults still apply at runtime.
+                 * But for an audit-style coverage probe, flag it so
+                 * the theme author knows they haven't styled it.
+                 */
+                if (!result.missingSlots[name]) result.missingSlots[name] = [];
+                result.missingSlots[name].push(slot);
+                continue;
+            }
+
+            /*
+             * Skip extend()-marked values: the theme is explicitly
+             * augmenting defaults, not redefining them. That's the
+             * intended use of extend().
+             */
+            if (isExtendValue(themeValue)) continue;
+
+            if (typeof themeValue === 'string' && themeValue === expectedClasses[slot]) {
+                if (!result.redundantStructural[name]) result.redundantStructural[name] = [];
+                result.redundantStructural[name].push(slot);
+            }
+        }
+
+        for (const slot of themeSlots) {
+            if (!(slot in expectedClasses)) {
+                if (!result.unknownSlots[name]) result.unknownSlots[name] = [];
+                result.unknownSlots[name].push(slot);
+            }
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Predicate — returns `true` when the audit found no drift across all
+ * five categories. Use as the gate for CI-style assertions.
+ */
+export function isAuditClean(result: AuditResult): boolean {
+    return result.missingElements.length === 0 &&
+        result.unknownElements.length === 0 &&
+        Object.keys(result.missingSlots).length === 0 &&
+        Object.keys(result.unknownSlots).length === 0 &&
+        Object.keys(result.redundantStructural).length === 0;
+}
+
+export type FormatAuditResultOptions = {
+    /** Title for the rendered output. Default: `'Theme audit'`. */
+    title?: string;
+    /**
+     * Categories to suppress in the output. Useful when the audit is
+     * advisory (e.g. you accept `redundantStructural` warnings during
+     * an in-progress migration).
+     */
+    skip?: ReadonlyArray<keyof AuditResult>;
+};
+
+/**
+ * Format an `AuditResult` as a human-readable multi-line string for
+ * test assertions, CI logs, or interactive output. Returns an empty
+ * string when the result is clean.
+ */
+export function formatAuditResult(
+    result: AuditResult,
+    options: FormatAuditResultOptions = {},
+): string {
+    const { title = 'Theme audit', skip = [] } = options;
+    const skipSet = new Set<keyof AuditResult>(skip);
+    const lines: string[] = [];
+
+    if (!skipSet.has('missingElements') && result.missingElements.length > 0) {
+        lines.push(`  Missing elements (${result.missingElements.length}):`);
+        for (const name of result.missingElements.sort()) {
+            lines.push(`    - ${name}`);
+        }
+    }
+
+    if (!skipSet.has('unknownElements') && result.unknownElements.length > 0) {
+        lines.push(`  Unknown elements (${result.unknownElements.length}):`);
+        for (const name of result.unknownElements.sort()) {
+            lines.push(`    - ${name}`);
+        }
+    }
+
+    if (!skipSet.has('missingSlots')) {
+        const names = Object.keys(result.missingSlots).sort();
+        if (names.length > 0) {
+            lines.push('  Missing slots:');
+            for (const name of names) {
+                lines.push(`    - ${name}: ${result.missingSlots[name].sort().join(', ')}`);
+            }
+        }
+    }
+
+    if (!skipSet.has('unknownSlots')) {
+        const names = Object.keys(result.unknownSlots).sort();
+        if (names.length > 0) {
+            lines.push('  Unknown slots:');
+            for (const name of names) {
+                lines.push(`    - ${name}: ${result.unknownSlots[name].sort().join(', ')}`);
+            }
+        }
+    }
+
+    if (!skipSet.has('redundantStructural')) {
+        const names = Object.keys(result.redundantStructural).sort();
+        if (names.length > 0) {
+            lines.push('  Redundant structural (theme value === default):');
+            for (const name of names) {
+                lines.push(`    - ${name}: ${result.redundantStructural[name].sort().join(', ')}`);
+            }
+        }
+    }
+
+    if (lines.length === 0) return '';
+    return `${title}:\n${lines.join('\n')}`;
+}

--- a/packages/core/src/theme/audit.ts
+++ b/packages/core/src/theme/audit.ts
@@ -6,10 +6,11 @@ import type {
 } from './types';
 
 /**
- * Result of `auditTheme()` — a structured drift report. All four
- * record fields are keyed by component name; the value is the list of
- * slots that drifted. Top-level arrays cover element-level drift
- * (missing or unknown component names).
+ * Result of `auditTheme()` — a structured drift report with five
+ * fields: two top-level string arrays (`missingElements`,
+ * `unknownElements`) for element-level drift, plus three records
+ * (`missingSlots`, `unknownSlots`, `redundantStructural`) keyed by
+ * component name where the value is the list of slots that drifted.
  */
 export type AuditResult = {
     /** Component names present in `expected` but missing from `theme.elements`. */
@@ -67,12 +68,19 @@ export type ExpectedThemeCatalog = Record<string, ComponentThemeDefinition>;
  */
 export function auditTheme(theme: Theme, expected: ExpectedThemeCatalog): AuditResult {
     const themeElements = theme.elements as Record<string, ThemeElementDefinition | undefined>;
+    /*
+     * Prototype-free records: keys come from theme code (potentially
+     * third-party) and assigning into a regular `{}` would trigger the
+     * `__proto__` setter for attacker-controlled keys. `Object.create(null)`
+     * also pairs with the `Object.hasOwn` checks below — both pieces
+     * together close the prototype-chain hole in `in`-based lookups.
+     */
     const result: AuditResult = {
         missingElements: [],
         unknownElements: [],
-        missingSlots: {},
-        unknownSlots: {},
-        redundantStructural: {},
+        missingSlots: Object.create(null) as Record<string, string[]>,
+        unknownSlots: Object.create(null) as Record<string, string[]>,
+        redundantStructural: Object.create(null) as Record<string, string[]>,
     };
 
     const expectedNames = Object.keys(expected);
@@ -85,7 +93,7 @@ export function auditTheme(theme: Theme, expected: ExpectedThemeCatalog): AuditR
     }
 
     for (const name of themeNames) {
-        if (!(name in expected)) {
+        if (!Object.hasOwn(expected, name)) {
             result.unknownElements.push(name);
         }
     }
@@ -129,7 +137,7 @@ export function auditTheme(theme: Theme, expected: ExpectedThemeCatalog): AuditR
         }
 
         for (const slot of themeSlots) {
-            if (!(slot in expectedClasses)) {
+            if (!Object.hasOwn(expectedClasses, slot)) {
                 if (!result.unknownSlots[name]) result.unknownSlots[name] = [];
                 result.unknownSlots[name].push(slot);
             }
@@ -175,16 +183,22 @@ export function formatAuditResult(
     const skipSet = new Set<keyof AuditResult>(skip);
     const lines: string[] = [];
 
+    /*
+     * Sort copies (`[...arr].sort()`), not the inputs. The formatter
+     * is meant to be side-effect-free so callers can re-render the
+     * same `AuditResult` without seeing in-place mutation noise.
+     */
+
     if (!skipSet.has('missingElements') && result.missingElements.length > 0) {
         lines.push(`  Missing elements (${result.missingElements.length}):`);
-        for (const name of result.missingElements.sort()) {
+        for (const name of [...result.missingElements].sort()) {
             lines.push(`    - ${name}`);
         }
     }
 
     if (!skipSet.has('unknownElements') && result.unknownElements.length > 0) {
         lines.push(`  Unknown elements (${result.unknownElements.length}):`);
-        for (const name of result.unknownElements.sort()) {
+        for (const name of [...result.unknownElements].sort()) {
             lines.push(`    - ${name}`);
         }
     }
@@ -194,7 +208,7 @@ export function formatAuditResult(
         if (names.length > 0) {
             lines.push('  Missing slots:');
             for (const name of names) {
-                lines.push(`    - ${name}: ${result.missingSlots[name].sort().join(', ')}`);
+                lines.push(`    - ${name}: ${[...result.missingSlots[name]].sort().join(', ')}`);
             }
         }
     }
@@ -204,7 +218,7 @@ export function formatAuditResult(
         if (names.length > 0) {
             lines.push('  Unknown slots:');
             for (const name of names) {
-                lines.push(`    - ${name}: ${result.unknownSlots[name].sort().join(', ')}`);
+                lines.push(`    - ${name}: ${[...result.unknownSlots[name]].sort().join(', ')}`);
             }
         }
     }
@@ -214,7 +228,7 @@ export function formatAuditResult(
         if (names.length > 0) {
             lines.push('  Redundant structural (theme value === default):');
             for (const name of names) {
-                lines.push(`    - ${name}: ${result.redundantStructural[name].sort().join(', ')}`);
+                lines.push(`    - ${name}: ${[...result.redundantStructural[name]].sort().join(', ')}`);
             }
         }
     }

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -8,6 +8,16 @@ export { extractVariantConfig, resolveVariantClasses } from './variant';
 export { defineTheme } from './define';
 export { mergeThemes } from './merge-themes';
 export { themableProps, useThemeProps } from './themable';
+export {
+    auditTheme,
+    formatAuditResult,
+    isAuditClean,
+} from './audit';
+export type {
+    AuditResult,
+    ExpectedThemeCatalog,
+    FormatAuditResultOptions,
+} from './audit';
 export type {
     ExtendValue,
     ClassesMergeFn,

--- a/packages/core/test/unit/theme/audit.spec.ts
+++ b/packages/core/test/unit/theme/audit.spec.ts
@@ -67,15 +67,11 @@ describe('auditTheme', () => {
     });
 
     it('flags unknown slots per element', () => {
+        const buttonClasses: Record<string, string> = { root: 'btn', icon: 'h-4' };
+        buttonClasses.extraSlot = 'mystery';
         const theme: Theme = {
             elements: {
-                button: {
-                    classes: {
-                        root: 'btn', 
-                        icon: 'h-4', 
-                        extraSlot: 'mystery', 
-                    }, 
-                },
+                button: { classes: buttonClasses },
                 badge: { classes: { root: 'tag' } },
             } as Theme['elements'],
         };
@@ -273,5 +269,27 @@ describe('formatAuditResult', () => {
         expect(alpha).toBeGreaterThan(0);
         expect(alpha).toBeLessThan(mike);
         expect(mike).toBeLessThan(zebra);
+    });
+
+    it('does not mutate the input AuditResult arrays', () => {
+        const missingElements = ['zebra', 'alpha'];
+        const slots = ['root', 'icon'];
+        const result: ReturnType<typeof auditTheme> = {
+            missingElements,
+            unknownElements: [],
+            missingSlots: { button: slots },
+            unknownSlots: {},
+            redundantStructural: {},
+        };
+
+        formatAuditResult(result);
+
+        // Inputs preserved in original (unsorted) order — formatter
+        // sorts copies, not the inputs themselves.
+        expect(result.missingElements).toEqual(['zebra', 'alpha']);
+        expect(result.missingSlots.button).toEqual(['root', 'icon']);
+        // Same identities — formatter doesn't reassign.
+        expect(result.missingElements).toBe(missingElements);
+        expect(result.missingSlots.button).toBe(slots);
     });
 });

--- a/packages/core/test/unit/theme/audit.spec.ts
+++ b/packages/core/test/unit/theme/audit.spec.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from 'vitest';
+import {
+    auditTheme,
+    formatAuditResult,
+    isAuditClean,
+} from '../../../src/theme/audit';
+import type { ExpectedThemeCatalog } from '../../../src/theme/audit';
+import { extend } from '../../../src/theme/extend';
+import type { Theme } from '../../../src/theme/types';
+
+const expected: ExpectedThemeCatalog = {
+    button: {
+        classes: {
+            root: 'vc-button',
+            icon: 'vc-button-icon',
+        },
+    },
+    badge: { classes: { root: 'vc-badge' } },
+};
+
+describe('auditTheme', () => {
+    it('returns a clean report for a fully-covered theme', () => {
+        const theme: Theme = {
+            elements: {
+                button: { classes: { root: 'btn-primary', icon: 'h-4 w-4' } },
+                badge: { classes: { root: 'inline-flex rounded-full' } },
+            } as Theme['elements'],
+        };
+
+        const result = auditTheme(theme, expected);
+        expect(isAuditClean(result)).toBe(true);
+    });
+
+    it('flags missing elements (component name not in theme)', () => {
+        const theme: Theme = { elements: { button: { classes: { root: 'btn', icon: 'h-4' } } } as Theme['elements'] };
+
+        const result = auditTheme(theme, expected);
+        expect(result.missingElements).toEqual(['badge']);
+        expect(isAuditClean(result)).toBe(false);
+    });
+
+    it('flags unknown elements (theme has component name not in expected)', () => {
+        const theme: Theme = {
+            elements: {
+                button: { classes: { root: 'btn', icon: 'h-4' } },
+                badge: { classes: { root: 'tag' } },
+                mystery: { classes: { root: 'unknown' } },
+            } as Theme['elements'],
+        };
+
+        const result = auditTheme(theme, expected);
+        expect(result.unknownElements).toEqual(['mystery']);
+        expect(isAuditClean(result)).toBe(false);
+    });
+
+    it('flags missing slots per element', () => {
+        const theme: Theme = {
+            elements: {
+                button: { classes: { root: 'btn' } },
+                badge: { classes: { root: 'tag' } },
+            } as Theme['elements'],
+        };
+
+        const result = auditTheme(theme, expected);
+        expect(result.missingSlots).toEqual({ button: ['icon'] });
+        expect(isAuditClean(result)).toBe(false);
+    });
+
+    it('flags unknown slots per element', () => {
+        const theme: Theme = {
+            elements: {
+                button: {
+                    classes: {
+                        root: 'btn', 
+                        icon: 'h-4', 
+                        extraSlot: 'mystery', 
+                    }, 
+                },
+                badge: { classes: { root: 'tag' } },
+            } as Theme['elements'],
+        };
+
+        const result = auditTheme(theme, expected);
+        expect(result.unknownSlots).toEqual({ button: ['extraSlot'] });
+        expect(isAuditClean(result)).toBe(false);
+    });
+
+    it('flags redundantStructural when theme value === default', () => {
+        const theme: Theme = {
+            elements: {
+                button: { classes: { root: 'vc-button', icon: 'h-4' } }, // root duplicates default
+                badge: { classes: { root: 'tag' } },
+            } as Theme['elements'],
+        };
+
+        const result = auditTheme(theme, expected);
+        expect(result.redundantStructural).toEqual({ button: ['root'] });
+        expect(isAuditClean(result)).toBe(false);
+    });
+
+    it('does not flag extend()-marked values as redundantStructural', () => {
+        const theme: Theme = {
+            elements: {
+                button: {
+                    classes: {
+                        root: extend('vc-button'), // value happens to equal default but is wrapped in extend()
+                        icon: 'h-4',
+                    },
+                },
+                badge: { classes: { root: 'tag' } },
+            } as Theme['elements'],
+        };
+
+        const result = auditTheme(theme, expected);
+        expect(result.redundantStructural).toEqual({});
+        expect(isAuditClean(result)).toBe(true);
+    });
+
+    it('skips audit details for elements absent from theme', () => {
+        // missingElements is the only field that should fire when an
+        // element is wholly absent — no missingSlots noise.
+        const theme: Theme = { elements: { button: { classes: { root: 'btn', icon: 'h-4' } } } as Theme['elements'] };
+
+        const result = auditTheme(theme, expected);
+        expect(result.missingElements).toEqual(['badge']);
+        expect(result.missingSlots).toEqual({});
+    });
+
+    it('handles a theme with empty elements gracefully', () => {
+        const theme: Theme = { elements: {} };
+        const result = auditTheme(theme, expected);
+        expect(result.missingElements.sort()).toEqual(['badge', 'button']);
+        expect(result.unknownElements).toEqual([]);
+        expect(result.missingSlots).toEqual({});
+        expect(result.unknownSlots).toEqual({});
+        expect(result.redundantStructural).toEqual({});
+    });
+
+    it('handles theme entries that omit classes', () => {
+        const theme: Theme = {
+            elements: {
+                button: { variants: { size: { sm: { root: 'sm' } } } } as Theme['elements'][string],
+                badge: { classes: { root: 'tag' } },
+            } as Theme['elements'],
+        };
+
+        const result = auditTheme(theme, expected);
+        // Theme has no classes for button → both slots missing.
+        expect(result.missingSlots).toEqual({ button: ['root', 'icon'] });
+    });
+
+    it('aggregates multiple findings across categories', () => {
+        const theme: Theme = {
+            elements: {
+                button: { classes: { root: 'vc-button', extraSlot: 'mystery' } }, // redundant + unknown + missing icon
+                mystery: { classes: { root: 'x' } }, // unknown element
+                // badge missing → missingElements
+            } as Theme['elements'],
+        };
+
+        const result = auditTheme(theme, expected);
+        expect(result.missingElements).toEqual(['badge']);
+        expect(result.unknownElements).toEqual(['mystery']);
+        expect(result.missingSlots).toEqual({ button: ['icon'] });
+        expect(result.unknownSlots).toEqual({ button: ['extraSlot'] });
+        expect(result.redundantStructural).toEqual({ button: ['root'] });
+    });
+});
+
+describe('isAuditClean', () => {
+    it('returns true only when every category is empty', () => {
+        expect(isAuditClean({
+            missingElements: [],
+            unknownElements: [],
+            missingSlots: {},
+            unknownSlots: {},
+            redundantStructural: {},
+        })).toBe(true);
+
+        expect(isAuditClean({
+            missingElements: ['x'],
+            unknownElements: [],
+            missingSlots: {},
+            unknownSlots: {},
+            redundantStructural: {},
+        })).toBe(false);
+
+        expect(isAuditClean({
+            missingElements: [],
+            unknownElements: [],
+            missingSlots: { x: ['y'] },
+            unknownSlots: {},
+            redundantStructural: {},
+        })).toBe(false);
+    });
+});
+
+describe('formatAuditResult', () => {
+    it('returns empty string for a clean result', () => {
+        const out = formatAuditResult({
+            missingElements: [],
+            unknownElements: [],
+            missingSlots: {},
+            unknownSlots: {},
+            redundantStructural: {},
+        });
+        expect(out).toBe('');
+    });
+
+    it('renders all five categories with title prefix', () => {
+        const out = formatAuditResult({
+            missingElements: ['badge'],
+            unknownElements: ['mystery'],
+            missingSlots: { button: ['icon'] },
+            unknownSlots: { button: ['extraSlot'] },
+            redundantStructural: { button: ['root'] },
+        });
+
+        expect(out).toContain('Theme audit:');
+        expect(out).toContain('Missing elements (1)');
+        expect(out).toContain('- badge');
+        expect(out).toContain('Unknown elements (1)');
+        expect(out).toContain('- mystery');
+        expect(out).toContain('Missing slots:');
+        expect(out).toContain('button: icon');
+        expect(out).toContain('Unknown slots:');
+        expect(out).toContain('button: extraSlot');
+        expect(out).toContain('Redundant structural');
+        expect(out).toContain('button: root');
+    });
+
+    it('honors custom title', () => {
+        const out = formatAuditResult(
+            {
+                missingElements: ['x'],
+                unknownElements: [],
+                missingSlots: {},
+                unknownSlots: {},
+                redundantStructural: {},
+            },
+            { title: 'theme-tailwind audit' },
+        );
+        expect(out).toContain('theme-tailwind audit:');
+    });
+
+    it('skips suppressed categories', () => {
+        const out = formatAuditResult(
+            {
+                missingElements: ['x'],
+                unknownElements: ['y'],
+                missingSlots: {},
+                unknownSlots: {},
+                redundantStructural: { button: ['root'] },
+            },
+            { skip: ['redundantStructural', 'unknownElements'] },
+        );
+        expect(out).toContain('Missing elements');
+        expect(out).not.toContain('Unknown elements');
+        expect(out).not.toContain('Redundant structural');
+    });
+
+    it('sorts entries alphabetically for stable output', () => {
+        const out = formatAuditResult({
+            missingElements: ['zebra', 'alpha', 'mike'],
+            unknownElements: [],
+            missingSlots: {},
+            unknownSlots: {},
+            redundantStructural: {},
+        });
+        const alpha = out.indexOf('alpha');
+        const mike = out.indexOf('mike');
+        const zebra = out.indexOf('zebra');
+        expect(alpha).toBeGreaterThan(0);
+        expect(alpha).toBeLessThan(mike);
+        expect(mike).toBeLessThan(zebra);
+    });
+});


### PR DESCRIPTION
…tep 7)

Pure function that audits a Theme against an expected catalog of component defaults. Designed for CI use — drift in any of five categories fails loudly so a future PR that drops a slot, adds a typo, or copy-pastes the structural default doesn't sneak past review.

Categories:
- missingElements: expected component names absent from theme
- unknownElements: theme component names absent from expected
- missingSlots: per-element, expected slot keys not in theme
- unknownSlots: per-element, theme slot keys not in expected
- redundantStructural: theme value === default value (no value-add; likely a missed extend() marker). Slots wrapped in extend() are never flagged here.

Companion APIs:
- isAuditClean(result): boolean — predicate for CI gates
- formatAuditResult(result, { title?, skip? }): string — pretty-prints categories for test assertions; empty string when clean; skip suppresses categories during in-progress migrations
- ExpectedThemeCatalog type alias for Record<string, ComponentThemeDefinition> — consumers pass component packages' exported *ThemeDefaults directly, no transformation needed.

Variants and compound variants are out of scope for v1; the audit checks elements[name].classes only. Future iterations may add variant-axis coverage if the demand surfaces.

17 new tests in packages/core/test/unit/theme/audit.spec.ts cover each category individually, the extend()-marker exception, multi- category aggregation, edge cases (empty theme, theme entries that omit classes), and all three companion APIs.

Architecture.md gets a "Theme audit" subsection documenting the canonical use pattern with per-component imports.

Plan 015 P5 marked partially done (function shipped; per-theme audit tests with vitest infra in theme packages deferred as slice 7b in plan 024 step 7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added theme audit utility to validate themes, detect configuration drift, and generate formatted audit reports.

* **Documentation**
  * Added documentation for the theme audit API and its capabilities.

* **Tests**
  * Added comprehensive test suite for theme audit functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1548)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->