### PR TITLE
test(visual-regression): playwright snapshot CI infrastructure (plan 015 P2)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1541,3 +1541,52 @@ Theme entries ship in `@vuecs/theme-tailwind` (uses
 prefixes, scoped via the `group` utility added by `<VCStepperItem>`) and
 `@vuecs/theme-bootstrap` (Bootstrap utility classes only, with
 data-state visualization handled by the bridge CSS as noted above).
+
+## Visual regression CI (@vuecs-tests/visual-regression, plan 015 P2)
+
+Playwright snapshots every shared demo view × every shipping theme
+to catch unintentional visual drift. Lives in a private workspace at
+`tests/visual-regression/` (workspace glob `tests/*` was added to the
+root `package.json` for this).
+
+```
+tests/visual-regression/
+  playwright.config.ts   <- webServer boots all 3 example apps
+                             (:5180 tailwind, :5181 bootstrap, :5182 bulma)
+  specs/themes.spec.ts   <- reads sharedRoutes from @vuecs-examples/shared/routes
+                             generates 99 tests (3 themes × 33 routes)
+  specs/__snapshots__/   <- committed baselines (one PNG per test)
+  package.json           <- @vuecs-tests/visual-regression (private)
+```
+
+Adding a view to `examples/_shared/src/routes.ts` automatically lights
+it up in this matrix on every theme — no separate registration step.
+
+**CI wiring:**
+- `.github/workflows/visual-regression.yml` — runs on PRs that touch
+  packages / themes / icons / examples / the visual-regression
+  workspace itself. Builds, installs Chromium, runs `playwright test`
+  in compare-only mode. Uploads the HTML report as a workflow
+  artefact on failure.
+- `.github/workflows/visual-regression-update.yml` — manually
+  triggered (`workflow_dispatch`). Runs `playwright test --update-snapshots`
+  on Ubuntu, then opens a PR with the regenerated PNGs via
+  `peter-evans/create-pull-request`.
+
+**Why two workflows.** Baselines are platform-specific (font hinting +
+subpixel rendering differs by OS). Generating them on macOS / Windows
+produces baselines that won't match the Ubuntu CI runner. The update
+workflow runs in the same Ubuntu environment as the compare workflow,
+so the two stay aligned. Local iteration uses Docker
+(`mcr.microsoft.com/playwright:v1.49.0-jammy`) when an Ubuntu-rendered
+diff is needed.
+
+**Bootstrap status.** Infrastructure is shipped; the actual baseline
+PNGs are not yet committed. Maintainer triggers the update workflow
+once to generate the initial 99 baselines, then subsequent PRs
+compare against them. Documented at
+`tests/visual-regression/README.md`.
+
+**Tolerance.** `maxDiffPixelRatio: 0.002` — 0.2% pixel difference is
+Playwright's recommended default for theme-level diffs. Tighten in
+`playwright.config.ts` once false positives prove rare.

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1587,9 +1587,12 @@ it up in this matrix on every theme — no separate registration step.
 subpixel rendering differs by OS). Generating them on macOS / Windows
 produces baselines that won't match the Ubuntu CI runner. The update
 workflow runs in the same Ubuntu environment as the compare workflow,
-so the two stay aligned. Local iteration uses Docker
-(`mcr.microsoft.com/playwright:v1.49.0-jammy`) when an Ubuntu-rendered
-diff is needed.
+so the two stay aligned. Local iteration uses Docker — pin the image
+tag to the exact Playwright version locked in `package-lock.json`
+(e.g. `mcr.microsoft.com/playwright:v1.59.1-jammy` while
+`@playwright/test@1.59.1` is locked). A mismatched image ships a
+different Chromium build + font stack, defeating the whole point of
+matching CI.
 
 **Bootstrap status.** Infrastructure is shipped; the actual baseline
 PNGs are not yet committed. Maintainer triggers the update workflow

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1577,7 +1577,11 @@ it up in this matrix on every theme — no separate registration step.
   packages / themes / icons / examples / the visual-regression
   workspace itself. Builds, installs Chromium, runs `playwright test`
   in compare-only mode. Uploads the HTML report as a workflow
-  artefact on failure.
+  artefact on failure. Includes a **self-bootstrap guard**: if
+  `specs/__snapshots__/` contains no `.png` files, the workflow emits
+  a warning and skips comparison (rather than failing on missing
+  baselines). The guard becomes a no-op once the first baseline run
+  lands.
 - `.github/workflows/visual-regression-update.yml` — manually
   triggered (`workflow_dispatch`). Runs `playwright test --update-snapshots`
   on Ubuntu, then opens a PR with the regenerated PNGs via

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -39,6 +39,14 @@ vuecs/
     tailwind/         # @vuecs/example-tailwind — vanilla Vite + Vue 3 + Tailwind theme
     bootstrap/        # @vuecs/example-bootstrap — vanilla Vite + Vue 3 + Bootstrap 5; no Tailwind
     bulma/            # @vuecs/example-bulma — vanilla Vite + Vue 3 + Bulma 1.0+; no Tailwind
+  tests/              # Test workspaces (npm workspaces) — source-only, never published
+    visual-regression/  # @vuecs-tests/visual-regression — Playwright snapshot
+                        # matrix (3 themes × 33 demo routes = 99 tests). Drives
+                        # the same sharedRoutes catalog the example apps consume.
+                        # CI compares on PR; baselines committed under
+                        # specs/__snapshots__/ (regenerate via the
+                        # visual-regression-update workflow on Ubuntu).
+                        # See plan 015 P2 / .agents/architecture.md.
   docs/               # @vuecs/docs — VitePress documentation site (deployed to vuecs.dev)
     src/
       .vitepress/

--- a/.github/workflows/visual-regression-update.yml
+++ b/.github/workflows/visual-regression-update.yml
@@ -1,0 +1,69 @@
+name: Visual Regression — Update Baselines
+
+# Manually triggered. Captures fresh snapshots on Ubuntu (matching the
+# compare-job environment) and opens a PR with the updated baselines.
+# Use after intentional visual changes — or to bootstrap a theme's
+# baselines for the first time.
+
+on:
+    workflow_dispatch:
+        inputs:
+            branch:
+                description: 'Branch to update baselines against (default: current)'
+                required: false
+                default: ''
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+env:
+    NODE_VERSION: 22
+
+defaults:
+    run:
+        shell: bash
+
+jobs:
+    update:
+        name: Capture and commit baselines
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v6
+                with:
+                    ref: ${{ inputs.branch || github.ref }}
+                    token: ${{ secrets.GITHUB_TOKEN }}
+
+            -   name: Install
+                uses: ./.github/actions/install
+                with:
+                    node-version: ${{ env.NODE_VERSION }}
+
+            -   name: Build
+                uses: ./.github/actions/build
+
+            -   name: Install Playwright browsers
+                run: npm run -w @vuecs-tests/visual-regression install:browsers
+
+            -   name: Capture baselines
+                run: npm run -w @vuecs-tests/visual-regression test:update
+
+            -   name: Open update PR
+                uses: peter-evans/create-pull-request@v7
+                with:
+                    commit-message: 'chore(visual-regression): update baselines'
+                    title: 'chore(visual-regression): update baselines'
+                    body: |
+                        Regenerates visual-regression baselines on Ubuntu (CI environment).
+
+                        Triggered by `workflow_dispatch` from ${{ github.actor }}.
+
+                        Review the diffs carefully — every changed PNG corresponds to a visual change in at least one theme.
+                    branch: visual-regression/update-baselines
+                    delete-branch: true
+                    add-paths: |
+                        tests/visual-regression/specs/__snapshots__/

--- a/.github/workflows/visual-regression-update.yml
+++ b/.github/workflows/visual-regression-update.yml
@@ -50,7 +50,7 @@ jobs:
                 run: npm run -w @vuecs-tests/visual-regression install:browsers
 
             -   name: Capture baselines
-                run: npm run -w @vuecs-tests/visual-regression test:update
+                run: npm run -w @vuecs-tests/visual-regression test:visual:update
 
             -   name: Open update PR
                 uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -40,10 +40,30 @@ jobs:
             -   name: Build
                 uses: ./.github/actions/build
 
+            # Self-bootstrap guard: skip comparison until baselines exist
+            # on master. Without this, the very first run of this workflow
+            # — i.e. the PR that introduces visual-regression itself — would
+            # always fail because no baselines have been captured yet.
+            # After merging this PR, trigger `Visual Regression — Update
+            # Baselines` (workflow_dispatch) to capture the initial 99
+            # baselines on Ubuntu. Once that PR merges, this step's guard
+            # becomes a no-op and real comparisons run on every PR.
+            -   name: Check for baselines
+                id: baselines
+                run: |
+                    if [ -z "$(find tests/visual-regression/specs/__snapshots__ -name '*.png' -print -quit 2>/dev/null)" ]; then
+                        echo "exists=false" >> "$GITHUB_OUTPUT"
+                        echo "::warning::No visual-regression baselines committed yet. Skipping comparison. Trigger the 'Visual Regression — Update Baselines' workflow to capture the initial baselines."
+                    else
+                        echo "exists=true" >> "$GITHUB_OUTPUT"
+                    fi
+
             -   name: Install Playwright browsers
+                if: steps.baselines.outputs.exists == 'true'
                 run: npm run -w @vuecs-tests/visual-regression install:browsers
 
             -   name: Run visual regression
+                if: steps.baselines.outputs.exists == 'true'
                 run: npm run -w @vuecs-tests/visual-regression test:visual
 
             -   name: Upload diff report

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -44,7 +44,7 @@ jobs:
                 run: npm run -w @vuecs-tests/visual-regression install:browsers
 
             -   name: Run visual regression
-                run: npm run -w @vuecs-tests/visual-regression test
+                run: npm run -w @vuecs-tests/visual-regression test:visual
 
             -   name: Upload diff report
                 if: failure()

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,55 @@
+name: Visual Regression
+
+on:
+    pull_request:
+        branches:
+            - master
+        paths:
+            - 'packages/**'
+            - 'themes/**'
+            - 'icons/**'
+            - 'examples/**'
+            - 'tests/visual-regression/**'
+            - '.github/workflows/visual-regression.yml'
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+env:
+    NODE_VERSION: 22
+
+defaults:
+    run:
+        shell: bash
+
+jobs:
+    compare:
+        name: Compare snapshots
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v6
+
+            -   name: Install
+                uses: ./.github/actions/install
+                with:
+                    node-version: ${{ env.NODE_VERSION }}
+
+            -   name: Build
+                uses: ./.github/actions/build
+
+            -   name: Install Playwright browsers
+                run: npm run -w @vuecs-tests/visual-regression install:browsers
+
+            -   name: Run visual regression
+                run: npm run -w @vuecs-tests/visual-regression test
+
+            -   name: Upload diff report
+                if: failure()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: playwright-report
+                    path: tests/visual-regression/playwright-report/
+                    retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ cache
 # predev/prebuild hooks in docs/package.json). Per-build hashed filenames
 # would otherwise churn the diff. Source lives in docs/demos/.
 docs/src/public/demos/
+
+# Playwright HTML report + per-run test artefacts. Baselines under
+# `tests/visual-regression/specs/__snapshots__/` ARE committed; these are
+# transient artefacts from each test run.
+tests/visual-regression/playwright-report/
+tests/visual-regression/test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "themes/*",
                 "icons/*",
                 "examples/*",
+                "tests/*",
                 "docs"
             ],
             "devDependencies": {
@@ -5073,6 +5074,22 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@playwright/test": {
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+            "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.59.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@polka/url": {
             "version": "1.0.0-next.29",
             "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
@@ -7785,6 +7802,10 @@
         },
         "node_modules/@vuecs-examples/shared": {
             "resolved": "examples/_shared",
+            "link": true
+        },
+        "node_modules/@vuecs-tests/visual-regression": {
+            "resolved": "tests/visual-regression",
             "link": true
         },
         "node_modules/@vuecs/button": {
@@ -16365,6 +16386,53 @@
                 "pathe": "^2.0.3"
             }
         },
+        "node_modules/playwright": {
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+            "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.59.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.59.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+            "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/pluralize": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -22287,6 +22355,19 @@
                 "@vuecs/core": "^2.0.0",
                 "date-fns": "^3.x || ^4.x",
                 "vue": "^3.x"
+            }
+        },
+        "tests/visual-regression": {
+            "name": "@vuecs-tests/visual-regression",
+            "version": "0.0.0",
+            "license": "Apache-2.0",
+            "devDependencies": {
+                "@playwright/test": "^1.49.0",
+                "@vuecs-examples/shared": "*",
+                "typescript": "^5.9.3"
+            },
+            "engines": {
+                "node": ">=22.0.0"
             }
         },
         "themes/bootstrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22362,9 +22362,10 @@
             "version": "0.0.0",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@playwright/test": "^1.49.0",
+                "@playwright/test": "^1.59.1",
                 "@vuecs-examples/shared": "*",
-                "typescript": "^5.9.3"
+                "typescript": "^5.9.3",
+                "vue": "^3.5.33"
             },
             "engines": {
                 "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "themes/*",
         "icons/*",
         "examples/*",
+        "tests/*",
         "docs"
     ],
     "keywords": [

--- a/tests/visual-regression/README.md
+++ b/tests/visual-regression/README.md
@@ -17,10 +17,10 @@ The same `sharedRoutes` catalog drives both this matrix and the example apps' na
 npm run -w @vuecs-tests/visual-regression install:browsers
 
 # Run the snapshot comparison
-npm run -w @vuecs-tests/visual-regression test
+npm run -w @vuecs-tests/visual-regression test:visual
 
 # After an intentional visual change — regenerate baselines
-npm run -w @vuecs-tests/visual-regression test:update
+npm run -w @vuecs-tests/visual-regression test:visual:update
 
 # Inspect the HTML report after a failure
 npm run -w @vuecs-tests/visual-regression report
@@ -44,7 +44,7 @@ To bootstrap or update baselines without an Ubuntu host:
    ```bash
    docker run --rm -it -v $(pwd):/work -w /work mcr.microsoft.com/playwright:v1.59.1-jammy bash
    # inside container:
-   npm ci && npm run -w @vuecs-tests/visual-regression test:update
+   npm ci && npm run -w @vuecs-tests/visual-regression test:visual:update
    ```
    Re-pin the tag when bumping `@playwright/test`.
 

--- a/tests/visual-regression/README.md
+++ b/tests/visual-regression/README.md
@@ -34,6 +34,8 @@ Snapshots live under `specs/__snapshots__/themes.spec.ts/<theme>-<route>.png` an
 
 **Baselines are platform-specific.** Font hinting + subpixel rendering differs between macOS, Windows, and Linux. CI runs on Ubuntu, so baselines must be generated on Ubuntu to avoid false positives.
 
+**Self-bootstrap.** The `Visual Regression` (compare) workflow detects when `specs/__snapshots__/` contains no `.png` baselines and emits a warning + skips comparison rather than failing. This lets the very first run of the workflow — i.e. the PR that introduces visual-regression itself — land cleanly, then the maintainer triggers the update workflow to seed baselines. Once baselines exist, the guard becomes a no-op and every PR runs the real comparison.
+
 To bootstrap or update baselines without an Ubuntu host:
 
 1. Trigger the `visual-regression-update` workflow via the GitHub Actions UI (`workflow_dispatch`). It runs Playwright with `--update-snapshots` and commits the generated PNGs back via a PR.

--- a/tests/visual-regression/README.md
+++ b/tests/visual-regression/README.md
@@ -1,0 +1,49 @@
+# @vuecs-tests/visual-regression
+
+Playwright snapshots of every shared demo view (`examples/_shared/src/views/*.vue`) rendered through each shipping theme:
+
+| Theme | Example app | Port |
+|---|---|---|
+| `@vuecs/theme-tailwind` | `examples/tailwind/` | 5180 |
+| `@vuecs/theme-bootstrap` | `examples/bootstrap/` | 5181 |
+| `@vuecs/theme-bulma` | `examples/bulma/` | 5182 |
+
+The same `sharedRoutes` catalog drives both this matrix and the example apps' nav — adding a view in `examples/_shared/src/routes.ts` lights it up here automatically.
+
+## Running locally
+
+```bash
+# One-time: install Chromium + its system deps
+npm run -w @vuecs-tests/visual-regression install:browsers
+
+# Run the snapshot comparison
+npm run -w @vuecs-tests/visual-regression test
+
+# After an intentional visual change — regenerate baselines
+npm run -w @vuecs-tests/visual-regression test:update
+
+# Inspect the HTML report after a failure
+npm run -w @vuecs-tests/visual-regression report
+```
+
+Playwright boots the three example app dev servers automatically via its `webServer` config — `reuseExistingServer: true` outside CI, so a manual `vite dev` session keeps working.
+
+## Baselines
+
+Snapshots live under `specs/__snapshots__/themes.spec.ts/<theme>-<route>.png` and **are committed to git**. They're how CI knows what "correct" looks like.
+
+**Baselines are platform-specific.** Font hinting + subpixel rendering differs between macOS, Windows, and Linux. CI runs on Ubuntu, so baselines must be generated on Ubuntu to avoid false positives.
+
+To bootstrap or update baselines without an Ubuntu host:
+
+1. Trigger the `visual-regression-update` workflow via the GitHub Actions UI (`workflow_dispatch`). It runs Playwright with `--update-snapshots` and commits the generated PNGs back via a PR.
+2. Or run locally in Docker:
+   ```bash
+   docker run --rm -it -v $(pwd):/work -w /work mcr.microsoft.com/playwright:v1.49.0-jammy bash
+   # inside container:
+   npm ci && npm run -w @vuecs-tests/visual-regression test:update
+   ```
+
+## Tolerance
+
+`maxDiffPixelRatio: 0.002` — 0.2% pixel difference is the Playwright-recommended default for theme-level diffs. Tighten in `playwright.config.ts` once false positives prove rare.

--- a/tests/visual-regression/README.md
+++ b/tests/visual-regression/README.md
@@ -37,12 +37,16 @@ Snapshots live under `specs/__snapshots__/themes.spec.ts/<theme>-<route>.png` an
 To bootstrap or update baselines without an Ubuntu host:
 
 1. Trigger the `visual-regression-update` workflow via the GitHub Actions UI (`workflow_dispatch`). It runs Playwright with `--update-snapshots` and commits the generated PNGs back via a PR.
-2. Or run locally in Docker:
+2. Or run locally in Docker — pin the image tag to the **same Playwright
+   version as `@playwright/test` in `package-lock.json`** (currently
+   1.59.1). A mismatched image ships a different Chromium build + font
+   stack and produces baselines that won't match the CI runner:
    ```bash
-   docker run --rm -it -v $(pwd):/work -w /work mcr.microsoft.com/playwright:v1.49.0-jammy bash
+   docker run --rm -it -v $(pwd):/work -w /work mcr.microsoft.com/playwright:v1.59.1-jammy bash
    # inside container:
    npm ci && npm run -w @vuecs-tests/visual-regression test:update
    ```
+   Re-pin the tag when bumping `@playwright/test`.
 
 ## Tolerance
 

--- a/tests/visual-regression/package.json
+++ b/tests/visual-regression/package.json
@@ -17,9 +17,9 @@
     },
     "scripts": {
         "install:browsers": "playwright install --with-deps chromium",
-        "test": "playwright test",
-        "test:update": "playwright test --update-snapshots",
-        "test:ui": "playwright test --ui",
+        "test:visual": "playwright test",
+        "test:visual:update": "playwright test --update-snapshots",
+        "test:visual:ui": "playwright test --ui",
         "report": "playwright show-report"
     },
     "devDependencies": {

--- a/tests/visual-regression/package.json
+++ b/tests/visual-regression/package.json
@@ -23,9 +23,10 @@
         "report": "playwright show-report"
     },
     "devDependencies": {
-        "@playwright/test": "^1.49.0",
+        "@playwright/test": "^1.59.1",
         "@vuecs-examples/shared": "*",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vue": "^3.5.33"
     },
     "engines": {
         "node": ">=22.0.0"

--- a/tests/visual-regression/package.json
+++ b/tests/visual-regression/package.json
@@ -1,0 +1,33 @@
+{
+    "name": "@vuecs-tests/visual-regression",
+    "private": true,
+    "type": "module",
+    "version": "0.0.0",
+    "description": "Playwright visual-regression snapshots covering each shipping theme × every shared demo view. Source-only — never published.",
+    "author": {
+        "name": "Peter Placzek",
+        "email": "contact@tada5hi.net",
+        "url": "https://github.com/tada5hi"
+    },
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Tada5hi/vuecs.git",
+        "directory": "tests/visual-regression"
+    },
+    "scripts": {
+        "install:browsers": "playwright install --with-deps chromium",
+        "test": "playwright test",
+        "test:update": "playwright test --update-snapshots",
+        "test:ui": "playwright test --ui",
+        "report": "playwright show-report"
+    },
+    "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "@vuecs-examples/shared": "*",
+        "typescript": "^5.9.3"
+    },
+    "engines": {
+        "node": ">=22.0.0"
+    }
+}

--- a/tests/visual-regression/playwright.config.ts
+++ b/tests/visual-regression/playwright.config.ts
@@ -24,9 +24,12 @@ export default defineConfig({
     testDir: './specs',
 
     /*
-     * Snapshots live alongside the specs. The default path template puts
-     * them under `__snapshots__/<spec name>/`. The {arg}-{platform} suffix
-     * keeps a single baseline per arg (we set arg = `<theme>-<route>`).
+     * Snapshots live alongside the specs under
+     * `__snapshots__/<spec>/<arg>.png`. We pass `arg = '<theme>-<route>'`
+     * to `toHaveScreenshot()`, which yields one baseline per
+     * theme × route pair — no `{platform}` segment because the CI
+     * matrix targets a single platform (Ubuntu). If a future job adds
+     * a second platform, append `-{platform}` here.
      */
     snapshotPathTemplate: '{testDir}/__snapshots__/{testFilePath}/{arg}{ext}',
 

--- a/tests/visual-regression/playwright.config.ts
+++ b/tests/visual-regression/playwright.config.ts
@@ -1,0 +1,98 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Visual-regression CI for vuecs themes (plan 015 P2 / plan 024).
+ *
+ * Snapshots every shared demo view in each shipping example app
+ * (`@vuecs/example-tailwind` :5180, `@vuecs/example-bootstrap` :5181,
+ * `@vuecs/example-bulma` :5182). Each example renders the same
+ * `examples/_shared/src/views/*.vue` catalog, so the comparison is
+ * apples-to-apples across themes.
+ *
+ * Snapshots live next to each spec under
+ * `specs/__snapshots__/<spec>/<theme>-<route>-*.png`. Run
+ * `npm run -w @vuecs-tests/visual-regression test:update` to regenerate
+ * after intentional visual changes. CI runs in compare-only mode and
+ * fails on diff.
+ *
+ * **Platform note:** snapshots are platform-specific (fonts, antialias).
+ * Baselines must be generated in the same OS as CI (Ubuntu) — generate
+ * locally via Docker or generate-and-commit in a CI workflow_dispatch
+ * run, not directly on macOS/Windows.
+ */
+export default defineConfig({
+    testDir: './specs',
+
+    /*
+     * Snapshots live alongside the specs. The default path template puts
+     * them under `__snapshots__/<spec name>/`. The {arg}-{platform} suffix
+     * keeps a single baseline per arg (we set arg = `<theme>-<route>`).
+     */
+    snapshotPathTemplate: '{testDir}/__snapshots__/{testFilePath}/{arg}{ext}',
+
+    expect: {
+        toHaveScreenshot: {
+            /*
+             * Pixel-perfect comparison is brittle across font hinting +
+             * subpixel rendering. 0.2% pixel-difference tolerance is the
+             * Playwright-recommended default for theme-level diffs;
+             * tighten later if false positives are rare.
+             */
+            maxDiffPixelRatio: 0.002,
+            animations: 'disabled',
+            caret: 'hide',
+        },
+    },
+
+    // Run specs in parallel — each app serves on its own port, no cross-talk.
+    fullyParallel: true,
+
+    // No retries — flaky tests should be fixed, not papered over.
+    retries: 0,
+
+    // Single worker locally to keep diff output readable; CI can override.
+    workers: process.env.CI ? 2 : 1,
+
+    reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+
+    use: {
+        // Each spec composes its own base URL based on theme.
+        viewport: { width: 1280, height: 800 },
+        // Wait for fonts before snapshotting — otherwise FOUC shifts text.
+        actionTimeout: 5_000,
+        navigationTimeout: 10_000,
+    },
+
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+
+    /*
+     * Boot all three example apps before running specs. Playwright reuses
+     * a server if it's already running locally (handy when iterating —
+     * keeps your manual `vite` dev session alive).
+     */
+    webServer: [
+        {
+            command: 'npm run -w @vuecs/example-tailwind dev',
+            url: 'http://localhost:5180',
+            reuseExistingServer: !process.env.CI,
+            timeout: 120_000,
+        },
+        {
+            command: 'npm run -w @vuecs/example-bootstrap dev',
+            url: 'http://localhost:5181',
+            reuseExistingServer: !process.env.CI,
+            timeout: 120_000,
+        },
+        {
+            command: 'npm run -w @vuecs/example-bulma dev',
+            url: 'http://localhost:5182',
+            reuseExistingServer: !process.env.CI,
+            timeout: 120_000,
+        },
+    ],
+});

--- a/tests/visual-regression/specs/shims.d.ts
+++ b/tests/visual-regression/specs/shims.d.ts
@@ -1,0 +1,11 @@
+// Mirrors `examples/_shared/src/shims.d.ts` so tsc can follow lazy
+// `.vue` imports declared in `@vuecs-examples/shared/routes` without
+// pulling Vue's full SFC tooling. The visual-regression specs never
+// actually mount these components — they only read `.path` / `.name`
+// from the catalog.
+declare module '*.vue' {
+    import type { DefineComponent } from 'vue';
+
+    const component: DefineComponent<{}, {}, any>;
+    export default component;
+}

--- a/tests/visual-regression/specs/themes.spec.ts
+++ b/tests/visual-regression/specs/themes.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test';
+import { sharedRoutes } from '@vuecs-examples/shared/routes';
+
+/**
+ * Per-theme × per-route snapshot matrix.
+ *
+ * Drives the same `sharedRoutes` catalog the example apps consume —
+ * adding a new view to `examples/_shared/src/routes.ts` automatically
+ * lights it up in this matrix on every theme.
+ */
+const themes = [
+    { name: 'tailwind', baseUrl: 'http://localhost:5180' },
+    { name: 'bootstrap', baseUrl: 'http://localhost:5181' },
+    { name: 'bulma', baseUrl: 'http://localhost:5182' },
+] as const;
+
+for (const theme of themes) {
+    test.describe(`theme-${theme.name}`, () => {
+        for (const route of sharedRoutes) {
+            test(`captures ${route.name}`, async ({ page }) => {
+                await page.goto(`${theme.baseUrl}${route.path}`);
+
+                /*
+                 * Wait for the route's demo content to mount. Each demo
+                 * view renders inside `<main>`, so anchoring on a stable
+                 * sentinel inside main avoids flake from router-link
+                 * navigation transitions and lazy-loaded chunks.
+                 */
+                await page.waitForLoadState('networkidle');
+                await page.waitForFunction(() => {
+                    const main = document.querySelector('main');
+                    return main !== null && main.children.length > 0;
+                });
+
+                /*
+                 * Render fonts before snapshotting. Playwright doesn't
+                 * include a font-ready primitive; document.fonts.ready
+                 * is the standards-based equivalent.
+                 */
+                await page.evaluate(() => document.fonts.ready);
+
+                await expect(page).toHaveScreenshot(
+                    `${theme.name}-${route.name}.png`,
+                    { fullPage: true },
+                );
+            });
+        }
+    });
+}

--- a/tests/visual-regression/tsconfig.json
+++ b/tests/visual-regression/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "resolveJsonModule": true,
+        "noEmit": true,
+        "types": ["node"]
+    },
+    "include": ["playwright.config.ts", "specs/**/*.ts", "specs/**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary

Plan 015 P2 visual-regression infrastructure. Catches unintentional theme drift across the full demo catalog.

- New private workspace `@vuecs-tests/visual-regression` under a fresh `tests/*` workspace glob.
- Playwright config boots all three example apps via `webServer` (`:5180` tailwind, `:5181` bootstrap, `:5182` bulma). `reuseExistingServer: !CI` keeps manual `vite dev` sessions usable.
- `specs/themes.spec.ts` reads `sharedRoutes` from `@vuecs-examples/shared/routes` — 3 themes × 33 routes = 99 tests, auto-extended when a view is added to `examples/_shared/src/routes.ts`.
- Tolerance `maxDiffPixelRatio: 0.002` (Playwright-recommended default for theme-level diffs).

## CI workflows

| Workflow | Trigger | What it does |
|---|---|---|
| `visual-regression.yml` | PRs touching packages/themes/icons/examples/tests-VR | Builds, installs Chromium, compares against committed baselines. Uploads HTML report on failure. |
| `visual-regression-update.yml` | Manual `workflow_dispatch` | Runs `playwright test --update-snapshots` and opens a PR with the regenerated baselines via `peter-evans/create-pull-request`. |

## Why no baselines yet

Playwright baselines are platform-specific (Ubuntu fonts ≠ macOS / Windows fonts ≠ each other). Generating them locally on macOS produces baselines the CI runner would reject on the first diff.

**Bootstrap dance** (post-merge):

1. Merge this PR.
2. Trigger `Visual Regression — Update Baselines` from the Actions tab (`workflow_dispatch`).
3. The workflow captures fresh baselines on Ubuntu and opens a PR with ~99 PNG files under `tests/visual-regression/specs/__snapshots__/`.
4. Review the PR carefully (every PNG = a theme × route pair) and merge.
5. Subsequent PRs then compare against the committed baselines and fail on drift.

Documented in `tests/visual-regression/README.md`.

## Test plan

- [x] `npx playwright test --list` enumerates 99 tests (3 themes × 33 routes)
- [x] `npx tsc --noEmit -p tests/visual-regression/tsconfig.json` — clean
- [x] `npx eslint` — 0 errors (88 pre-existing warnings unchanged)
- [x] `npx nx run-many --target=build` — all 26 packages build clean
- [ ] CI run on this PR will execute the comparison and fail (no baselines yet) — that's expected and unblocks the bootstrap workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Playwright-based visual-regression suite that captures snapshots across three themes and all shared demo routes, with a small pixel-diff tolerance.
* **Bug Fix / CI**
  * Added CI workflows to compare snapshots on PRs and a manual workflow to regenerate and publish baseline images.
* **Documentation**
  * Added docs explaining test matrix, local/CI run commands, and baseline management.
* **Chores**
  * Registered a dedicated tests workspace and ignored Playwright run artefacts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1551)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->