### PR TITLE
test(themes): per-theme auditTheme() coverage probes (plan 024 7b)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -516,10 +516,20 @@ compound variants are out of scope for v1. Slots wrapped in
 `extend()` markers are never flagged as `redundantStructural` (the
 marker signals deliberate augmentation, not redefinition).
 
-Per-theme audit tests (`themes/{tailwind,bootstrap,bulma}/test/`)
-that wire vitest into the theme packages are deferred as a follow-up
-slice; the audit function is shipped first so consumers can already
-build their own audits against vuecs's components.
+Per-theme audit tests ship in
+`themes/{tailwind,bootstrap,bulma}/test/unit/audit.spec.ts` (plan 024
+slice 7b). Each spec imports the exposed `*ThemeDefaults` from
+`@vuecs/elements`, `@vuecs/navigation`, and `@vuecs/overlays`, builds
+an `expectedCatalog`, and runs `auditTheme()` against the theme.
+`unknownElements` / `unknownSlots` are currently suppressed via the
+`skip` option until the remaining component packages (`button`,
+`countdown`, `forms`, `gravatar`, `list`, `navigation/{item,items}`,
+`pagination`, `timeago`) export their defaults from their top-level
+barrel — once they do, the catalog expands and the suppression
+shrinks. A pinned `isAuditClean(result) === false` assertion in each
+spec doubles as a reminder: when the un-catalogued packages get
+exposed, that assertion starts failing and prompts the catalog
+update.
 
 ### CSP nonce wiring (plan 017 known gap / plan 024 step 8)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22294,7 +22294,10 @@
             "version": "3.0.0",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@vuecs/core": "^2.0.0"
+                "@vuecs/core": "^2.0.0",
+                "@vuecs/elements": "^0.0.0",
+                "@vuecs/navigation": "^2.4.1",
+                "@vuecs/overlays": "^0.0.0"
             },
             "engines": {
                 "node": ">=22.0.0"
@@ -22340,6 +22343,9 @@
             "devDependencies": {
                 "@vuecs/core": "^2.0.0",
                 "@vuecs/design": "^0.0.0",
+                "@vuecs/elements": "^0.0.0",
+                "@vuecs/navigation": "^2.4.1",
+                "@vuecs/overlays": "^0.0.0",
                 "@vueuse/core": "^14.3.0",
                 "culori": "^4.0.1",
                 "tailwindcss": "^4.0.0",
@@ -22381,6 +22387,9 @@
             "devDependencies": {
                 "@vuecs/core": "^2.0.0",
                 "@vuecs/design": "^0.0.0",
+                "@vuecs/elements": "^0.0.0",
+                "@vuecs/navigation": "^2.4.1",
+                "@vuecs/overlays": "^0.0.0",
                 "@vueuse/core": "^14.3.0",
                 "jsdom": "^29.1.1",
                 "vue": "^3.5.33"

--- a/packages/navigation/src/components/stepper/index.ts
+++ b/packages/navigation/src/components/stepper/index.ts
@@ -17,4 +17,5 @@ export type { StepperTitleProps } from './StepperTitle.vue';
 export type { StepperDescriptionProps } from './StepperDescription.vue';
 export type { StepperSeparatorProps } from './StepperSeparator.vue';
 
+export * from './theme';
 export * from './types';

--- a/packages/overlays/src/components/context-menu/index.ts
+++ b/packages/overlays/src/components/context-menu/index.ts
@@ -28,4 +28,5 @@ export type { ContextMenuSubProps } from './ContextMenuSub.vue';
 export type { ContextMenuSubTriggerProps } from './ContextMenuSubTrigger.vue';
 export type { ContextMenuSubContentProps } from './ContextMenuSubContent.vue';
 
+export * from './theme';
 export * from './types';

--- a/packages/overlays/src/components/dropdown-menu/index.ts
+++ b/packages/overlays/src/components/dropdown-menu/index.ts
@@ -30,4 +30,5 @@ export type { DropdownMenuSubTriggerProps } from './DropdownMenuSubTrigger.vue';
 export type { DropdownMenuSubContentProps } from './DropdownMenuSubContent.vue';
 export type { DropdownMenuArrowProps } from './DropdownMenuArrow.vue';
 
+export * from './theme';
 export * from './types';

--- a/packages/overlays/src/components/hover-card/index.ts
+++ b/packages/overlays/src/components/hover-card/index.ts
@@ -8,4 +8,5 @@ export type { HoverCardTriggerProps } from './HoverCardTrigger.vue';
 export type { HoverCardContentProps } from './HoverCardContent.vue';
 export type { HoverCardArrowProps } from './HoverCardArrow.vue';
 
+export * from './theme';
 export * from './types';

--- a/packages/overlays/src/components/modal/index.ts
+++ b/packages/overlays/src/components/modal/index.ts
@@ -12,5 +12,6 @@ export type { ModalTitleProps } from './ModalTitle.vue';
 export type { ModalDescriptionProps } from './ModalDescription.vue';
 export type { ModalCloseProps } from './ModalClose.vue';
 
+export * from './theme';
 export * from './types';
 export * from './use-modal';

--- a/packages/overlays/src/components/popover/index.ts
+++ b/packages/overlays/src/components/popover/index.ts
@@ -10,4 +10,5 @@ export type { PopoverContentProps } from './PopoverContent.vue';
 export type { PopoverArrowProps } from './PopoverArrow.vue';
 export type { PopoverCloseProps } from './PopoverClose.vue';
 
+export * from './theme';
 export * from './types';

--- a/packages/overlays/src/components/tooltip/index.ts
+++ b/packages/overlays/src/components/tooltip/index.ts
@@ -10,4 +10,5 @@ export type { TooltipTriggerProps } from './TooltipTrigger.vue';
 export type { TooltipContentProps } from './TooltipContent.vue';
 export type { TooltipArrowProps } from './TooltipArrow.vue';
 
+export * from './theme';
 export * from './types';

--- a/themes/bootstrap/package.json
+++ b/themes/bootstrap/package.json
@@ -36,10 +36,15 @@
     "scripts": {
         "build:js": "tsdown",
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
-        "build": "rimraf dist && npm run build:js && npm run build:types"
+        "build": "rimraf dist && npm run build:js && npm run build:types",
+        "test": "vitest --config test/vitest.config.ts --run",
+        "test:coverage": "vitest --config test/vitest.config.ts --run --coverage"
     },
     "devDependencies": {
-        "@vuecs/core": "^2.0.0"
+        "@vuecs/core": "^2.0.0",
+        "@vuecs/elements": "^0.0.0",
+        "@vuecs/navigation": "^2.4.1",
+        "@vuecs/overlays": "^0.0.0"
     },
     "peerDependencies": {
         "@vuecs/core": "^2.0.0"

--- a/themes/bootstrap/test/unit/audit.spec.ts
+++ b/themes/bootstrap/test/unit/audit.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+    auditTheme,
+    formatAuditResult,
+    isAuditClean,
+} from '@vuecs/core';
+import {
+    aspectRatioThemeDefaults,
+    avatarThemeDefaults,
+    badgeThemeDefaults,
+    separatorThemeDefaults,
+    tagThemeDefaults,
+    tagsThemeDefaults,
+} from '@vuecs/elements';
+import { stepperThemeDefaults } from '@vuecs/navigation';
+import {
+    contextMenuThemeDefaults,
+    dropdownMenuThemeDefaults,
+    hoverCardThemeDefaults,
+    modalThemeDefaults,
+    popoverThemeDefaults,
+    tooltipThemeDefaults,
+} from '@vuecs/overlays';
+import bootstrapTheme from '../../src';
+
+/*
+ * Per-theme `auditTheme` coverage probe (plan 015 P5 / plan 024 step 7b).
+ *
+ * The expected catalog covers component packages that export their
+ * `*ThemeDefaults`: `@vuecs/elements`, `@vuecs/navigation` (stepper),
+ * `@vuecs/overlays`. Packages that still hold their defaults internally
+ * (button, countdown, forms, gravatar, list, navigation/{item,items},
+ * pagination, timeago) are not yet in the catalog — those theme entries
+ * surface as `unknownElements` and are suppressed via `skip` until each
+ * package exports its defaults.
+ */
+const expectedCatalog = {
+    aspectRatio: aspectRatioThemeDefaults,
+    avatar: avatarThemeDefaults,
+    badge: badgeThemeDefaults,
+    separator: separatorThemeDefaults,
+    tag: tagThemeDefaults,
+    tags: tagsThemeDefaults,
+    stepper: stepperThemeDefaults,
+    modal: modalThemeDefaults,
+    popover: popoverThemeDefaults,
+    hoverCard: hoverCardThemeDefaults,
+    tooltip: tooltipThemeDefaults,
+    dropdownMenu: dropdownMenuThemeDefaults,
+    contextMenu: contextMenuThemeDefaults,
+};
+
+const AUDIT_SKIP = ['unknownElements', 'unknownSlots'] as const;
+
+describe('theme-bootstrap — auditTheme()', () => {
+    it('covers every expected component slot without drift', () => {
+        const result = auditTheme(bootstrapTheme(), expectedCatalog);
+        const report = formatAuditResult(result, {
+            title: 'theme-bootstrap',
+            skip: [...AUDIT_SKIP],
+        });
+        // formatAuditResult returns '' when all non-skipped categories are clean.
+        expect(report).toBe('');
+    });
+
+    it('isAuditClean ignores the skip option and only reflects raw drift', () => {
+        // Sanity check: every audited theme will currently fail the strict
+        // `isAuditClean` predicate because `unknownElements` still lists
+        // un-catalogued components. Pin this so the moment those packages
+        // export their defaults, this test starts failing — prompting the
+        // catalog above to be expanded.
+        const result = auditTheme(bootstrapTheme(), expectedCatalog);
+        expect(isAuditClean(result)).toBe(false);
+        expect(result.unknownElements.length).toBeGreaterThan(0);
+    });
+});

--- a/themes/bootstrap/test/vitest.config.ts
+++ b/themes/bootstrap/test/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['test/unit/**/*.{test,spec}.{js,ts}'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.{ts,tsx,js,jsx}'],
+            thresholds: {
+                branches: 80,
+                functions: 80,
+                lines: 80,
+                statements: 80,
+            },
+        },
+    },
+});

--- a/themes/bulma/package.json
+++ b/themes/bulma/package.json
@@ -41,12 +41,17 @@
         "build:js": "tsdown",
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build": "rimraf dist && npm run build:js && npm run build:types",
+        "test": "vitest --config test/vitest.config.ts --run",
+        "test:coverage": "vitest --config test/vitest.config.ts --run --coverage",
         "palette-catalog:build": "tsx scripts/build-palette-catalog.ts",
         "palette-catalog:check": "tsx scripts/build-palette-catalog.ts --check"
     },
     "devDependencies": {
         "@vuecs/core": "^2.0.0",
         "@vuecs/design": "^0.0.0",
+        "@vuecs/elements": "^0.0.0",
+        "@vuecs/navigation": "^2.4.1",
+        "@vuecs/overlays": "^0.0.0",
         "@vueuse/core": "^14.3.0",
         "culori": "^4.0.1",
         "tailwindcss": "^4.0.0",

--- a/themes/bulma/test/unit/audit.spec.ts
+++ b/themes/bulma/test/unit/audit.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+    auditTheme,
+    formatAuditResult,
+    isAuditClean,
+} from '@vuecs/core';
+import {
+    aspectRatioThemeDefaults,
+    avatarThemeDefaults,
+    badgeThemeDefaults,
+    separatorThemeDefaults,
+    tagThemeDefaults,
+    tagsThemeDefaults,
+} from '@vuecs/elements';
+import { stepperThemeDefaults } from '@vuecs/navigation';
+import {
+    contextMenuThemeDefaults,
+    dropdownMenuThemeDefaults,
+    hoverCardThemeDefaults,
+    modalThemeDefaults,
+    popoverThemeDefaults,
+    tooltipThemeDefaults,
+} from '@vuecs/overlays';
+import bulmaTheme from '../../src';
+
+/*
+ * Per-theme `auditTheme` coverage probe (plan 015 P5 / plan 024 step 7b).
+ *
+ * The expected catalog covers component packages that export their
+ * `*ThemeDefaults`: `@vuecs/elements`, `@vuecs/navigation` (stepper),
+ * `@vuecs/overlays`. Packages that still hold their defaults internally
+ * (button, countdown, forms, gravatar, list, navigation/{item,items},
+ * pagination, timeago) are not yet in the catalog — those theme entries
+ * surface as `unknownElements` and are suppressed via `skip` until each
+ * package exports its defaults.
+ */
+const expectedCatalog = {
+    aspectRatio: aspectRatioThemeDefaults,
+    avatar: avatarThemeDefaults,
+    badge: badgeThemeDefaults,
+    separator: separatorThemeDefaults,
+    tag: tagThemeDefaults,
+    tags: tagsThemeDefaults,
+    stepper: stepperThemeDefaults,
+    modal: modalThemeDefaults,
+    popover: popoverThemeDefaults,
+    hoverCard: hoverCardThemeDefaults,
+    tooltip: tooltipThemeDefaults,
+    dropdownMenu: dropdownMenuThemeDefaults,
+    contextMenu: contextMenuThemeDefaults,
+};
+
+const AUDIT_SKIP = ['unknownElements', 'unknownSlots'] as const;
+
+describe('theme-bulma — auditTheme()', () => {
+    it('covers every expected component slot without drift', () => {
+        const result = auditTheme(bulmaTheme(), expectedCatalog);
+        const report = formatAuditResult(result, {
+            title: 'theme-bulma',
+            skip: [...AUDIT_SKIP],
+        });
+        // formatAuditResult returns '' when all non-skipped categories are clean.
+        expect(report).toBe('');
+    });
+
+    it('isAuditClean ignores the skip option and only reflects raw drift', () => {
+        // Sanity check: every audited theme will currently fail the strict
+        // `isAuditClean` predicate because `unknownElements` still lists
+        // un-catalogued components. Pin this so the moment those packages
+        // export their defaults, this test starts failing — prompting the
+        // catalog above to be expanded.
+        const result = auditTheme(bulmaTheme(), expectedCatalog);
+        expect(isAuditClean(result)).toBe(false);
+        expect(result.unknownElements.length).toBeGreaterThan(0);
+    });
+});

--- a/themes/bulma/test/vitest.config.ts
+++ b/themes/bulma/test/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['test/unit/**/*.{test,spec}.{js,ts}'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.{ts,tsx,js,jsx}'],
+            thresholds: {
+                branches: 80,
+                functions: 80,
+                lines: 80,
+                statements: 80,
+            },
+        },
+    },
+});

--- a/themes/tailwind/package.json
+++ b/themes/tailwind/package.json
@@ -51,6 +51,9 @@
     "devDependencies": {
         "@vuecs/core": "^2.0.0",
         "@vuecs/design": "^0.0.0",
+        "@vuecs/elements": "^0.0.0",
+        "@vuecs/navigation": "^2.4.1",
+        "@vuecs/overlays": "^0.0.0",
         "@vueuse/core": "^14.3.0",
         "jsdom": "^29.1.1",
         "vue": "^3.5.33"

--- a/themes/tailwind/test/unit/audit.spec.ts
+++ b/themes/tailwind/test/unit/audit.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+    auditTheme,
+    formatAuditResult,
+    isAuditClean,
+} from '@vuecs/core';
+import {
+    aspectRatioThemeDefaults,
+    avatarThemeDefaults,
+    badgeThemeDefaults,
+    separatorThemeDefaults,
+    tagThemeDefaults,
+    tagsThemeDefaults,
+} from '@vuecs/elements';
+import { stepperThemeDefaults } from '@vuecs/navigation';
+import {
+    contextMenuThemeDefaults,
+    dropdownMenuThemeDefaults,
+    hoverCardThemeDefaults,
+    modalThemeDefaults,
+    popoverThemeDefaults,
+    tooltipThemeDefaults,
+} from '@vuecs/overlays';
+import tailwindTheme from '../../src';
+
+/*
+ * Per-theme `auditTheme` coverage probe (plan 015 P5 / plan 024 step 7b).
+ *
+ * The expected catalog covers component packages that export their
+ * `*ThemeDefaults`: `@vuecs/elements`, `@vuecs/navigation` (stepper),
+ * `@vuecs/overlays`. Packages that still hold their defaults internally
+ * (button, countdown, forms, gravatar, list, navigation/{item,items},
+ * pagination, timeago) are not yet in the catalog — those theme entries
+ * surface as `unknownElements` and are suppressed via `skip` until each
+ * package exports its defaults.
+ */
+const expectedCatalog = {
+    aspectRatio: aspectRatioThemeDefaults,
+    avatar: avatarThemeDefaults,
+    badge: badgeThemeDefaults,
+    separator: separatorThemeDefaults,
+    tag: tagThemeDefaults,
+    tags: tagsThemeDefaults,
+    stepper: stepperThemeDefaults,
+    modal: modalThemeDefaults,
+    popover: popoverThemeDefaults,
+    hoverCard: hoverCardThemeDefaults,
+    tooltip: tooltipThemeDefaults,
+    dropdownMenu: dropdownMenuThemeDefaults,
+    contextMenu: contextMenuThemeDefaults,
+};
+
+const AUDIT_SKIP = ['unknownElements', 'unknownSlots'] as const;
+
+describe('theme-tailwind — auditTheme()', () => {
+    it('covers every expected component slot without drift', () => {
+        const result = auditTheme(tailwindTheme(), expectedCatalog);
+        const report = formatAuditResult(result, {
+            title: 'theme-tailwind',
+            skip: [...AUDIT_SKIP],
+        });
+        // formatAuditResult returns '' when all non-skipped categories are clean.
+        expect(report).toBe('');
+    });
+
+    it('isAuditClean ignores the skip option and only reflects raw drift', () => {
+        // Sanity check: every audited theme will currently fail the strict
+        // `isAuditClean` predicate because `unknownElements` still lists
+        // un-catalogued components. Pin this so the moment those packages
+        // export their defaults, this test starts failing — prompting the
+        // catalog above to be expanded.
+        const result = auditTheme(tailwindTheme(), expectedCatalog);
+        expect(isAuditClean(result)).toBe(false);
+        expect(result.unknownElements.length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
## Summary

Slice 7b of plan 024 — wires the `auditTheme()` function from PR #1548 into each shipping theme as a CI probe.

- Adds vitest infra (`test/vitest.config.ts` + `test` / `test:coverage` scripts) to `themes/{bootstrap,bulma}/`. `theme-tailwind` already had it from PR #1536 / plan 017.
- Per-theme audit specs at `themes/<theme>/test/unit/audit.spec.ts`. Each imports `*ThemeDefaults` from `@vuecs/elements`, `@vuecs/navigation` (stepper), and `@vuecs/overlays` and asserts a clean audit report (with `unknownElements` / `unknownSlots` suppressed via the `skip` option — see catalog-gap note below).
- Surfaces `*ThemeDefaults` from per-component barrels in `@vuecs/navigation/stepper` and `@vuecs/overlays/{modal,popover,hover-card,tooltip,dropdown-menu,context-menu}`. Beyond unblocking the audit, third-party theme authors can now reference these defaults via `extend()` without reaching into internal paths.

### Catalog gap (deliberate first slice)

`@vuecs/{button, countdown, forms, gravatar, list, navigation/item, navigation/items, pagination, timeago}` still hold their `themeDefaults` as local consts. Exporting them is mechanical but adds a meaningful per-package diff; deferred to a follow-up.

A pinned `expect(isAuditClean(result)).toBe(false)` assertion in each theme spec doubles as a reminder: when those packages get exposed and the catalog expands, this assertion will start failing — prompting the spec to keep pace.

## Test plan

- [x] `npx nx run-many --target=test` — all 11 packages pass (309 tests total)
- [x] `npx eslint` — 0 errors (88 pre-existing warnings unchanged)
- [x] `npx nx run-many --target=build --projects=@vuecs/theme-*,@vuecs/navigation,@vuecs/overlays` — affected packages build clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Component theme APIs are now accessible via component entry points.

* **Tests**
  * Added audit test coverage for Bootstrap, Bulma, and Tailwind themes to validate component catalog compliance.

* **Chores**
  * Added test scripts and Vitest configuration for theme packages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1550)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->