### PR TITLE
feat(design,themes,nuxt): csp nonce wiring for palette style (plan 01…

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -521,6 +521,43 @@ that wire vitest into the theme packages are deferred as a follow-up
 slice; the audit function is shipped first so consumers can already
 build their own audits against vuecs's components.
 
+### CSP nonce wiring (plan 017 known gap / plan 024 step 8)
+
+Runtime palette switching writes inline CSS into a
+`<style id="vc-color-palette">` block. Under a strict
+Content-Security-Policy that disallows `style-src 'unsafe-inline'`,
+the browser blocks the block unless it carries a matching `nonce`
+attribute issued by the server per-request.
+
+vuecs threads a CSP nonce end-to-end:
+
+1. **`@vuecs/theme-tailwind` and `@vuecs/theme-bulma`** each augment
+   `Config['nonce']` via TypeScript declaration merging — consumers
+   set it once via `app.use(vuecs, { config: { nonce } })` or
+   subtree-scope via `<VCConfigProvider :config="{ nonce }">`.
+2. **`applyColorPaletteCss(css, doc?, nonce?)`** in `@vuecs/design`
+   takes the nonce as a third positional parameter, writes it to the
+   `<style>` element on creation, updates it on subsequent calls when
+   the value changes, and clears it when the new value is `undefined`
+   (so consumers can revoke a stale nonce on policy update).
+3. **`BindColorPaletteOptions.nonce` and `UseColorPaletteOptions.nonce`**
+   accept `string | (() => string | undefined)`. The getter form is
+   invoked on each `<style>` re-apply so reactive `setConfig({ nonce })`
+   propagates.
+4. **Per-theme `useColorPalette` wrappers** (`@vuecs/theme-tailwind`
+   and `@vuecs/theme-bulma`) read `useConfig('nonce')` and forward as
+   a getter to the generic dispatcher — consumers get nonce
+   attribution automatically with no extra wiring.
+5. **`@vuecs/theme-tailwind-nuxt`'s SSR plugin** resolves the nonce
+   via `nuxtApp.vueApp.runWithContext(() => useConfig('nonce').value)`
+   and emits it via `useHead({ style: [{ ..., nonce }] })` so the
+   server-rendered block matches the per-request CSP header on first
+   paint.
+
+`setColorPalette(palette, doc?, nonce?)` from each theme accepts the
+nonce as a third positional parameter for direct (non-composable)
+callers.
+
 ## Global Behavioral Defaults (#1491)
 
 Alongside the theme system, `@vuecs/core` exposes a parallel `DefaultsManager` for

--- a/packages/design/src/composables/use-color-palette.ts
+++ b/packages/design/src/composables/use-color-palette.ts
@@ -40,6 +40,15 @@ export interface UseColorPaletteOptions<T extends Record<string, unknown>> {
      * shapes supply their own.
      */
     extend?: (current: T, partial: Partial<T>) => T;
+    /**
+     * CSP nonce written to the `<style id="vc-color-palette">` element.
+     * Accepts a string (resolved once) or a getter
+     * `() => string | undefined` (called on every re-render, so reactive
+     * nonce changes propagate). Per-theme wrappers in
+     * `@vuecs/theme-tailwind` / `@vuecs/theme-bulma` read this from
+     * `useConfig('nonce')` automatically.
+     */
+    nonce?: string | (() => string | undefined);
 }
 
 function passthroughSanitize<T>(value: unknown): T {
@@ -92,7 +101,12 @@ export function useColorPaletteUnshared<
         storageKey = DEFAULT_STORAGE_KEY,
         sanitize = passthroughSanitize<T>,
         extend = shallowMerge,
+        nonce,
     } = options;
+
+    const resolveNonce: () => string | undefined = typeof nonce === 'function' ?
+        nonce :
+        () => nonce;
 
     const manager = useThemeRuntimeManager();
 
@@ -133,7 +147,7 @@ export function useColorPaletteUnshared<
          * `<style>` block.
          */
         watchEffect(() => {
-            applyColorPaletteCss(renderConcatenated(storage.value));
+            applyColorPaletteCss(renderConcatenated(storage.value), undefined, resolveNonce());
         });
     }
 

--- a/packages/design/src/palette.ts
+++ b/packages/design/src/palette.ts
@@ -126,10 +126,19 @@ export function bindColorPalette<T>(
     if (document) {
         applyColorPaletteCss(render(source.value), document, resolveNonce());
     }
+    /*
+     * Watch both the palette source AND the resolved nonce. The nonce
+     * getter form (e.g. `() => useConfig('nonce').value`) reads a
+     * reactive ref, so a nonce-only rotation (CSP policy update via
+     * `setConfig({ nonce })`) re-applies the `<style>` element's
+     * attribute without needing a palette mutation. Static nonce
+     * strings return the same primitive on every call → the nonce
+     * lane of the watcher is silently inert.
+     */
     watch(
-        source,
-        (next) => {
-            applyColorPaletteCss(render(next), document, resolveNonce());
+        [source, () => resolveNonce()] as const,
+        () => {
+            applyColorPaletteCss(render(source.value), document, resolveNonce());
         },
         { deep: true },
     );

--- a/packages/design/src/palette.ts
+++ b/packages/design/src/palette.ts
@@ -19,18 +19,40 @@ export const COLOR_PALETTE_STYLE_ELEMENT_ID = 'vc-color-palette';
  * (e.g. `@vuecs/theme-tailwind`'s `renderColorPaletteStyles()`); other
  * tooling can call it directly with custom CSS.
  *
+ * The optional `nonce` parameter wires CSP nonce attribution: when set,
+ * the created `<style>` element carries `nonce="..."` so it survives a
+ * strict Content-Security-Policy. Subsequent calls update the
+ * attribute when the value changes, and clear it when the new value is
+ * undefined (so consumers can revoke a stale nonce on policy update).
+ * Consumers typically read this via
+ * `useConfig('nonce')` (from `@vuecs/core`, augmented by
+ * `@vuecs/theme-tailwind`); the per-theme `useColorPalette` wrappers
+ * already do this.
+ *
  * On the server (`document` undefined) this is a no-op; SSR pre-render
  * paths should serialize the renderer's output into the response head
- * directly, then let the client take over on hydration.
+ * directly (with the nonce wired through framework-specific head
+ * APIs), then let the client take over on hydration.
  */
-export function applyColorPaletteCss(css: string, doc: Document | undefined = globalThis.document): void {
+export function applyColorPaletteCss(
+    css: string,
+    doc: Document | undefined = globalThis.document,
+    nonce?: string,
+): void {
     if (!doc) return;
 
     let style = doc.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID) as HTMLStyleElement | null;
     if (!style) {
         style = doc.createElement('style');
         style.id = COLOR_PALETTE_STYLE_ELEMENT_ID;
+        if (nonce) style.setAttribute('nonce', nonce);
         doc.head.appendChild(style);
+    } else if (nonce) {
+        if (style.getAttribute('nonce') !== nonce) {
+            style.setAttribute('nonce', nonce);
+        }
+    } else if (style.hasAttribute('nonce')) {
+        style.removeAttribute('nonce');
     }
     style.textContent = css;
 }
@@ -68,6 +90,12 @@ export interface BindColorPaletteOptions<T> {
      * no-op — the first reactive read on the client triggers a re-paint.
      */
     document?: Document;
+    /**
+     * CSP nonce written to the `<style id="vc-color-palette">` element.
+     * Accepts a string (resolved once) or a getter `() => string | undefined`
+     * (called on every re-apply, so reactive nonce changes propagate).
+     */
+    nonce?: string | (() => string | undefined);
 }
 
 /**
@@ -88,15 +116,20 @@ export function bindColorPalette<T>(
         render,
         extend,
         document = globalThis.document,
+        nonce,
     } = options;
 
+    const resolveNonce: () => string | undefined = typeof nonce === 'function' ?
+        nonce :
+        () => nonce;
+
     if (document) {
-        applyColorPaletteCss(render(source.value), document);
+        applyColorPaletteCss(render(source.value), document, resolveNonce());
     }
     watch(
         source,
         (next) => {
-            applyColorPaletteCss(render(next), document);
+            applyColorPaletteCss(render(next), document, resolveNonce());
         },
         { deep: true },
     );

--- a/packages/design/test/unit/composables/use-color-palette.spec.ts
+++ b/packages/design/test/unit/composables/use-color-palette.spec.ts
@@ -275,4 +275,46 @@ describe('useColorPalette (generic dispatcher) — plan 021 slice 2', () => {
         expect(api!.current.value).toEqual({ primary: 'red' });
         unmount();
     });
+
+    it('forwards a static nonce string to the rendered <style>', async () => {
+        const render = (p: Record<string, string>) => `:root { --primary: ${p.primary}; }`;
+        const manager: MockThemeManager = { themes: [{ palette: { render } }] };
+
+        const { unmount } = mountWithManager(manager, () => {
+            useColorPaletteUnshared({
+                initial: { primary: 'blue' },
+                persist: false,
+                storageKey: freshStorageKey(),
+                nonce: 'csp-static',
+            });
+        });
+        await nextTick();
+        const style = document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID);
+        expect(style?.getAttribute('nonce')).toBe('csp-static');
+        unmount();
+    });
+
+    it('invokes a nonce getter on each render — supports reactive nonce', async () => {
+        const render = (p: Record<string, string>) => `:root { --primary: ${p.primary}; }`;
+        const manager: MockThemeManager = { themes: [{ palette: { render } }] };
+        const nonceRef = ref<string | undefined>('initial');
+
+        let api: ReturnType<typeof useColorPaletteUnshared> | undefined;
+        const { unmount } = mountWithManager(manager, () => {
+            api = useColorPaletteUnshared({
+                initial: { primary: 'blue' },
+                persist: false,
+                storageKey: freshStorageKey(),
+                nonce: () => nonceRef.value,
+            });
+        });
+        await nextTick();
+        expect(document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID)?.getAttribute('nonce')).toBe('initial');
+
+        nonceRef.value = 'rotated';
+        api!.set({ primary: 'green' });
+        await nextTick();
+        expect(document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID)?.getAttribute('nonce')).toBe('rotated');
+        unmount();
+    });
 });

--- a/packages/design/test/unit/palette.spec.ts
+++ b/packages/design/test/unit/palette.spec.ts
@@ -156,6 +156,28 @@ describe('bindColorPalette (generic)', () => {
         expect(document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID)?.getAttribute('nonce')).toBe('second');
     });
 
+    it('re-applies the <style> nonce on nonce-only changes (no source mutation)', async () => {
+        const nonceRef = ref<string | undefined>('first');
+        const source = ref<FakePalette>({ primary: 'red' });
+        bindColorPalette(source, {
+            render: renderFake,
+            extend: shallowMerge,
+            nonce: () => nonceRef.value,
+        });
+        expect(document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID)?.getAttribute('nonce')).toBe('first');
+
+        // Rotate only the nonce — palette stays the same. Models a CSP
+        // policy update via `setConfig({ nonce })`.
+        nonceRef.value = 'rotated';
+        await nextTick();
+        expect(document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID)?.getAttribute('nonce')).toBe('rotated');
+
+        // Clearing the nonce removes the attribute on the next nonce-only tick.
+        nonceRef.value = undefined;
+        await nextTick();
+        expect(document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID)?.hasAttribute('nonce')).toBe(false);
+    });
+
     it('omits the nonce attribute when the getter returns undefined', () => {
         const source = ref<FakePalette>({ primary: 'red' });
         bindColorPalette(source, {

--- a/packages/design/test/unit/palette.spec.ts
+++ b/packages/design/test/unit/palette.spec.ts
@@ -36,6 +36,32 @@ describe('applyColorPaletteCss', () => {
         expect(styles.length).toBe(1);
         expect(styles[0].textContent).toBe(':root { --x: 2; }');
     });
+
+    it('writes a nonce attribute when the third arg is set', () => {
+        applyColorPaletteCss(':root { --x: 1; }', document, 'abc123');
+        const style = document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID);
+        expect(style?.getAttribute('nonce')).toBe('abc123');
+    });
+
+    it('updates the nonce attribute when the value changes', () => {
+        applyColorPaletteCss(':root { --x: 1; }', document, 'first');
+        applyColorPaletteCss(':root { --x: 2; }', document, 'second');
+        const style = document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID);
+        expect(style?.getAttribute('nonce')).toBe('second');
+    });
+
+    it('removes the nonce attribute when subsequent calls pass undefined', () => {
+        applyColorPaletteCss(':root { --x: 1; }', document, 'abc');
+        applyColorPaletteCss(':root { --x: 2; }', document);
+        const style = document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID);
+        expect(style?.hasAttribute('nonce')).toBe(false);
+    });
+
+    it('does not set nonce when undefined on initial call', () => {
+        applyColorPaletteCss(':root { --x: 1; }');
+        const style = document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID);
+        expect(style?.hasAttribute('nonce')).toBe(false);
+    });
 });
 
 describe('bindColorPalette (generic)', () => {
@@ -100,5 +126,44 @@ describe('bindColorPalette (generic)', () => {
         const { current, set } = bindColorPalette(source, { render: () => '', extend: shallowMerge });
         set({});
         expect(current.value).toEqual({});
+    });
+
+    it('forwards a static nonce string to the <style> element', () => {
+        const source = ref<FakePalette>({ primary: 'red' });
+        bindColorPalette(source, {
+            render: renderFake,
+            extend: shallowMerge,
+            nonce: 'static-nonce',
+        });
+        const style = document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID);
+        expect(style?.getAttribute('nonce')).toBe('static-nonce');
+    });
+
+    it('invokes the nonce getter on each re-render (reactive nonce support)', async () => {
+        const nonceRef = ref<string | undefined>('first');
+        const source = ref<FakePalette>({ primary: 'red' });
+        bindColorPalette(source, {
+            render: renderFake,
+            extend: shallowMerge,
+            nonce: () => nonceRef.value,
+        });
+        expect(document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID)?.getAttribute('nonce')).toBe('first');
+
+        // Mutate the source — getter is invoked again with the new nonce.
+        nonceRef.value = 'second';
+        source.value = { primary: 'green' };
+        await nextTick();
+        expect(document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID)?.getAttribute('nonce')).toBe('second');
+    });
+
+    it('omits the nonce attribute when the getter returns undefined', () => {
+        const source = ref<FakePalette>({ primary: 'red' });
+        bindColorPalette(source, {
+            render: renderFake,
+            extend: shallowMerge,
+            nonce: () => undefined,
+        });
+        const style = document.getElementById(COLOR_PALETTE_STYLE_ELEMENT_ID);
+        expect(style?.hasAttribute('nonce')).toBe(false);
     });
 });

--- a/themes/bulma/src/config.ts
+++ b/themes/bulma/src/config.ts
@@ -1,0 +1,32 @@
+// Anchor import so TypeScript can resolve `@vuecs/core` for the
+// declaration-merging augmentation below. Type-only — no runtime cost.
+import type {} from '@vuecs/core';
+
+/**
+ * Bulma-theme config keys. Augments the cross-cutting `Config`
+ * interface in `@vuecs/core`. Side-effect imported by this package's
+ * `index.ts` so the augmentation is loaded whenever consumers depend
+ * on `@vuecs/theme-bulma`.
+ *
+ * No `withDefaults` registration here — `nonce` has no sensible
+ * framework default; it must come from the consumer's CSP setup.
+ * `setColorPalette` may read it via `useConfig('nonce')` (returns
+ * `undefined` when unset). The same key is augmented by
+ * `@vuecs/theme-tailwind`; declaration-merging makes the two identical
+ * augmentations harmless when both themes are installed.
+ */
+declare module '@vuecs/core' {
+    interface Config {
+        /**
+         * CSP nonce written onto inline `<style>` tags created at
+         * runtime — used by `setColorPalette`'s
+         * `<style id="vc-color-palette">` block. When unset, no
+         * `nonce` attribute is added (works in non-CSP environments
+         * and in CSP environments that allow `unsafe-inline` for
+         * styles).
+         */
+        nonce?: string;
+    }
+}
+
+export {};

--- a/themes/bulma/src/index.ts
+++ b/themes/bulma/src/index.ts
@@ -1,4 +1,5 @@
 import type { Theme } from '@vuecs/core';
+import './config';
 import { TAILWIND_COLOR_PALETTES } from './constants';
 import { renderColorPaletteStyles } from './palette';
 

--- a/themes/bulma/src/palette.ts
+++ b/themes/bulma/src/palette.ts
@@ -103,6 +103,11 @@ export function renderColorPaletteStyles(palette: ColorPaletteConfig): string {
  * `@vuecs/design`'s `applyColorPaletteCss()` with our
  * `renderColorPaletteStyles()` renderer.
  *
+ * The optional `nonce` parameter wires CSP nonce attribution onto the
+ * `<style id="vc-color-palette">` block. Direct callers pass the value
+ * explicitly; the `useColorPalette` composable reads it from
+ * `useConfig('nonce')` automatically.
+ *
  * On the server this is a no-op; use `renderColorPaletteStyles()` directly
  * and inject the result into the SSR response head (a future
  * `@vuecs/theme-bulma-nuxt` will do that automatically).
@@ -110,6 +115,7 @@ export function renderColorPaletteStyles(palette: ColorPaletteConfig): string {
 export function setColorPalette(
     palette: ColorPaletteConfig,
     doc: Document | undefined = globalThis.document,
+    nonce?: string,
 ): void {
-    applyColorPaletteCss(renderColorPaletteStyles(palette), doc);
+    applyColorPaletteCss(renderColorPaletteStyles(palette), doc, nonce);
 }

--- a/themes/bulma/src/use-color-palette.ts
+++ b/themes/bulma/src/use-color-palette.ts
@@ -1,3 +1,4 @@
+import { useConfig } from '@vuecs/core';
 import { useColorPalette as useColorPaletteCore } from '@vuecs/design';
 import type { UseColorPaletteReturn } from '@vuecs/design';
 import { SEMANTIC_SCALES, TAILWIND_COLOR_PALETTES } from './constants';
@@ -65,10 +66,19 @@ const sanitize = (value: unknown): ColorPaletteConfig => {
  * concatenates).
  */
 export function useColorPalette(options: UseColorPaletteOptions = {}): UseColorPaletteReturn<ColorPaletteConfig> {
+    /*
+     * CSP nonce: read via the cross-cutting Config registry (augmented
+     * by this package's `config.ts` to expose `nonce?: string`). Passed
+     * as a getter so the dispatcher re-reads on every `<style>` re-apply
+     * — supports reactive `setConfig({ nonce: '...' })` flows.
+     */
+    const nonce = useConfig('nonce');
+
     return useColorPaletteCore<ColorPaletteConfig>({
         ...options,
         sanitize,
         extend: (current, partial) => ({ ...current, ...partial }),
+        nonce: () => nonce.value,
     });
 }
 

--- a/themes/tailwind-nuxt/src/runtime/composables/useColorPalette.ts
+++ b/themes/tailwind-nuxt/src/runtime/composables/useColorPalette.ts
@@ -1,3 +1,4 @@
+import { useConfig } from '@vuecs/core';
 import { bindColorPalette } from '@vuecs/design';
 import type { UseColorPaletteReturn } from '@vuecs/design';
 import { renderColorPaletteStyles } from '@vuecs/theme-tailwind';
@@ -35,9 +36,20 @@ export function useColorPalette(): UseColorPaletteReturn<ColorPaletteConfig> {
         watch: true,
     });
 
+    /*
+     * CSP nonce: read via the cross-cutting Config registry (augmented
+     * by `@vuecs/theme-tailwind` to expose `nonce?: string`). Passed as
+     * a getter so the bound watcher re-reads on every `<style>` re-apply
+     * — matches the per-request nonce that the SSR plugin already wires
+     * via `useHead({ style: [{ ..., nonce }] })` so the client-side bind
+     * doesn't strip the SSR-emitted nonce on hydration.
+     */
+    const nonce = useConfig('nonce');
+
     return bindColorPalette(cookie, {
         render: renderColorPaletteStyles,
         extend: (current, partial) => ({ ...current, ...partial }),
+        nonce: () => nonce.value,
     });
 }
 

--- a/themes/tailwind-nuxt/src/runtime/plugins/color-palette.server.ts
+++ b/themes/tailwind-nuxt/src/runtime/plugins/color-palette.server.ts
@@ -1,3 +1,4 @@
+import { useConfig } from '@vuecs/core';
 import {
     COLOR_PALETTE_STYLE_ELEMENT_ID,
     THEME_RUNTIME_MANAGER_SYMBOL,
@@ -60,6 +61,17 @@ export default defineNuxtPlugin({
             .runWithContext(() => inject(THEME_RUNTIME_MANAGER_SYMBOL, undefined));
 
         /*
+         * Resolve the CSP nonce from the cross-cutting Config registry.
+         * `useConfig` returns a ComputedRef; on the server we read once
+         * at head-emit time. Consumers wire the nonce per-request via
+         * `app.use(vuecs, { config: { nonce } })` or
+         * `<VCConfigProvider :config="{ nonce }">`. When unset, no
+         * `nonce` attribute is added.
+         */
+        const nonce = nuxtApp.vueApp
+            .runWithContext(() => useConfig('nonce').value);
+
+        /*
          * Prefer the theme-runtime dispatch when a manager is
          * installed; fall back to Tailwind's own renderer when not. The
          * fallback preserves the pre-plan-021 behaviour for consumers
@@ -92,6 +104,12 @@ export default defineNuxtPlugin({
          * `</style>` HTML-injection surface entirely. unhead's
          * type-validated `children` field maps to textContent.
          */
-        useHead({ style: [{ id: COLOR_PALETTE_STYLE_ELEMENT_ID, children: css }] });
+        useHead({
+            style: [{
+                id: COLOR_PALETTE_STYLE_ELEMENT_ID,
+                children: css,
+                ...(nonce ? { nonce } : {}),
+            }],
+        });
     },
 });

--- a/themes/tailwind/src/palette.ts
+++ b/themes/tailwind/src/palette.ts
@@ -47,10 +47,19 @@ export function renderColorPaletteStyles(palette: ColorPaletteConfig): string {
  * Composes `@vuecs/design`'s `applyColorPaletteCss()` with our
  * `renderColorPaletteStyles()` renderer.
  *
+ * The optional `nonce` parameter wires CSP nonce attribution onto the
+ * `<style id="vc-color-palette">` block. Direct callers pass the value
+ * explicitly; the `useColorPalette` composable reads it from
+ * `useConfig('nonce')` automatically.
+ *
  * On the server this is a no-op; use `renderColorPaletteStyles()` directly
  * and inject the result into the SSR response head (see
  * `@vuecs/theme-tailwind-nuxt`).
  */
-export function setColorPalette(palette: ColorPaletteConfig, doc: Document | undefined = globalThis.document): void {
-    applyColorPaletteCss(renderColorPaletteStyles(palette), doc);
+export function setColorPalette(
+    palette: ColorPaletteConfig,
+    doc: Document | undefined = globalThis.document,
+    nonce?: string,
+): void {
+    applyColorPaletteCss(renderColorPaletteStyles(palette), doc, nonce);
 }

--- a/themes/tailwind/src/use-color-palette.ts
+++ b/themes/tailwind/src/use-color-palette.ts
@@ -1,3 +1,4 @@
+import { useConfig } from '@vuecs/core';
 import { useColorPalette as useColorPaletteCore } from '@vuecs/design';
 import type { UseColorPaletteReturn } from '@vuecs/design';
 import { SEMANTIC_SCALES, TAILWIND_COLOR_PALETTES } from './constants';
@@ -59,10 +60,19 @@ const sanitize = (value: unknown): ColorPaletteConfig => {
  * `@vuecs/theme-tailwind-nuxt` module ships its own `useColorPalette()`.
  */
 export function useColorPalette(options: UseColorPaletteOptions = {}): UseColorPaletteReturn<ColorPaletteConfig> {
+    /*
+     * CSP nonce: read via the cross-cutting Config registry (augmented
+     * by `@vuecs/theme-tailwind` to expose `nonce?: string`). Passed as
+     * a getter so the dispatcher re-reads on every `<style>` re-apply
+     * — supports reactive `setConfig({ nonce: '...' })` flows.
+     */
+    const nonce = useConfig('nonce');
+
     return useColorPaletteCore<ColorPaletteConfig>({
         ...options,
         sanitize,
         extend: (current, partial) => ({ ...current, ...partial }),
+        nonce: () => nonce.value,
     });
 }
 


### PR DESCRIPTION
…7 gap / plan 024 step 8)

Close the long-standing known gap from PR #1536: applyColorPaletteCss docs said setColorPalette would read useConfig('nonce'), but the plumbing wasn't there. Thread the nonce end-to-end now:

@vuecs/design:
- applyColorPaletteCss(css, doc?, nonce?) takes the nonce as a third positional parameter. Sets the attribute on creation, updates on subsequent calls when the value changes, removes when the new value is undefined (so consumers can revoke on policy rotation).
- BindColorPaletteOptions.nonce and UseColorPaletteOptions.nonce accept string | (() => string | undefined). Getter form is invoked on every re-apply so reactive setConfig({ nonce }) propagates.
- bindColorPalette + useColorPaletteUnshared thread nonce through.

@vuecs/theme-tailwind / @vuecs/theme-bulma:
- useColorPalette wrappers read useConfig('nonce') from @vuecs/core and forward as a getter to the generic dispatcher. Consumers get nonce attribution automatically with no extra wiring.
- setColorPalette(palette, doc?, nonce?) accepts the nonce as a third positional parameter for direct (non-composable) callers.
- @vuecs/theme-bulma gained its own config.ts mirroring theme-tailwind's Config['nonce'] augmentation. Declaration-merging keeps the two identical augmentations harmless when both themes are installed; the augmentation works for either theme alone.

@vuecs/theme-tailwind-nuxt SSR plugin:
- Resolves nonce via nuxtApp.vueApp.runWithContext(() => useConfig('nonce').value)
- Emits the nonce attribute via useHead({ style: [{ ..., nonce }] }) so the server-rendered <style id="vc-color-palette"> matches the per-request CSP header on first paint.

9 new tests in packages/design covering nonce attribute lifecycle (initial set / update / clear / not-set), bindColorPalette with static and getter forms, generic useColorPalette nonce forwarding including reactive nonce rotation across re-renders.

architecture.md gains a "CSP nonce wiring" subsection documenting the end-to-end path. Plan 017 known-gaps section marked resolved. Plan 024 step 8 closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Content Security Policy (CSP) nonce support for runtime color palette switching. Users can now provide a CSP nonce as a static value or reactive getter function to ensure dynamically generated palette style elements comply with strict CSP policies without requiring `unsafe-inline` directives.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1549)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->