### PR TITLE
build: bump vite/plugin-vue, fix broken nuxt build pipeline

### DIFF
--- a/examples/bootstrap/package.json
+++ b/examples/bootstrap/package.json
@@ -24,7 +24,7 @@
         "node": ">=22.0.0"
     },
     "devDependencies": {
-        "@vitejs/plugin-vue": "^6.0.4",
+        "@vitejs/plugin-vue": "^6.0.6",
         "@vuecs-examples/shared": "*",
         "@vuecs/button": "*",
         "@vuecs/core": "*",
@@ -44,7 +44,7 @@
         "@vuecs/timeago": "*",
         "bootstrap": "^5.3.3",
         "typescript": "^5.9.3",
-        "vite": "^7.1.0",
+        "vite": "^8.0.12",
         "vue": "^3.5.34",
         "vue-router": "^5.0.6",
         "vue-tsc": "^3.2.8"

--- a/examples/bulma/package.json
+++ b/examples/bulma/package.json
@@ -24,7 +24,7 @@
         "node": ">=22.0.0"
     },
     "devDependencies": {
-        "@vitejs/plugin-vue": "^6.0.4",
+        "@vitejs/plugin-vue": "^6.0.6",
         "@vuecs-examples/shared": "*",
         "@vuecs/button": "*",
         "@vuecs/core": "*",
@@ -44,7 +44,7 @@
         "@vuecs/timeago": "*",
         "bulma": "^1.0.4",
         "typescript": "^5.9.3",
-        "vite": "^7.1.0",
+        "vite": "^8.0.12",
         "vue": "^3.5.34",
         "vue-router": "^5.0.6",
         "vue-tsc": "^3.2.8"

--- a/examples/tailwind/package.json
+++ b/examples/tailwind/package.json
@@ -25,7 +25,7 @@
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.3.0",
-        "@vitejs/plugin-vue": "^6.0.4",
+        "@vitejs/plugin-vue": "^6.0.6",
         "@vuecs-examples/shared": "*",
         "@vuecs/button": "*",
         "@vuecs/core": "*",
@@ -45,7 +45,7 @@
         "@vuecs/timeago": "*",
         "tailwindcss": "^4.3.0",
         "typescript": "^5.9.3",
-        "vite": "^7.1.0",
+        "vite": "^8.0.12",
         "vue": "^3.5.34",
         "vue-router": "^5.0.6",
         "vue-tsc": "^3.2.8"

--- a/icons/font-awesome/tsconfig.build.json
+++ b/icons/font-awesome/tsconfig.build.json
@@ -2,9 +2,10 @@
     "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
 }

--- a/icons/lucide/tsconfig.build.json
+++ b/icons/lucide/tsconfig.build.json
@@ -2,9 +2,10 @@
     "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "@tada5hi/eslint-config": "^2.3.0",
                 "@tada5hi/tsconfig": "^0.7.2",
                 "@tsdown/css": "^0.22.0",
-                "@vitejs/plugin-vue": "^6.0.4",
+                "@vitejs/plugin-vue": "^6.0.6",
                 "@vitest/coverage-v8": "^4.1.6",
                 "eslint": "^10.3.0",
                 "eslint-plugin-vue": "^10.9.1",
@@ -31,6 +31,7 @@
                 "tsdown": "^0.22.0",
                 "typescript": "^5.9.3",
                 "typescript-eslint": "^8.59.3",
+                "unbuild": "^3.6.1",
                 "vitest": "^4.1.2",
                 "vue-tsc": "^3.2.8"
             },
@@ -67,184 +68,6 @@
                 "node": ">=22.0.0"
             }
         },
-        "docs/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "docs/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "docs/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "docs/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "docs/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "docs/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "docs/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "docs/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "docs/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "docs/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "docs/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "docs/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "docs/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "docs/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "examples/_shared": {
             "name": "@vuecs-examples/shared",
             "version": "0.0.0",
@@ -270,190 +93,12 @@
                 "vue": "^3.x"
             }
         },
-        "examples/_shared/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "examples/_shared/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "examples/_shared/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "examples/_shared/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "examples/_shared/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/_shared/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "examples/_shared/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/_shared/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/_shared/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/_shared/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "examples/_shared/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "examples/_shared/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "examples/_shared/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "examples/_shared/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "examples/bootstrap": {
             "name": "@vuecs/example-bootstrap",
             "version": "0.0.0",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@vitejs/plugin-vue": "^6.0.4",
+                "@vitejs/plugin-vue": "^6.0.6",
                 "@vuecs-examples/shared": "*",
                 "@vuecs/button": "*",
                 "@vuecs/core": "*",
@@ -473,7 +118,7 @@
                 "@vuecs/timeago": "*",
                 "bootstrap": "^5.3.3",
                 "typescript": "^5.9.3",
-                "vite": "^7.1.0",
+                "vite": "^8.0.12",
                 "vue": "^3.5.34",
                 "vue-router": "^5.0.6",
                 "vue-tsc": "^3.2.8"
@@ -482,190 +127,12 @@
                 "node": ">=22.0.0"
             }
         },
-        "examples/bootstrap/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "examples/bootstrap/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "examples/bootstrap/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "examples/bootstrap/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "examples/bootstrap/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/bootstrap/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "examples/bootstrap/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/bootstrap/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/bootstrap/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/bootstrap/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "examples/bootstrap/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "examples/bootstrap/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "examples/bootstrap/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "examples/bootstrap/node_modules/vue/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
         "examples/bulma": {
             "name": "@vuecs/example-bulma",
             "version": "0.0.0",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@vitejs/plugin-vue": "^6.0.4",
+                "@vitejs/plugin-vue": "^6.0.6",
                 "@vuecs-examples/shared": "*",
                 "@vuecs/button": "*",
                 "@vuecs/core": "*",
@@ -685,191 +152,13 @@
                 "@vuecs/timeago": "*",
                 "bulma": "^1.0.4",
                 "typescript": "^5.9.3",
-                "vite": "^7.1.0",
+                "vite": "^8.0.12",
                 "vue": "^3.5.34",
                 "vue-router": "^5.0.6",
                 "vue-tsc": "^3.2.8"
             },
             "engines": {
                 "node": ">=22.0.0"
-            }
-        },
-        "examples/bulma/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "examples/bulma/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "examples/bulma/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "examples/bulma/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "examples/bulma/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/bulma/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "examples/bulma/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/bulma/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/bulma/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/bulma/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "examples/bulma/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "examples/bulma/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "examples/bulma/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "examples/bulma/node_modules/vue/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
             }
         },
         "examples/nuxt": {
@@ -904,191 +193,13 @@
                 "vue-router": "^5.0.6"
             }
         },
-        "examples/nuxt/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "examples/nuxt/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "examples/nuxt/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "examples/nuxt/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "examples/nuxt/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/nuxt/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "examples/nuxt/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/nuxt/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/nuxt/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/nuxt/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "examples/nuxt/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "examples/nuxt/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "examples/nuxt/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "examples/nuxt/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "examples/tailwind": {
             "name": "@vuecs/example-tailwind",
             "version": "0.0.0",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@tailwindcss/vite": "^4.3.0",
-                "@vitejs/plugin-vue": "^6.0.4",
+                "@vitejs/plugin-vue": "^6.0.6",
                 "@vuecs-examples/shared": "*",
                 "@vuecs/button": "*",
                 "@vuecs/core": "*",
@@ -1108,191 +219,13 @@
                 "@vuecs/timeago": "*",
                 "tailwindcss": "^4.3.0",
                 "typescript": "^5.9.3",
-                "vite": "^7.1.0",
+                "vite": "^8.0.12",
                 "vue": "^3.5.34",
                 "vue-router": "^5.0.6",
                 "vue-tsc": "^3.2.8"
             },
             "engines": {
                 "node": ">=22.0.0"
-            }
-        },
-        "examples/tailwind/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "examples/tailwind/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "examples/tailwind/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "examples/tailwind/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "examples/tailwind/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/tailwind/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "examples/tailwind/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/tailwind/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/tailwind/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "examples/tailwind/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "examples/tailwind/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "examples/tailwind/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "examples/tailwind/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "examples/tailwind/node_modules/vue/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
             }
         },
         "icons/font-awesome": {
@@ -1324,16 +257,16 @@
             }
         },
         "node_modules/@algolia/abtesting": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.17.0.tgz",
-            "integrity": "sha512-nuhHZdTiCtRzJEe9VSNzyqE9cOQMt01UWBzymFnjbgwrxxZpbGHQde6Oa/y9zyspTCjbUtb7Q5HQek1CLiLyeg==",
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.18.1.tgz",
+            "integrity": "sha512-aehCadlWOGvrT91KUIZpC0MbB8KBW9yUuvTJFd2xesR7le/IsT4nJUnjCCZ4ZqZCeTcPHPV5mo//fZ5oxcSVYw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.51.0",
-                "@algolia/requester-browser-xhr": "5.51.0",
-                "@algolia/requester-fetch": "5.51.0",
-                "@algolia/requester-node-http": "5.51.0"
+                "@algolia/client-common": "5.52.1",
+                "@algolia/requester-browser-xhr": "5.52.1",
+                "@algolia/requester-fetch": "5.52.1",
+                "@algolia/requester-node-http": "5.52.1"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -1389,41 +322,41 @@
             }
         },
         "node_modules/@algolia/client-abtesting": {
-            "version": "5.51.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.51.0.tgz",
-            "integrity": "sha512-PKrKlIla1U2J7mFcIQn6N3pWP4oySmkxShnbbDsj/H7818gKbET5KsUwsVoNjWIxHKTJMCTcQ7ekAJ8Ea23NMg==",
+            "version": "5.52.1",
+            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.52.1.tgz",
+            "integrity": "sha512-HmXOGBOAOJPounpBzBpuY0zDYeiCpxgHnQmuA7JO6ScukcBdGp3/XM9zJk5pJx/xNGD68mbPGXWpDxGtl6BwDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.51.0",
-                "@algolia/requester-browser-xhr": "5.51.0",
-                "@algolia/requester-fetch": "5.51.0",
-                "@algolia/requester-node-http": "5.51.0"
+                "@algolia/client-common": "5.52.1",
+                "@algolia/requester-browser-xhr": "5.52.1",
+                "@algolia/requester-fetch": "5.52.1",
+                "@algolia/requester-node-http": "5.52.1"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-analytics": {
-            "version": "5.51.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.51.0.tgz",
-            "integrity": "sha512-U+HCY1K16Km91pIRL1kN6bW6BbGFAF/WhkRSCx4wyl1aFpbrlhSFQs/dAwWbmyBiHWwVWhl7stWHQ1pum5EfMw==",
+            "version": "5.52.1",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.52.1.tgz",
+            "integrity": "sha512-5oo4+I8iixie9vXhCyNFCzeIr8pqA3FQ//VsLHTDvZAV4ttYOPGvYHGQq5NSalrLx5Jc3dRro/5uDOlnUMcBJg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.51.0",
-                "@algolia/requester-browser-xhr": "5.51.0",
-                "@algolia/requester-fetch": "5.51.0",
-                "@algolia/requester-node-http": "5.51.0"
+                "@algolia/client-common": "5.52.1",
+                "@algolia/requester-browser-xhr": "5.52.1",
+                "@algolia/requester-fetch": "5.52.1",
+                "@algolia/requester-node-http": "5.52.1"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-common": {
-            "version": "5.51.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.51.0.tgz",
-            "integrity": "sha512-YPJ3dEuZLCRp846Az94t6Z2gwSNRazP+SmBco7p6SCa4fYrtIE820PDXYZshbNrj2Z8Qfbmv7BQ1Lecl5L3G/w==",
+            "version": "5.52.1",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.52.1.tgz",
+            "integrity": "sha512-qCDoZfx5MpX7XQzvQ3bC4tSEMkQWQMaF/ABtLuoze03Y/flR563CCSws02qIJ23oX7lxl92LsilZjINVyTdtLw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1431,151 +364,151 @@
             }
         },
         "node_modules/@algolia/client-insights": {
-            "version": "5.51.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.51.0.tgz",
-            "integrity": "sha512-/gEwLlR7fQ7YjOW+ADRZ0NxLDtpTC61FSzlZ01Gdl1kTJfU0Rq3Y/TYqwxGxlQGcUiXtGzrpjxXWh3Y0TZD6NA==",
+            "version": "5.52.1",
+            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.52.1.tgz",
+            "integrity": "sha512-hnGs0/lsFJ2PWDxNBz7pxreXo/Xz7gxYRcfePBUjsH26ad0kU/sgnVZd9LwWBpsQv65z2jlb5dkyaB9WE9M9FQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.51.0",
-                "@algolia/requester-browser-xhr": "5.51.0",
-                "@algolia/requester-fetch": "5.51.0",
-                "@algolia/requester-node-http": "5.51.0"
+                "@algolia/client-common": "5.52.1",
+                "@algolia/requester-browser-xhr": "5.52.1",
+                "@algolia/requester-fetch": "5.52.1",
+                "@algolia/requester-node-http": "5.52.1"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-personalization": {
-            "version": "5.51.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.51.0.tgz",
-            "integrity": "sha512-nRwUN1Y2cKyOAFZyIBagkEfZSIhP05nWhT4Rjwl84lcjECssYggftrAODrZ4leakXxSGjhxs/AdaAFEIBqwVFA==",
+            "version": "5.52.1",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.52.1.tgz",
+            "integrity": "sha512-2VxxNc/uBysyKvGeBdSM5n9eIDKH8kWD7wd9/yqbJAiVwU4Yv6tU1LSJusHKrXV/aCu1KW7t9Gug9QyeEmtn/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.51.0",
-                "@algolia/requester-browser-xhr": "5.51.0",
-                "@algolia/requester-fetch": "5.51.0",
-                "@algolia/requester-node-http": "5.51.0"
+                "@algolia/client-common": "5.52.1",
+                "@algolia/requester-browser-xhr": "5.52.1",
+                "@algolia/requester-fetch": "5.52.1",
+                "@algolia/requester-node-http": "5.52.1"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-query-suggestions": {
-            "version": "5.51.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.51.0.tgz",
-            "integrity": "sha512-pybzYCG7VoQKppo+z5iZOKpW8XqtFxhsAIRgEaNboCnfypKukiBHJAwB+pmr7vMZXBsOHwklGYWwCG82e8qshA==",
+            "version": "5.52.1",
+            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.52.1.tgz",
+            "integrity": "sha512-O6mPtsw3xEfNOe6gWFpYLeAZAIljNa4Hgna3bq15PwyN7nbjTY0wXJFRbzs/0YVf75Br+SbOQUmjKxXYjDiSiQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.51.0",
-                "@algolia/requester-browser-xhr": "5.51.0",
-                "@algolia/requester-fetch": "5.51.0",
-                "@algolia/requester-node-http": "5.51.0"
+                "@algolia/client-common": "5.52.1",
+                "@algolia/requester-browser-xhr": "5.52.1",
+                "@algolia/requester-fetch": "5.52.1",
+                "@algolia/requester-node-http": "5.52.1"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-search": {
-            "version": "5.51.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.51.0.tgz",
-            "integrity": "sha512-DWVIlj6RqcvdhwP0gBU9OpOQPnHdcAk9jlT+z8rsNb2+liWv4eUlfQZ7saGBraFsnygEHD3PtdppIHvqwBAb5w==",
+            "version": "5.52.1",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.1.tgz",
+            "integrity": "sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.51.0",
-                "@algolia/requester-browser-xhr": "5.51.0",
-                "@algolia/requester-fetch": "5.51.0",
-                "@algolia/requester-node-http": "5.51.0"
+                "@algolia/client-common": "5.52.1",
+                "@algolia/requester-browser-xhr": "5.52.1",
+                "@algolia/requester-fetch": "5.52.1",
+                "@algolia/requester-node-http": "5.52.1"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/ingestion": {
-            "version": "1.51.0",
-            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.51.0.tgz",
-            "integrity": "sha512-bA25s12iUDJi/X8M7tWlPRT8GeOhls/yDbdoUqinz27lNqsOlcM1UrAxIKdIZ6lm3sXit+ewPIz1pS2x6rXu8g==",
+            "version": "1.52.1",
+            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.52.1.tgz",
+            "integrity": "sha512-U9zZfc5xIu9wRxZkt+HceJUAD4VKHKbAyLSloJdEyMRmphXeibfrY9cxqIXBcmPeZzGhn3Imb35Dq8l19PkJhw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.51.0",
-                "@algolia/requester-browser-xhr": "5.51.0",
-                "@algolia/requester-fetch": "5.51.0",
-                "@algolia/requester-node-http": "5.51.0"
+                "@algolia/client-common": "5.52.1",
+                "@algolia/requester-browser-xhr": "5.52.1",
+                "@algolia/requester-fetch": "5.52.1",
+                "@algolia/requester-node-http": "5.52.1"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/monitoring": {
-            "version": "1.51.0",
-            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.51.0.tgz",
-            "integrity": "sha512-zj+RcE5e0NE0/ew6oEOTgOplPHry+w2oi7h0Y87lhdq4E0d7xLS31KVB8kKfCGkrG7AYtZvrcyvLOKS5d0no4Q==",
+            "version": "1.52.1",
+            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.52.1.tgz",
+            "integrity": "sha512-a3SGNceHmkQfq77iG8Ka+w1pvwfZa/0lzEIgse30fL0kD+yKnd/dg0dQvSfFPAEt2f21DMcGkDSSeJlO3KdQjQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.51.0",
-                "@algolia/requester-browser-xhr": "5.51.0",
-                "@algolia/requester-fetch": "5.51.0",
-                "@algolia/requester-node-http": "5.51.0"
+                "@algolia/client-common": "5.52.1",
+                "@algolia/requester-browser-xhr": "5.52.1",
+                "@algolia/requester-fetch": "5.52.1",
+                "@algolia/requester-node-http": "5.52.1"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/recommend": {
-            "version": "5.51.0",
-            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.51.0.tgz",
-            "integrity": "sha512-/HDgccfye1Rq3bPxaSCsvSEBHzSMmtpM9ZRGRtAuC62Cv+ql/76IWnxjGTDXtqIJ+/j7ZlFYAzq9fkp95wF2SQ==",
+            "version": "5.52.1",
+            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.52.1.tgz",
+            "integrity": "sha512-z98QEguCFDpxb4S/PyrUK1igqF8tPsdbqOUUO6ON91vJ58w+Gwa6ncrI0oNXSFcrkxA5EqPKPQ2A1PBCn08TYQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.51.0",
-                "@algolia/requester-browser-xhr": "5.51.0",
-                "@algolia/requester-fetch": "5.51.0",
-                "@algolia/requester-node-http": "5.51.0"
+                "@algolia/client-common": "5.52.1",
+                "@algolia/requester-browser-xhr": "5.52.1",
+                "@algolia/requester-fetch": "5.52.1",
+                "@algolia/requester-node-http": "5.52.1"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-browser-xhr": {
-            "version": "5.51.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.51.0.tgz",
-            "integrity": "sha512-nJdW+WBwGlXWMJbxxB7/AJPvNq0lLJSudXmIQCJbmH8jsOXQhRpAtoCD4ceLyJKv3ze9JbQu4Gqu5JDLckuFcw==",
+            "version": "5.52.1",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.52.1.tgz",
+            "integrity": "sha512-CI7+/0I11QeZM59Uc8whd2or0kqzFVjpaPn9Qpwll/krHcBAxk24WkAQ6WX+IwDVMfpont4YGbKwAmCre3vE8Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.51.0"
+                "@algolia/client-common": "5.52.1"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-fetch": {
-            "version": "5.51.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.51.0.tgz",
-            "integrity": "sha512-bsBgRI/1h1mjS3eCyfGau78yGZVmiDLmT1aU6dMnk75/T0SgKqnSKNpQ53xKoDYVChGDcNnpHXWpoUSo8MH1+w==",
+            "version": "5.52.1",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.52.1.tgz",
+            "integrity": "sha512-S6bDuw9byfOvm3T71cgdoZgrgnZq6hpdMLkx52Louh57nUAmvGQESz2aojOynQHjbTiV55smvAFbgn0qT4tJrg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.51.0"
+                "@algolia/client-common": "5.52.1"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-node-http": {
-            "version": "5.51.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.51.0.tgz",
-            "integrity": "sha512-zPrIDVPpmKWgrjmWOqpqrhqAhNjvVkjoj+mqw2NBPxEOuKNzP0H+Qz5NJLLTOepBVj1UFedFaF3AUgxLsB9ukQ==",
+            "version": "5.52.1",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.52.1.tgz",
+            "integrity": "sha512-tqZXM+54rWo4mk5jL5Z/flE11nPmNEdXwFBM5py9DkOmbjeCNemfVd45FyM97XdzfZ0dl9uOJC6PYn1FpkeyQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.51.0"
+                "@algolia/client-common": "5.52.1"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -1661,6 +594,13 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/code-frame/node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@babel/compat-data": {
             "version": "7.29.3",
             "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
@@ -1719,46 +659,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/core/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/core/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@babel/core/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/core/node_modules/semver": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -1787,6 +687,56 @@
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
+        "node_modules/@babel/generator/node_modules/@babel/helper-string-parser": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.5.tgz",
+            "integrity": "sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/@babel/generator/node_modules/@babel/helper-validator-identifier": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.5.tgz",
+            "integrity": "sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/@babel/generator/node_modules/@babel/parser": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.5.tgz",
+            "integrity": "sha512-/Mfg83rK3+jsRbl4Vbd0jqxc6M1A1/WNFtgrowRM1unEsD3XcNnrBdMM0JWakd0/RN9lseQKwPduW1TiEwKOlQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^8.0.0-rc.5"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/@babel/generator/node_modules/@babel/types": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.5.tgz",
+            "integrity": "sha512-JeSVu/m8x/zpp4CLjYHVNXuhEyOkhPXuxM8YOXjh6L4LlvQNKuUNOTo5KdBuKAcTDHw8DquToTaEkhsBqPXOaA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^8.0.0-rc.5",
+                "@babel/helper-validator-identifier": "^8.0.0-rc.5"
+            },
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
         "node_modules/@babel/helper-annotate-as-pure": {
             "version": "7.27.3",
             "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
@@ -1795,30 +745,6 @@
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.27.3"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1924,30 +850,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-module-imports": {
             "version": "7.28.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
@@ -1957,30 +859,6 @@
             "dependencies": {
                 "@babel/traverse": "^7.28.6",
                 "@babel/types": "^7.28.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-module-imports/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2012,30 +890,6 @@
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.27.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2083,38 +937,13 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/helper-string-parser": {
+        "node_modules/@babel/helper-string-parser": {
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
             "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-string-parser": {
-            "version": "8.0.0-rc.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.4.tgz",
-            "integrity": "sha512-dluR3v287dp6YPF57kyKKrHPKffUeuxH1zQcF1WD30TeFzWXhDiVi1U6PkqaDB0++H1PeCwRhmYl4DvoerlPIw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
@@ -2150,44 +979,19 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helpers/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helpers/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/parser": {
-            "version": "8.0.0-rc.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.4.tgz",
-            "integrity": "sha512-0S/1yefMa15N4i2v3t8Fw9pgMHhf2gF6Lc1UEXI96Ls6FNAjqvHHZouZ2ZS/deqLhbMFtmfVeFac6iTsvFbLwA==",
-            "dev": true,
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^8.0.0-rc.4"
+                "@babel/types": "^7.29.0"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
             "engines": {
-                "node": "^20.19.0 || >=22.12.0"
+                "node": ">=6.0.0"
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
@@ -2257,46 +1061,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/template/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/template/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@babel/template/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/traverse": {
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
@@ -2333,37 +1097,10 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/traverse/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/traverse/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@babel/traverse/node_modules/@babel/types": {
+        "node_modules/@babel/types": {
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
             "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -2371,30 +1108,6 @@
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/types": {
-            "version": "8.0.0-rc.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.4.tgz",
-            "integrity": "sha512-bw30DV880P/VYtsjWWdoWmJpb9S2Vn1/PqayyccTELzRQ/HslIO7+BD9rNoZ4AAFOAjC1vrNeBCkAsyh6Ibfww==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^8.0.0-rc.4",
-                "@babel/helper-validator-identifier": "^8.0.0-rc.4"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@babel/types/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.0-rc.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.4.tgz",
-            "integrity": "sha512-HTD3bskipk5MSm08twTW6832jzIXUhxMddy4NPPzIMuyMEsrs0ZgwAaMj5ubB5+6hMlUjDu17vNconEmwsmpYg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
             }
         },
         "node_modules/@bcoe/v8-coverage": {
@@ -2421,27 +1134,33 @@
             }
         },
         "node_modules/@clack/core": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
-            "integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.3.1.tgz",
+            "integrity": "sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fast-wrap-ansi": "^0.1.3",
+                "fast-wrap-ansi": "^0.2.0",
                 "sisteransi": "^1.0.5"
+            },
+            "engines": {
+                "node": ">= 20.12.0"
             }
         },
         "node_modules/@clack/prompts": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
-            "integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.4.0.tgz",
+            "integrity": "sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@clack/core": "1.2.0",
-                "fast-string-width": "^1.1.0",
-                "fast-wrap-ansi": "^0.1.3",
+                "@clack/core": "1.3.1",
+                "fast-string-width": "^3.0.2",
+                "fast-wrap-ansi": "^0.2.0",
                 "sisteransi": "^1.0.5"
+            },
+            "engines": {
+                "node": ">= 20.12.0"
             }
         },
         "node_modules/@cloudflare/kv-asset-handler": {
@@ -2462,16 +1181,16 @@
             "license": "MIT"
         },
         "node_modules/@commitlint/cli": {
-            "version": "20.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.0.tgz",
-            "integrity": "sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==",
+            "version": "20.5.3",
+            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.3.tgz",
+            "integrity": "sha512-OJdL0EXWD5y9LPa0nr/geOwzaS8BsdaybKkcloB0JgsguGxNv2R+hC2FTPqrAcprg35zF33KOQerY0x8W1aesA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@commitlint/format": "^20.5.0",
-                "@commitlint/lint": "^20.5.0",
-                "@commitlint/load": "^20.5.0",
+                "@commitlint/lint": "^20.5.3",
+                "@commitlint/load": "^20.5.3",
                 "@commitlint/read": "^20.5.0",
                 "@commitlint/types": "^20.5.0",
                 "tinyexec": "^1.0.0",
@@ -2485,9 +1204,9 @@
             }
         },
         "node_modules/@commitlint/config-conventional": {
-            "version": "20.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.5.0.tgz",
-            "integrity": "sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA==",
+            "version": "20.5.3",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.5.3.tgz",
+            "integrity": "sha512-j34Qqeaa152chJgz2ysyk0BCpHenJn1lV0Rx0VXf8k3ccQcED+48EZrzMvo9jLmJUyBrrBwvu89I+2er4gW7QQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2514,19 +1233,15 @@
             }
         },
         "node_modules/@commitlint/ensure": {
-            "version": "20.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.0.tgz",
-            "integrity": "sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw==",
+            "version": "20.5.3",
+            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.3.tgz",
+            "integrity": "sha512-4i4AgNvH62owG9MwSiWKrle7HGNpBHHdLnWFIp5fTsHUYe5kRuh15t08L/0pdbbrRk8JKXQxxN4hZQcn+szkrw==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@commitlint/types": "^20.5.0",
-                "lodash.camelcase": "^4.3.0",
-                "lodash.kebabcase": "^4.1.1",
-                "lodash.snakecase": "^4.1.1",
-                "lodash.startcase": "^4.4.0",
-                "lodash.upperfirst": "^4.3.1"
+                "es-toolkit": "^1.46.0"
             },
             "engines": {
                 "node": ">=v18"
@@ -2574,16 +1289,16 @@
             }
         },
         "node_modules/@commitlint/lint": {
-            "version": "20.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.0.tgz",
-            "integrity": "sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA==",
+            "version": "20.5.3",
+            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.3.tgz",
+            "integrity": "sha512-M7JbWBNr2gXKaPc4i/KipsuW1gkDHpj35KPjWtKy3Z+2AQw5wu1gBi1LIO0uoaij67CqY4K8PxPZSGens4evCw==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@commitlint/is-ignored": "^20.5.0",
                 "@commitlint/parse": "^20.5.0",
-                "@commitlint/rules": "^20.5.0",
+                "@commitlint/rules": "^20.5.3",
                 "@commitlint/types": "^20.5.0"
             },
             "engines": {
@@ -2591,21 +1306,21 @@
             }
         },
         "node_modules/@commitlint/load": {
-            "version": "20.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.0.tgz",
-            "integrity": "sha512-sLhhYTL/KxeOTZjjabKDhwidGZan84XKK1+XFkwDYL/4883kIajcz/dZFAhBJmZPtL8+nBx6bnkzA95YxPeDPw==",
+            "version": "20.5.3",
+            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.3.tgz",
+            "integrity": "sha512-1FDZWuKyu98Myb8i7Tp31jPU2rZpOwAdYRyJcy2KoGg7Xk2A+bgHN8smhMaaNSNkmE8fwt53BokywZq8Gv/5XQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@commitlint/config-validator": "^20.5.0",
                 "@commitlint/execute-rule": "^20.0.0",
-                "@commitlint/resolve-extends": "^20.5.0",
+                "@commitlint/resolve-extends": "^20.5.3",
                 "@commitlint/types": "^20.5.0",
                 "cosmiconfig": "^9.0.1",
                 "cosmiconfig-typescript-loader": "^6.1.0",
+                "es-toolkit": "^1.46.0",
                 "is-plain-obj": "^4.1.0",
-                "lodash.mergewith": "^4.6.2",
                 "picocolors": "^1.1.1"
             },
             "engines": {
@@ -2658,18 +1373,18 @@
             }
         },
         "node_modules/@commitlint/resolve-extends": {
-            "version": "20.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.0.tgz",
-            "integrity": "sha512-3SHPWUW2v0tyspCTcfSsYml0gses92l6TlogwzvM2cbxDgmhSRc+fldDjvGkCXJrjSM87BBaWYTPWwwyASZRrg==",
+            "version": "20.5.3",
+            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.3.tgz",
+            "integrity": "sha512-+ogW9v/u9JqpvAgTrLra/YTFo0KkjU6iNblF89pPsj4NebNc+DAWctsludwezI8YnsjBmfHpApSwcXprN/f/ew==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@commitlint/config-validator": "^20.5.0",
                 "@commitlint/types": "^20.5.0",
-                "global-directory": "^4.0.1",
+                "es-toolkit": "^1.46.0",
+                "global-directory": "^5.0.0",
                 "import-meta-resolve": "^4.0.0",
-                "lodash.mergewith": "^4.6.2",
                 "resolve-from": "^5.0.0"
             },
             "engines": {
@@ -2677,14 +1392,14 @@
             }
         },
         "node_modules/@commitlint/rules": {
-            "version": "20.5.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.0.tgz",
-            "integrity": "sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ==",
+            "version": "20.5.3",
+            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.3.tgz",
+            "integrity": "sha512-MPlMnb9D3wbszYMp+1hPtuhtPJndRo6I6yfkZVA4+jR8w7Kqp0u2u/Y+gzbaItx5Lltq5rw7FSZQWJMoXUC4NQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@commitlint/ensure": "^20.5.0",
+                "@commitlint/ensure": "^20.5.3",
                 "@commitlint/message": "^20.4.3",
                 "@commitlint/to-lines": "^20.0.0",
                 "@commitlint/types": "^20.5.0"
@@ -2981,20 +1696,20 @@
             "license": "MIT"
         },
         "node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
+            "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
+                "@emnapi/wasi-threads": "1.0.4",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
+            "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3002,9 +1717,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
+            "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3012,9 +1727,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+            "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
             "cpu": [
                 "ppc64"
             ],
@@ -3029,9 +1744,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+            "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
             "cpu": [
                 "arm"
             ],
@@ -3046,9 +1761,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+            "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
             "cpu": [
                 "arm64"
             ],
@@ -3063,9 +1778,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+            "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
             "cpu": [
                 "x64"
             ],
@@ -3080,9 +1795,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+            "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
             "cpu": [
                 "arm64"
             ],
@@ -3097,9 +1812,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+            "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
             "cpu": [
                 "x64"
             ],
@@ -3114,9 +1829,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
             "cpu": [
                 "arm64"
             ],
@@ -3131,9 +1846,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+            "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
             "cpu": [
                 "x64"
             ],
@@ -3148,9 +1863,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+            "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
             "cpu": [
                 "arm"
             ],
@@ -3165,9 +1880,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+            "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
             "cpu": [
                 "arm64"
             ],
@@ -3182,9 +1897,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+            "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
             "cpu": [
                 "ia32"
             ],
@@ -3199,9 +1914,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+            "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
             "cpu": [
                 "loong64"
             ],
@@ -3216,9 +1931,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+            "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
             "cpu": [
                 "mips64el"
             ],
@@ -3233,9 +1948,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+            "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
             "cpu": [
                 "ppc64"
             ],
@@ -3250,9 +1965,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+            "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -3267,9 +1982,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+            "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
             "cpu": [
                 "s390x"
             ],
@@ -3284,9 +1999,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+            "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
             "cpu": [
                 "x64"
             ],
@@ -3301,9 +2016,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
             "cpu": [
                 "arm64"
             ],
@@ -3318,9 +2033,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
             "cpu": [
                 "x64"
             ],
@@ -3335,9 +2050,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
             "cpu": [
                 "arm64"
             ],
@@ -3352,9 +2067,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
             "cpu": [
                 "x64"
             ],
@@ -3369,9 +2084,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+            "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
             "cpu": [
                 "arm64"
             ],
@@ -3386,9 +2101,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+            "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
             "cpu": [
                 "x64"
             ],
@@ -3403,9 +2118,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+            "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
             "cpu": [
                 "arm64"
             ],
@@ -3420,9 +2135,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+            "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
             "cpu": [
                 "ia32"
             ],
@@ -3437,9 +2152,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+            "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
             "cpu": [
                 "x64"
             ],
@@ -3662,25 +2377,39 @@
             }
         },
         "node_modules/@humanfs/core": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/types": "^0.15.0"
+            },
             "engines": {
                 "node": ">=18.18.0"
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.7",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-            "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@humanfs/core": "^0.19.1",
+                "@humanfs/core": "^0.19.2",
+                "@humanfs/types": "^0.15.0",
                 "@humanwhocodes/retry": "^0.4.0"
             },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/types": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+            "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=18.18.0"
             }
@@ -3724,9 +2453,9 @@
             }
         },
         "node_modules/@iconify-json/simple-icons": {
-            "version": "1.2.79",
-            "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.79.tgz",
-            "integrity": "sha512-aNyO7Fd1qej9oQfIyohYFRv0lhQLaZ+6UkK1c1qwax0MDPUOZOdq65MlU500kow97pD/W+b2u1And3e25eE24Q==",
+            "version": "1.2.82",
+            "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.82.tgz",
+            "integrity": "sha512-4p978qHx8eD/QBOhgBzp/p7uS3OO2KCnVpFPJTUvuhuDXv1Hr4RcxcZ5MWc6ptkf/3Dlb1xb23068OtPyx10mA==",
             "dev": true,
             "license": "CC0-1.0",
             "dependencies": {
@@ -4000,6 +2729,32 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/abbrev": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+            "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+            "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^3.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
@@ -4051,14 +2806,14 @@
             }
         },
         "node_modules/@nuxt/cli": {
-            "version": "3.35.1",
-            "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.35.1.tgz",
-            "integrity": "sha512-nX9XO+e3l9pnhHL2zsbnBmQb/nsOQYhGz2XiqE8X962QN9ufc1ZSuDZoTmQVv/ymkbYNR6hpNWW8RZQhuhzadw==",
+            "version": "3.35.2",
+            "resolved": "https://registry.npmjs.org/@nuxt/cli/-/cli-3.35.2.tgz",
+            "integrity": "sha512-sCxNnFuYamqippdj+Cj4Nue55yaUvasaneyf2mnowK5/F1TKln/WVqTH18McxQ4baLlIlVapIFovKjJx1L8XMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@bomb.sh/tab": "^0.0.14",
-                "@clack/prompts": "^1.2.0",
+                "@bomb.sh/tab": "^0.0.15",
+                "@clack/prompts": "^1.3.0",
                 "c12": "^3.3.4",
                 "citty": "^0.2.2",
                 "confbox": "^0.2.4",
@@ -4069,21 +2824,21 @@
                 "fuse.js": "^7.3.0",
                 "fzf": "^0.5.2",
                 "giget": "^3.2.0",
-                "jiti": "^2.6.1",
-                "listhen": "^1.9.1",
+                "jiti": "^2.7.0",
+                "listhen": "^1.10.0",
                 "nypm": "^0.6.6",
                 "ofetch": "^1.5.1",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
                 "perfect-debounce": "^2.1.0",
-                "pkg-types": "^2.3.0",
+                "pkg-types": "^2.3.1",
                 "scule": "^1.3.0",
-                "semver": "^7.7.4",
+                "semver": "^7.8.0",
                 "srvx": "^0.11.15",
                 "std-env": "^4.1.0",
                 "tinyclip": "^0.1.12",
-                "tinyexec": "^1.1.1",
-                "ufo": "^1.6.3",
+                "tinyexec": "^1.1.2",
+                "ufo": "^1.6.4",
                 "youch": "^4.1.1"
             },
             "bin": {
@@ -4096,7 +2851,7 @@
                 "node": "^16.14.0 || >=18.0.0"
             },
             "peerDependencies": {
-                "@nuxt/schema": "^4.4.2"
+                "@nuxt/schema": "^4.4.5"
             },
             "peerDependenciesMeta": {
                 "@nuxt/schema": {
@@ -4105,9 +2860,9 @@
             }
         },
         "node_modules/@nuxt/cli/node_modules/@bomb.sh/tab": {
-            "version": "0.0.14",
-            "resolved": "https://registry.npmjs.org/@bomb.sh/tab/-/tab-0.0.14.tgz",
-            "integrity": "sha512-cHMk2LI430MVoX1unTt9oK1iZzQS4CYDz97MSxKLNErW69T43Z2QLFTpdS/3jVOIKrIADWfuxQ+nQNJkNV7E4w==",
+            "version": "0.0.15",
+            "resolved": "https://registry.npmjs.org/@bomb.sh/tab/-/tab-0.0.15.tgz",
+            "integrity": "sha512-Y90ub44TAvbdO9P8mcD/XPyQjFhiR5xmd4Fk7JErmWmEWEUimNnjWiBrVZ16Tj3GA1rLZ+uvCN2V/pzLawv31g==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -4128,6 +2883,43 @@
                 "commander": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@nuxt/cli/node_modules/cac": {
+            "version": "6.7.14",
+            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+            "extraneous": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@nuxt/cli/node_modules/citty": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+            "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@nuxt/cli/node_modules/commander": {
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+            "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+            "extraneous": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/cli/node_modules/jiti": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+            "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jiti": "lib/jiti-cli.mjs"
             }
         },
         "node_modules/@nuxt/devalue": {
@@ -4224,6 +3016,19 @@
                 "devtools-wizard": "cli.mjs"
             }
         },
+        "node_modules/@nuxt/devtools/node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/@nuxt/devtools/node_modules/isexe": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
@@ -4232,6 +3037,105 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=20"
+            }
+        },
+        "node_modules/@nuxt/devtools/node_modules/open": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "wsl-utils": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@nuxt/devtools/node_modules/vite-plugin-inspect": {
+            "version": "11.3.3",
+            "resolved": "https://registry.npmjs.org/vite-plugin-inspect/-/vite-plugin-inspect-11.3.3.tgz",
+            "integrity": "sha512-u2eV5La99oHoYPHE6UvbwgEqKKOQGz86wMg40CCosP6q8BkB6e5xPneZfYagK4ojPJSj5anHCrnvC20DpwVdRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansis": "^4.1.0",
+                "debug": "^4.4.1",
+                "error-stack-parser-es": "^1.0.5",
+                "ohash": "^2.0.11",
+                "open": "^10.2.0",
+                "perfect-debounce": "^2.0.0",
+                "sirv": "^3.0.1",
+                "unplugin-utils": "^0.3.0",
+                "vite-dev-rpc": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "vite": "^6.0.0 || ^7.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "@nuxt/kit": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@nuxt/devtools/node_modules/vite-plugin-inspect/node_modules/birpc": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+            "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/@nuxt/devtools/node_modules/vite-plugin-inspect/node_modules/vite-dev-rpc": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vite-dev-rpc/-/vite-dev-rpc-1.1.0.tgz",
+            "integrity": "sha512-pKXZlgoXGoE8sEKiKJSng4hI1sQ4wi5YT24FCrwrLt6opmkjlqPPVmiPWWJn8M8byMxRGzp1CrFuqQs4M/Z39A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "birpc": "^2.4.0",
+                "vite-hot-client": "^2.1.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.1 || ^7.0.0-0"
+            }
+        },
+        "node_modules/@nuxt/devtools/node_modules/vite-plugin-vue-tracer": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-vue-tracer/-/vite-plugin-vue-tracer-1.3.0.tgz",
+            "integrity": "sha512-Cgfce6VikzOw5MUJTpeg50s5rRjzU1Vr61ZjuHunVVHLjZZ5AUlgyExHthZ3r59vtoz9W2rDt23FYG81avYBKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "estree-walker": "^3.0.3",
+                "exsolve": "^1.0.8",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3",
+                "source-map-js": "^1.2.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "vite": "^6.0.0 || ^7.0.0",
+                "vue": "^3.5.0"
             }
         },
         "node_modules/@nuxt/devtools/node_modules/which": {
@@ -4288,48 +3192,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
-            }
-        },
-        "node_modules/@nuxt/module-builder": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@nuxt/module-builder/-/module-builder-1.0.2.tgz",
-            "integrity": "sha512-9M+0oZimbwom1J+HrfDuR5NDPED6C+DlM+2xfXju9wqB6VpVfYkS6WNEmS0URw8kpJcKBuogAc7ADO7vRS4s4A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "citty": "^0.1.6",
-                "consola": "^3.4.2",
-                "defu": "^6.1.4",
-                "jiti": "^2.5.1",
-                "magic-regexp": "^0.10.0",
-                "mkdist": "^2.3.0",
-                "mlly": "^1.7.4",
-                "pathe": "^2.0.3",
-                "pkg-types": "^2.2.0",
-                "tsconfck": "^3.1.6",
-                "unbuild": "^3.6.0",
-                "vue-sfc-transformer": "^0.1.16"
-            },
-            "bin": {
-                "nuxt-build-module": "dist/cli.mjs",
-                "nuxt-module-build": "dist/cli.mjs"
-            },
-            "engines": {
-                "node": "^18.0.0 || >=20.0.0"
-            },
-            "peerDependencies": {
-                "@nuxt/cli": "^3.26.4",
-                "typescript": "^5.8.3"
-            }
-        },
-        "node_modules/@nuxt/module-builder/node_modules/citty": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-            "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "consola": "^3.2.3"
             }
         },
         "node_modules/@nuxt/nitro-server": {
@@ -4438,6 +3300,13 @@
                 "@nuxt/kit": ">=3.0.0"
             }
         },
+        "node_modules/@nuxt/telemetry/node_modules/citty": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+            "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@nuxt/telemetry/node_modules/ofetch": {
             "version": "2.0.0-alpha.3",
             "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-2.0.0-alpha.3.tgz",
@@ -4507,6 +3376,490 @@
                 }
             }
         },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/android-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/android-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/android-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/linux-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/@esbuild/win32-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/esbuild": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
+            }
+        },
         "node_modules/@nuxt/vite-builder/node_modules/escape-string-regexp": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -4518,6 +3871,81 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@nuxt/vite-builder/node_modules/vite": {
+            "version": "7.3.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+            "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.27.0",
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "lightningcss": "^1.21.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@nx/nx-darwin-arm64": {
@@ -4584,6 +4012,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4598,6 +4029,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4612,6 +4046,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4626,6 +4063,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4794,6 +4234,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4811,6 +4254,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4828,6 +4274,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4845,6 +4294,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4862,6 +4314,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4879,6 +4334,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4896,6 +4354,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4913,6 +4374,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4958,6 +4422,40 @@
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
+        "node_modules/@oxc-minify/binding-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@oxc-minify/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@oxc-minify/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -4978,9 +4476,9 @@
             }
         },
         "node_modules/@oxc-minify/binding-wasm32-wasi/node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -5166,6 +4664,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5183,6 +4684,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5200,6 +4704,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5217,6 +4724,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5234,6 +4744,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5251,6 +4764,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5268,6 +4784,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5285,6 +4804,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5330,6 +4852,40 @@
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
+        "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -5350,9 +4906,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -5409,6 +4965,16 @@
             ],
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.129.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+            "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
             }
         },
         "node_modules/@oxc-transform/binding-android-arm-eabi": {
@@ -5538,6 +5104,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5555,6 +5124,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5572,6 +5144,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5589,6 +5164,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5606,6 +5184,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5623,6 +5204,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5640,6 +5224,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5657,6 +5244,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5702,6 +5292,40 @@
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
+        "node_modules/@oxc-transform/binding-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@oxc-transform/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@oxc-transform/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
@@ -5722,9 +5346,9 @@
             }
         },
         "node_modules/@oxc-transform/binding-wasm32-wasi/node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -5911,6 +5535,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5932,6 +5559,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5953,6 +5583,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5974,6 +5607,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5995,6 +5631,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6016,6 +5655,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6230,6 +5872,345 @@
                 "url": "https://github.com/sponsors/sxzz"
             }
         },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
+            "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
+            "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
+            "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
+            "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
+            "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
+            "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
+            "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
+            "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
+            "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
+            "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
+            "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
+            "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
+            "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@tybys/wasm-util": {
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
+            "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
+            "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
         "node_modules/@rolldown/pluginutils": {
             "version": "1.0.0-rc.13",
             "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
@@ -6238,16 +6219,16 @@
             "license": "MIT"
         },
         "node_modules/@rollup/plugin-alias": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-6.0.0.tgz",
-            "integrity": "sha512-tPCzJOtS7uuVZd+xPhoy5W4vThe6KWXNmsFCNktaAh5RTqcLiSfT4huPQIXkgJ6YCOjJHvecOAzQxLFhPxKr+g==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.1.tgz",
+            "integrity": "sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=20.19.0"
+                "node": ">=14.0.0"
             },
             "peerDependencies": {
-                "rollup": ">=4.0.0"
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
             },
             "peerDependenciesMeta": {
                 "rollup": {
@@ -6256,9 +6237,9 @@
             }
         },
         "node_modules/@rollup/plugin-commonjs": {
-            "version": "29.0.2",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.2.tgz",
-            "integrity": "sha512-S/ggWH1LU7jTyi9DxZOKyxpVd4hF/OZ0JrEbeLjXk/DFXwRny0tjD2c992zOUYQobLrVkRVMDdmHP16HKP7GRg==",
+            "version": "28.0.9",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.9.tgz",
+            "integrity": "sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6441,9 +6422,9 @@
             "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-            "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+            "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
             "cpu": [
                 "arm"
             ],
@@ -6455,9 +6436,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-            "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+            "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
             "cpu": [
                 "arm64"
             ],
@@ -6469,9 +6450,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-            "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+            "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
             "cpu": [
                 "arm64"
             ],
@@ -6483,9 +6464,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-            "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+            "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
             "cpu": [
                 "x64"
             ],
@@ -6497,9 +6478,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-            "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+            "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
             "cpu": [
                 "arm64"
             ],
@@ -6511,9 +6492,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-            "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+            "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
             "cpu": [
                 "x64"
             ],
@@ -6525,13 +6506,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-            "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+            "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6539,13 +6523,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-            "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+            "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6553,13 +6540,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-            "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+            "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6567,13 +6557,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-            "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+            "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6581,13 +6574,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-            "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+            "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
             "cpu": [
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6595,13 +6591,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-            "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+            "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
             "cpu": [
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6609,13 +6608,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-            "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+            "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6623,13 +6625,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-            "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+            "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6637,13 +6642,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-            "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+            "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6651,13 +6659,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-            "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+            "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6665,13 +6676,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-            "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+            "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6679,13 +6693,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-            "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+            "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6693,13 +6710,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-            "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+            "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6707,9 +6727,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-            "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+            "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
             "cpu": [
                 "x64"
             ],
@@ -6721,9 +6741,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-            "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+            "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
             "cpu": [
                 "arm64"
             ],
@@ -6735,9 +6755,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-            "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+            "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
             "cpu": [
                 "arm64"
             ],
@@ -6749,9 +6769,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-            "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+            "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
             "cpu": [
                 "ia32"
             ],
@@ -6763,9 +6783,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-            "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+            "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
             "cpu": [
                 "x64"
             ],
@@ -6777,9 +6797,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-            "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+            "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
             "cpu": [
                 "x64"
             ],
@@ -7176,6 +7196,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7193,6 +7216,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7210,6 +7236,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7227,6 +7256,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7265,72 +7297,6 @@
             "engines": {
                 "node": ">=14.0.0"
             }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-            "version": "1.10.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.1",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-            "version": "1.10.0",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-            "version": "2.8.1",
-            "dev": true,
-            "inBundle": true,
-            "license": "0BSD",
-            "optional": true
         },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
             "version": "4.3.0",
@@ -7450,344 +7416,6 @@
                 }
             }
         },
-        "node_modules/@tsdown/css/node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@oxc-project/types": {
-            "version": "0.129.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
-            "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/Boshen"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
-            "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
-            "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
-            "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
-            "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
-            "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
-            "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
-            "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
-            "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
-            "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
-            "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
-            "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
-            "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
-            "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
-            "cpu": [
-                "wasm32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/core": "1.10.0",
-                "@emnapi/runtime": "1.10.0",
-                "@napi-rs/wasm-runtime": "^1.1.4"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
-            "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
-            "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
-            "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@tsdown/css/node_modules/@tybys/wasm-util": {
-            "version": "0.10.2",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@tsdown/css/node_modules/rolldown": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
-            "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@oxc-project/types": "=0.129.0",
-                "@rolldown/pluginutils": "1.0.0"
-            },
-            "bin": {
-                "rolldown": "bin/cli.mjs"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0",
-                "@rolldown/binding-darwin-arm64": "1.0.0",
-                "@rolldown/binding-darwin-x64": "1.0.0",
-                "@rolldown/binding-freebsd-x64": "1.0.0",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0",
-                "@rolldown/binding-linux-x64-musl": "1.0.0",
-                "@rolldown/binding-openharmony-arm64": "1.0.0",
-                "@rolldown/binding-wasm32-wasi": "1.0.0",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0"
-            }
-        },
         "node_modules/@tybys/wasm-util": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
@@ -7824,9 +7452,9 @@
             "license": "MIT"
         },
         "node_modules/@types/estree": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
             "license": "MIT"
         },
         "node_modules/@types/hast": {
@@ -7896,14 +7524,14 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.6.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-            "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+            "version": "25.7.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+            "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "undici-types": "~7.19.0"
+                "undici-types": "~7.21.0"
             }
         },
         "node_modules/@types/resolve": {
@@ -8170,9 +7798,9 @@
             }
         },
         "node_modules/@ungap/structured-clone": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-            "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+            "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -8466,46 +8094,6 @@
                 }
             }
         },
-        "node_modules/@vue-macros/common/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@vue-macros/common/node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@vue-macros/common/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@vue-macros/common/node_modules/ast-kit": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
@@ -8556,30 +8144,6 @@
                 }
             }
         },
-        "node_modules/@vue/babel-plugin-jsx/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@vue/babel-plugin-jsx/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@vue/babel-plugin-resolve-type": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@vue/babel-plugin-resolve-type/-/babel-plugin-resolve-type-2.0.1.tgz",
@@ -8600,94 +8164,29 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-        "node_modules/@vue/babel-plugin-resolve-type/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@vue/babel-plugin-resolve-type/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@vue/babel-plugin-resolve-type/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@vue/compiler-core": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
-            "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
+            "version": "3.5.34",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
+            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.2",
-                "@vue/shared": "3.5.33",
+                "@babel/parser": "^7.29.3",
+                "@vue/shared": "3.5.34",
                 "entities": "^7.0.1",
                 "estree-walker": "^2.0.2",
                 "source-map-js": "^1.2.1"
             }
         },
-        "node_modules/@vue/compiler-core/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "license": "MIT",
+        "node_modules/@vue/compiler-core/node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "license": "BSD-2-Clause",
             "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@vue/compiler-core/node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
+                "node": ">=0.12"
             },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@vue/compiler-core/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/@vue/compiler-core/node_modules/estree-walker": {
@@ -8697,67 +8196,30 @@
             "license": "MIT"
         },
         "node_modules/@vue/compiler-dom": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
-            "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
+            "version": "3.5.34",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
+            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-core": "3.5.33",
-                "@vue/shared": "3.5.33"
+                "@vue/compiler-core": "3.5.34",
+                "@vue/shared": "3.5.34"
             }
         },
         "node_modules/@vue/compiler-sfc": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
-            "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
+            "version": "3.5.34",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
+            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.2",
-                "@vue/compiler-core": "3.5.33",
-                "@vue/compiler-dom": "3.5.33",
-                "@vue/compiler-ssr": "3.5.33",
-                "@vue/shared": "3.5.33",
+                "@babel/parser": "^7.29.3",
+                "@vue/compiler-core": "3.5.34",
+                "@vue/compiler-dom": "3.5.34",
+                "@vue/compiler-ssr": "3.5.34",
+                "@vue/shared": "3.5.34",
                 "estree-walker": "^2.0.2",
                 "magic-string": "^0.30.21",
-                "postcss": "^8.5.10",
+                "postcss": "^8.5.14",
                 "source-map-js": "^1.2.1"
-            }
-        },
-        "node_modules/@vue/compiler-sfc/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@vue/compiler-sfc/node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/@vue/compiler-sfc/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
@@ -8767,13 +8229,13 @@
             "license": "MIT"
         },
         "node_modules/@vue/compiler-ssr": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
-            "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
+            "version": "3.5.34",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
+            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.33",
-                "@vue/shared": "3.5.33"
+                "@vue/compiler-dom": "3.5.34",
+                "@vue/shared": "3.5.34"
             }
         },
         "node_modules/@vue/devtools-api": {
@@ -8837,27 +8299,27 @@
             "license": "MIT"
         },
         "node_modules/@vue/devtools-core": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.1.1.tgz",
-            "integrity": "sha512-bCCsSABp1/ot4j8xJEycM6Mtt2wbuucfByr6hMgjbYhrtlscOJypZKvy8f1FyWLYrLTchB5Qz216Lm92wfbq0A==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.1.2.tgz",
+            "integrity": "sha512-ZGGyaSBP4/+bN2Nd9ZHNYAVDRIzMw1rv2RyXWtyZlo6mQal+IDmTvKY4V+DjAEBhaXt30mHmsgYp1yXJ/2tIWg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-kit": "^8.1.1",
-                "@vue/devtools-shared": "^8.1.1"
+                "@vue/devtools-kit": "^8.1.2",
+                "@vue/devtools-shared": "^8.1.2"
             },
             "peerDependencies": {
                 "vue": "^3.0.0"
             }
         },
         "node_modules/@vue/devtools-kit": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.1.tgz",
-            "integrity": "sha512-gVBaBv++i+adg4JpH71k9ppl4soyR7Y2McEqO5YNgv0BI1kMZ7BDX5gnwkZ5COYgiCyhejZG+yGNrBAjj6Coqg==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.2.tgz",
+            "integrity": "sha512-f75/upc+GCyjXErpgPGz4582ujS0L/adAltGy+tqXMGUJpgAcfGr6CxnnhpZY8BHuMYt6KpbF8uaFrrQG66rGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-shared": "^8.1.1",
+                "@vue/devtools-shared": "^8.1.2",
                 "birpc": "^2.6.1",
                 "hookable": "^5.5.3",
                 "perfect-debounce": "^2.0.0"
@@ -8881,9 +8343,9 @@
             "license": "MIT"
         },
         "node_modules/@vue/devtools-shared": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.1.tgz",
-            "integrity": "sha512-+h4ttmJYl/txpxHKaoZcaKpC+pvckgLzIDiSQlaQ7kKthKh8KuwoLW2D8hPJEnqKzXOvu15UHEoGyngAXCz0EQ==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.2.tgz",
+            "integrity": "sha512-X9RyVFYAdkBe4IUf5v48TxBF/6QPmF8CmWrDAjXzfUHrgQ/HGfTC1A6TqgXqZ03ye66l3AD51BAGD69IvKM9sw==",
             "dev": true,
             "license": "MIT"
         },
@@ -8904,53 +8366,53 @@
             }
         },
         "node_modules/@vue/reactivity": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
-            "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
+            "version": "3.5.34",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
+            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
             "license": "MIT",
             "dependencies": {
-                "@vue/shared": "3.5.33"
+                "@vue/shared": "3.5.34"
             }
         },
         "node_modules/@vue/runtime-core": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
-            "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
+            "version": "3.5.34",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
+            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.33",
-                "@vue/shared": "3.5.33"
+                "@vue/reactivity": "3.5.34",
+                "@vue/shared": "3.5.34"
             }
         },
         "node_modules/@vue/runtime-dom": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
-            "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
+            "version": "3.5.34",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
+            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
             "license": "MIT",
             "dependencies": {
-                "@vue/reactivity": "3.5.33",
-                "@vue/runtime-core": "3.5.33",
-                "@vue/shared": "3.5.33",
+                "@vue/reactivity": "3.5.34",
+                "@vue/runtime-core": "3.5.34",
+                "@vue/shared": "3.5.34",
                 "csstype": "^3.2.3"
             }
         },
         "node_modules/@vue/server-renderer": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
-            "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
+            "version": "3.5.34",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
+            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-ssr": "3.5.33",
-                "@vue/shared": "3.5.33"
+                "@vue/compiler-ssr": "3.5.34",
+                "@vue/shared": "3.5.34"
             },
             "peerDependencies": {
-                "vue": "3.5.33"
+                "vue": "3.5.34"
             }
         },
         "node_modules/@vue/shared": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
-            "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
+            "version": "3.5.34",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
+            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
             "license": "MIT"
         },
         "node_modules/@vue/test-utils": {
@@ -9247,13 +8709,13 @@
             }
         },
         "node_modules/abbrev": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
-            "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+            "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
             "dev": true,
             "license": "ISC",
             "engines": {
-                "node": "^18.17.0 || >=20.5.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/abort-controller": {
@@ -9312,9 +8774,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -9330,35 +8792,35 @@
             }
         },
         "node_modules/algoliasearch": {
-            "version": "5.51.0",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.51.0.tgz",
-            "integrity": "sha512-u3XS8HaTzt5YN90KPsOXMRjYJUMVD1dtr6yi4NXQluMbZ5IjQNBu1MEabdAxFhYtEuexqomPMSmRIhQJUd3QSg==",
+            "version": "5.52.1",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz",
+            "integrity": "sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/abtesting": "1.17.0",
-                "@algolia/client-abtesting": "5.51.0",
-                "@algolia/client-analytics": "5.51.0",
-                "@algolia/client-common": "5.51.0",
-                "@algolia/client-insights": "5.51.0",
-                "@algolia/client-personalization": "5.51.0",
-                "@algolia/client-query-suggestions": "5.51.0",
-                "@algolia/client-search": "5.51.0",
-                "@algolia/ingestion": "1.51.0",
-                "@algolia/monitoring": "1.51.0",
-                "@algolia/recommend": "5.51.0",
-                "@algolia/requester-browser-xhr": "5.51.0",
-                "@algolia/requester-fetch": "5.51.0",
-                "@algolia/requester-node-http": "5.51.0"
+                "@algolia/abtesting": "1.18.1",
+                "@algolia/client-abtesting": "5.52.1",
+                "@algolia/client-analytics": "5.52.1",
+                "@algolia/client-common": "5.52.1",
+                "@algolia/client-insights": "5.52.1",
+                "@algolia/client-personalization": "5.52.1",
+                "@algolia/client-query-suggestions": "5.52.1",
+                "@algolia/client-search": "5.52.1",
+                "@algolia/ingestion": "1.52.1",
+                "@algolia/monitoring": "1.52.1",
+                "@algolia/recommend": "5.52.1",
+                "@algolia/requester-browser-xhr": "5.52.1",
+                "@algolia/requester-fetch": "5.52.1",
+                "@algolia/requester-node-http": "5.52.1"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/alien-signals": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.1.2.tgz",
-            "integrity": "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.0.tgz",
+            "integrity": "sha512-5J9+NpCLHgic4xnZtI8SznvNagwJsZSvRFsAwoLlLw+Edaqa4upCiOC19P8Vx2DqmEvqK2qJBMtI8+9eXOEb/A==",
             "dev": true,
             "license": "MIT"
         },
@@ -9399,9 +8861,9 @@
             }
         },
         "node_modules/ansis": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
-            "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.0.tgz",
+            "integrity": "sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==",
             "dev": true,
             "license": "ISC",
             "engines": {
@@ -9716,6 +9178,56 @@
                 "url": "https://github.com/sponsors/sxzz"
             }
         },
+        "node_modules/ast-kit/node_modules/@babel/helper-string-parser": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.5.tgz",
+            "integrity": "sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/ast-kit/node_modules/@babel/helper-validator-identifier": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.5.tgz",
+            "integrity": "sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/ast-kit/node_modules/@babel/parser": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.5.tgz",
+            "integrity": "sha512-/Mfg83rK3+jsRbl4Vbd0jqxc6M1A1/WNFtgrowRM1unEsD3XcNnrBdMM0JWakd0/RN9lseQKwPduW1TiEwKOlQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^8.0.0-rc.5"
+            },
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/ast-kit/node_modules/@babel/types": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.5.tgz",
+            "integrity": "sha512-JeSVu/m8x/zpp4CLjYHVNXuhEyOkhPXuxM8YOXjh6L4LlvQNKuUNOTo5KdBuKAcTDHw8DquToTaEkhsBqPXOaA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^8.0.0-rc.5",
+                "@babel/helper-validator-identifier": "^8.0.0-rc.5"
+            },
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
         "node_modules/ast-v8-to-istanbul": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
@@ -9727,13 +9239,6 @@
                 "estree-walker": "^3.0.3",
                 "js-tokens": "^10.0.0"
             }
-        },
-        "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-            "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/ast-walker-scope": {
             "version": "0.8.3",
@@ -9750,46 +9255,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sxzz"
-            }
-        },
-        "node_modules/ast-walker-scope/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/ast-walker-scope/node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/ast-walker-scope/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/ast-walker-scope/node_modules/ast-kit": {
@@ -10023,9 +9488,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.19",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
-            "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+            "version": "2.10.29",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+            "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -10105,9 +9570,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10207,9 +9672,9 @@
             "license": "MIT"
         },
         "node_modules/builtin-modules": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.1.0.tgz",
-            "integrity": "sha512-c5JxaDrzwRjq3WyJkI1AGR5xy6Gr6udlt7sQPbl09+3ckB+Zo2qqQ2KhCTBr7Q8dHB43bENGYEk4xddrFH/b7A==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.2.0.tgz",
+            "integrity": "sha512-02yxLeyxF4dNl6SlY6/5HfRSrSdZ/sCPoxy2kZNP5dZZX8LSAD9aE2gtJIUgWrsQTiMPl3mxESyrobSwvRGisQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10331,9 +9796,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001788",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-            "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+            "version": "1.0.30001792",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+            "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
             "dev": true,
             "funding": [
                 {
@@ -10469,11 +9934,13 @@
             }
         },
         "node_modules/citty": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
-            "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
-            "dev": true,
-            "license": "MIT"
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+            "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+            "license": "MIT",
+            "dependencies": {
+                "consola": "^3.2.3"
+            }
         },
         "node_modules/clean-regexp": {
             "version": "1.0.0",
@@ -11223,44 +10690,6 @@
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
-        "node_modules/data-urls/node_modules/tr46": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "punycode": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/data-urls/node_modules/webidl-conversions": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/data-urls/node_modules/whatwg-url": {
-            "version": "16.0.1",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@exodus/bytes": "^1.11.0",
-                "tr46": "^6.0.0",
-                "webidl-conversions": "^8.0.1"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-            }
-        },
         "node_modules/date-fns": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -11510,19 +10939,6 @@
                 "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
             }
         },
-        "node_modules/dom-serializer/node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
         "node_modules/domelementtype": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -11742,9 +11158,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.339",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
-            "integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==",
+            "version": "1.5.354",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.354.tgz",
+            "integrity": "sha512-JaBHwWcfIdmSAfWM5l3uwjGd431j8YEMikZ+K/2nXVuBqJKyZ0f+2h4n4JY5AyNiZmnY9qQr2RU3v9DxDmHMNg==",
             "dev": true,
             "license": "ISC"
         },
@@ -11763,9 +11179,9 @@
             "license": "MIT"
         },
         "node_modules/empathic": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
-            "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+            "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -11820,9 +11236,10 @@
             }
         },
         "node_modules/entities": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -11890,9 +11307,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -11925,10 +11342,22 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-toolkit": {
+            "version": "1.46.1",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+            "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "workspaces": [
+                "docs",
+                "benchmarks"
+            ]
+        },
         "node_modules/esbuild": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+            "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -11939,32 +11368,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.7",
-                "@esbuild/android-arm": "0.27.7",
-                "@esbuild/android-arm64": "0.27.7",
-                "@esbuild/android-x64": "0.27.7",
-                "@esbuild/darwin-arm64": "0.27.7",
-                "@esbuild/darwin-x64": "0.27.7",
-                "@esbuild/freebsd-arm64": "0.27.7",
-                "@esbuild/freebsd-x64": "0.27.7",
-                "@esbuild/linux-arm": "0.27.7",
-                "@esbuild/linux-arm64": "0.27.7",
-                "@esbuild/linux-ia32": "0.27.7",
-                "@esbuild/linux-loong64": "0.27.7",
-                "@esbuild/linux-mips64el": "0.27.7",
-                "@esbuild/linux-ppc64": "0.27.7",
-                "@esbuild/linux-riscv64": "0.27.7",
-                "@esbuild/linux-s390x": "0.27.7",
-                "@esbuild/linux-x64": "0.27.7",
-                "@esbuild/netbsd-arm64": "0.27.7",
-                "@esbuild/netbsd-x64": "0.27.7",
-                "@esbuild/openbsd-arm64": "0.27.7",
-                "@esbuild/openbsd-x64": "0.27.7",
-                "@esbuild/openharmony-arm64": "0.27.7",
-                "@esbuild/sunos-x64": "0.27.7",
-                "@esbuild/win32-arm64": "0.27.7",
-                "@esbuild/win32-ia32": "0.27.7",
-                "@esbuild/win32-x64": "0.27.7"
+                "@esbuild/aix-ppc64": "0.28.0",
+                "@esbuild/android-arm": "0.28.0",
+                "@esbuild/android-arm64": "0.28.0",
+                "@esbuild/android-x64": "0.28.0",
+                "@esbuild/darwin-arm64": "0.28.0",
+                "@esbuild/darwin-x64": "0.28.0",
+                "@esbuild/freebsd-arm64": "0.28.0",
+                "@esbuild/freebsd-x64": "0.28.0",
+                "@esbuild/linux-arm": "0.28.0",
+                "@esbuild/linux-arm64": "0.28.0",
+                "@esbuild/linux-ia32": "0.28.0",
+                "@esbuild/linux-loong64": "0.28.0",
+                "@esbuild/linux-mips64el": "0.28.0",
+                "@esbuild/linux-ppc64": "0.28.0",
+                "@esbuild/linux-riscv64": "0.28.0",
+                "@esbuild/linux-s390x": "0.28.0",
+                "@esbuild/linux-x64": "0.28.0",
+                "@esbuild/netbsd-arm64": "0.28.0",
+                "@esbuild/netbsd-x64": "0.28.0",
+                "@esbuild/openbsd-arm64": "0.28.0",
+                "@esbuild/openbsd-x64": "0.28.0",
+                "@esbuild/openharmony-arm64": "0.28.0",
+                "@esbuild/sunos-x64": "0.28.0",
+                "@esbuild/win32-arm64": "0.28.0",
+                "@esbuild/win32-ia32": "0.28.0",
+                "@esbuild/win32-x64": "0.28.0"
             }
         },
         "node_modules/escalade": {
@@ -12165,9 +11594,9 @@
             }
         },
         "node_modules/eslint/node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12502,9 +11931,9 @@
             "license": "MIT"
         },
         "node_modules/fast-npm-meta": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/fast-npm-meta/-/fast-npm-meta-1.5.0.tgz",
-            "integrity": "sha512-71pTBPrA9WPPsJQ0Q06ZlTQQVJPYd87xZsvFwxFqru7a6kdriMVW1Hjd37W3W13ZuF/K/Zzq6eVlAHVoZCHuQw==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/fast-npm-meta/-/fast-npm-meta-1.5.1.tgz",
+            "integrity": "sha512-tWhw7z4jFuQgZB9tbQyUh5BY9nNd/wimM+fBLfmmJjakkJDNvbJKm0nQ5ruPKC0us1HGg7L6iBk1fxpSzcgSaA==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -12515,26 +11944,26 @@
             }
         },
         "node_modules/fast-string-truncated-width": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
-            "integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+            "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-string-width": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
-            "integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+            "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fast-string-truncated-width": "^1.2.0"
+                "fast-string-truncated-width": "^3.0.2"
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -12550,13 +11979,13 @@
             "peer": true
         },
         "node_modules/fast-wrap-ansi": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
-            "integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+            "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fast-string-width": "^1.1.0"
+                "fast-string-width": "^3.0.2"
             }
         },
         "node_modules/fastq": {
@@ -12729,9 +12158,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
             "dev": true,
             "funding": [
                 {
@@ -12966,13 +12395,16 @@
             }
         },
         "node_modules/get-tsconfig": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-            "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+            "version": "5.0.0-beta.5",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.5.tgz",
+            "integrity": "sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "resolve-pkg-maps": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=20.20.0"
             },
             "funding": {
                 "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
@@ -13037,25 +12469,26 @@
             }
         },
         "node_modules/global-directory": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
-            "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
+            "integrity": "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "ini": "4.1.1"
+                "ini": "6.0.0"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/globals": {
-            "version": "17.5.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-            "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+            "version": "17.6.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+            "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -13501,13 +12934,14 @@
             "license": "ISC"
         },
         "node_modules/ini": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
-            "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+            "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/ioredis": {
@@ -13576,19 +13010,32 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "version": "2.16.2",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+            "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "hasown": "^2.0.2"
+                "hasown": "^2.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-core-module/node_modules/hasown": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/is-docker": {
@@ -13703,6 +13150,32 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-installed-globally/node_modules/global-directory": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+            "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ini": "4.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-installed-globally/node_modules/ini": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+            "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/is-interactive": {
@@ -13938,16 +13411,6 @@
                 "node": ">=14"
             }
         },
-        "node_modules/js-beautify/node_modules/abbrev": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
-            "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
         "node_modules/js-beautify/node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -14010,22 +13473,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/js-beautify/node_modules/nopt": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
-            "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "abbrev": "^2.0.0"
-            },
-            "bin": {
-                "nopt": "bin/nopt.js"
-            },
-            "engines": {
-                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-            }
-        },
         "node_modules/js-beautify/node_modules/path-scurry": {
             "version": "1.11.1",
             "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -14054,9 +13501,9 @@
             }
         },
         "node_modules/js-tokens": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+            "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -14113,44 +13560,6 @@
                 "canvas": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/jsdom/node_modules/tr46": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "punycode": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/jsdom/node_modules/webidl-conversions": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=20"
-            }
-        },
-        "node_modules/jsdom/node_modules/whatwg-url": {
-            "version": "16.0.1",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@exodus/bytes": "^1.11.0",
-                "tr46": "^6.0.0",
-                "webidl-conversions": "^8.0.1"
-            },
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/jsdom/node_modules/xml-name-validator": {
@@ -14475,6 +13884,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -14496,6 +13908,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -14517,6 +13932,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -14538,6 +13956,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -14617,9 +14038,9 @@
             }
         },
         "node_modules/listhen": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.9.1.tgz",
-            "integrity": "sha512-4EhoyVcXEpNlY5HJRSQpH7Rba94M8N2JmI62ePjl0lrJKXSfG0F1FAgHGxBoz/T3pe41sUEwkIRRIcaUL0/Ofw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.10.0.tgz",
+            "integrity": "sha512-kfz4C0OrC6IpaVMtYDJtf6PFjurxe9NBBoDAh/o2p587INryFOO4DQ9OetbCdDrWFt1m1CJKvYrzkGsuPHw8nQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14628,7 +14049,7 @@
                 "citty": "^0.2.2",
                 "consola": "^3.4.2",
                 "crossws": ">=0.2.0 <0.5.0",
-                "defu": "^6.1.6",
+                "defu": "^6.1.7",
                 "get-port-please": "^3.2.0",
                 "h3": "^1.15.11",
                 "http-shutdown": "^1.2.2",
@@ -14636,16 +14057,23 @@
                 "mlly": "^1.8.2",
                 "node-forge": "^1.4.0",
                 "pathe": "^2.0.3",
-                "std-env": "^4.0.0",
+                "std-env": "^4.1.0",
                 "tinyclip": "^0.1.12",
-                "ufo": "^1.6.3",
+                "ufo": "^1.6.4",
                 "untun": "^0.1.3",
-                "uqr": "^0.1.2"
+                "uqr": "^0.1.3"
             },
             "bin": {
                 "listen": "bin/listhen.mjs",
                 "listhen": "bin/listhen.mjs"
             }
+        },
+        "node_modules/listhen/node_modules/citty": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+            "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/local-pkg": {
             "version": "1.1.2",
@@ -14705,14 +14133,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/lodash.camelcase": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/lodash.defaults": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -14727,14 +14147,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/lodash.kebabcase": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-            "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -14742,44 +14154,12 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/lodash.mergewith": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-            "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/lodash.snakecase": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-            "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
-        "node_modules/lodash.startcase": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-            "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/lodash.uniq": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
             "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/lodash.upperfirst": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
-            "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
         },
         "node_modules/log-symbols": {
             "version": "4.1.0",
@@ -14799,9 +14179,9 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "11.3.5",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+            "version": "11.3.6",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+            "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -14875,46 +14255,6 @@
                 "@babel/parser": "^7.29.0",
                 "@babel/types": "^7.29.0",
                 "source-map-js": "^1.2.1"
-            }
-        },
-        "node_modules/magicast/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "devOptional": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/magicast/node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-            "devOptional": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/magicast/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "devOptional": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/make-dir": {
@@ -15744,16 +15084,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/mkdist/node_modules/citty": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-            "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "consola": "^3.2.3"
-            }
-        },
         "node_modules/mkdist/node_modules/esbuild": {
             "version": "0.25.12",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -15804,32 +15134,6 @@
             "license": "MIT",
             "bin": {
                 "jiti": "bin/jiti.js"
-            }
-        },
-        "node_modules/mkdist/node_modules/postcss-nested": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-7.0.2.tgz",
-            "integrity": "sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "postcss-selector-parser": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=18.0"
-            },
-            "peerDependencies": {
-                "postcss": "^8.2.14"
             }
         },
         "node_modules/mlly": {
@@ -15893,9 +15197,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
             "funding": [
                 {
                     "type": "github",
@@ -16018,447 +15322,57 @@
                 }
             }
         },
-        "node_modules/nitropack/node_modules/@esbuild/aix-ppc64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-            "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-            "cpu": [
-                "ppc64"
-            ],
+        "node_modules/nitropack/node_modules/@rollup/plugin-alias": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-6.0.0.tgz",
+            "integrity": "sha512-tPCzJOtS7uuVZd+xPhoy5W4vThe6KWXNmsFCNktaAh5RTqcLiSfT4huPQIXkgJ6YCOjJHvecOAzQxLFhPxKr+g==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "os": [
-                "aix"
-            ],
             "engines": {
-                "node": ">=18"
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "rollup": ">=4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/nitropack/node_modules/@esbuild/android-arm": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-            "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-            "cpu": [
-                "arm"
-            ],
+        "node_modules/nitropack/node_modules/@rollup/plugin-commonjs": {
+            "version": "29.0.2",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.2.tgz",
+            "integrity": "sha512-S/ggWH1LU7jTyi9DxZOKyxpVd4hF/OZ0JrEbeLjXk/DFXwRny0tjD2c992zOUYQobLrVkRVMDdmHP16HKP7GRg==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "commondir": "^1.0.1",
+                "estree-walker": "^2.0.2",
+                "fdir": "^6.2.0",
+                "is-reference": "1.2.1",
+                "magic-string": "^0.30.3",
+                "picomatch": "^4.0.2"
+            },
             "engines": {
-                "node": ">=18"
+                "node": ">=16.0.0 || 14 >= 14.17"
+            },
+            "peerDependencies": {
+                "rollup": "^2.68.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
             }
         },
-        "node_modules/nitropack/node_modules/@esbuild/android-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-            "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-            "cpu": [
-                "arm64"
-            ],
+        "node_modules/nitropack/node_modules/citty": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+            "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
             "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/android-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-            "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-            "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/darwin-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-            "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-            "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-            "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/linux-arm": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-            "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/linux-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-            "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/linux-ia32": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-            "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/linux-loong64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-            "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-            "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-            "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-            "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/linux-s390x": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-            "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/linux-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-            "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-            "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-            "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-            "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-            "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-            "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/sunos-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-            "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/win32-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-            "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/win32-ia32": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-            "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nitropack/node_modules/@esbuild/win32-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-            "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
+            "license": "MIT"
         },
         "node_modules/nitropack/node_modules/dot-prop": {
             "version": "10.1.0",
@@ -16476,48 +15390,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/nitropack/node_modules/esbuild": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-            "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.28.0",
-                "@esbuild/android-arm": "0.28.0",
-                "@esbuild/android-arm64": "0.28.0",
-                "@esbuild/android-x64": "0.28.0",
-                "@esbuild/darwin-arm64": "0.28.0",
-                "@esbuild/darwin-x64": "0.28.0",
-                "@esbuild/freebsd-arm64": "0.28.0",
-                "@esbuild/freebsd-x64": "0.28.0",
-                "@esbuild/linux-arm": "0.28.0",
-                "@esbuild/linux-arm64": "0.28.0",
-                "@esbuild/linux-ia32": "0.28.0",
-                "@esbuild/linux-loong64": "0.28.0",
-                "@esbuild/linux-mips64el": "0.28.0",
-                "@esbuild/linux-ppc64": "0.28.0",
-                "@esbuild/linux-riscv64": "0.28.0",
-                "@esbuild/linux-s390x": "0.28.0",
-                "@esbuild/linux-x64": "0.28.0",
-                "@esbuild/netbsd-arm64": "0.28.0",
-                "@esbuild/netbsd-x64": "0.28.0",
-                "@esbuild/openbsd-arm64": "0.28.0",
-                "@esbuild/openbsd-x64": "0.28.0",
-                "@esbuild/openharmony-arm64": "0.28.0",
-                "@esbuild/sunos-x64": "0.28.0",
-                "@esbuild/win32-arm64": "0.28.0",
-                "@esbuild/win32-ia32": "0.28.0",
-                "@esbuild/win32-x64": "0.28.0"
-            }
-        },
         "node_modules/nitropack/node_modules/escape-string-regexp": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -16530,6 +15402,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/nitropack/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/nitropack/node_modules/hookable": {
             "version": "5.5.3",
@@ -16573,6 +15452,31 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/node-fetch/node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/node-fetch/node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/node-fetch/node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
         "node_modules/node-forge": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
@@ -16603,26 +15507,26 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.37",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-            "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+            "version": "2.0.44",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+            "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/nopt": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
-            "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+            "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "abbrev": "^3.0.0"
+                "abbrev": "^2.0.0"
             },
             "bin": {
                 "nopt": "bin/nopt.js"
             },
             "engines": {
-                "node": "^18.17.0 || >=20.5.0"
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/normalize-path": {
@@ -16915,37 +15819,6 @@
                 }
             }
         },
-        "node_modules/nx/node_modules/@emnapi/core": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
-            "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.0.4",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/nx/node_modules/@emnapi/runtime": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
-            "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/nx/node_modules/@emnapi/wasi-threads": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
-            "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/nx/node_modules/balanced-match": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
@@ -16979,27 +15852,6 @@
                 "node": ">=0.8.0"
             }
         },
-        "node_modules/nx/node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/nx/node_modules/ignore": {
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -17026,17 +15878,17 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/nx/node_modules/yaml": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-            "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+        "node_modules/nx/node_modules/semver": {
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "dev": true,
             "license": "ISC",
             "bin": {
-                "yaml": "bin.mjs"
+                "semver": "bin/semver.js"
             },
             "engines": {
-                "node": ">= 14.6"
+                "node": ">=10"
             }
         },
         "node_modules/nypm": {
@@ -17056,6 +15908,13 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/nypm/node_modules/citty": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+            "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/obug": {
             "version": "2.1.1",
@@ -17899,6 +16758,32 @@
                 "postcss": "^8.5.13"
             }
         },
+        "node_modules/postcss-nested": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-7.0.2.tgz",
+            "integrity": "sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/postcss/"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "postcss-selector-parser": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.2.14"
+            }
+        },
         "node_modules/postcss-normalize-charset": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.3.tgz",
@@ -18624,10 +17509,51 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/rolldown": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
+            "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.129.0",
+                "@rolldown/pluginutils": "1.0.0"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.0.0",
+                "@rolldown/binding-darwin-arm64": "1.0.0",
+                "@rolldown/binding-darwin-x64": "1.0.0",
+                "@rolldown/binding-freebsd-x64": "1.0.0",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0",
+                "@rolldown/binding-linux-x64-musl": "1.0.0",
+                "@rolldown/binding-openharmony-arm64": "1.0.0",
+                "@rolldown/binding-wasm32-wasi": "1.0.0",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0"
+            }
+        },
+        "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
+            "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/rollup": {
-            "version": "4.60.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-            "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+            "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -18641,31 +17567,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.60.2",
-                "@rollup/rollup-android-arm64": "4.60.2",
-                "@rollup/rollup-darwin-arm64": "4.60.2",
-                "@rollup/rollup-darwin-x64": "4.60.2",
-                "@rollup/rollup-freebsd-arm64": "4.60.2",
-                "@rollup/rollup-freebsd-x64": "4.60.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-                "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-                "@rollup/rollup-linux-arm64-musl": "4.60.2",
-                "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-                "@rollup/rollup-linux-loong64-musl": "4.60.2",
-                "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-                "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-                "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-                "@rollup/rollup-linux-x64-gnu": "4.60.2",
-                "@rollup/rollup-linux-x64-musl": "4.60.2",
-                "@rollup/rollup-openbsd-x64": "4.60.2",
-                "@rollup/rollup-openharmony-arm64": "4.60.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-                "@rollup/rollup-win32-x64-gnu": "4.60.2",
-                "@rollup/rollup-win32-x64-msvc": "4.60.2",
+                "@rollup/rollup-android-arm-eabi": "4.60.3",
+                "@rollup/rollup-android-arm64": "4.60.3",
+                "@rollup/rollup-darwin-arm64": "4.60.3",
+                "@rollup/rollup-darwin-x64": "4.60.3",
+                "@rollup/rollup-freebsd-arm64": "4.60.3",
+                "@rollup/rollup-freebsd-x64": "4.60.3",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+                "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+                "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+                "@rollup/rollup-linux-arm64-musl": "4.60.3",
+                "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+                "@rollup/rollup-linux-loong64-musl": "4.60.3",
+                "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+                "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+                "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+                "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+                "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+                "@rollup/rollup-linux-x64-gnu": "4.60.3",
+                "@rollup/rollup-linux-x64-musl": "4.60.3",
+                "@rollup/rollup-openbsd-x64": "4.60.3",
+                "@rollup/rollup-openharmony-arm64": "4.60.3",
+                "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+                "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+                "@rollup/rollup-win32-x64-gnu": "4.60.3",
+                "@rollup/rollup-win32-x64-msvc": "4.60.3",
                 "fsevents": "~2.3.2"
             }
         },
@@ -18787,6 +17713,22 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/rollup-plugin-visualizer/node_modules/is-wsl": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/rollup-plugin-visualizer/node_modules/open": {
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
@@ -18860,6 +17802,23 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/rollup-plugin-visualizer/node_modules/wsl-utils": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+            "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0",
+                "powershell-utils": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/rollup-plugin-visualizer/node_modules/yargs": {
             "version": "18.0.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
@@ -18887,6 +17846,13 @@
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=23"
             }
+        },
+        "node_modules/rollup/node_modules/@types/estree": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/rou3": {
             "version": "0.8.1",
@@ -18991,9 +17957,9 @@
             "peer": true
         },
         "node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
@@ -19702,9 +18668,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.46.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
-            "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
+            "version": "5.47.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+            "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -19798,22 +18764,22 @@
             }
         },
         "node_modules/tldts": {
-            "version": "7.0.28",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
-            "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+            "version": "7.0.30",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+            "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.0.28"
+                "tldts-core": "^7.0.30"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/tldts-core": {
-            "version": "7.0.28",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-            "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+            "version": "7.0.30",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+            "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -19874,11 +18840,17 @@
             }
         },
         "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
         },
         "node_modules/tree-kill": {
             "version": "1.2.2",
@@ -19912,27 +18884,6 @@
             },
             "peerDependencies": {
                 "typescript": ">=4.8.4"
-            }
-        },
-        "node_modules/tsconfck": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-            "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "tsconfck": "bin/tsconfck.js"
-            },
-            "engines": {
-                "node": "^18 || >=20"
-            },
-            "peerDependencies": {
-                "typescript": "^5.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
             }
         },
         "node_modules/tsconfig-paths": {
@@ -20023,6 +18974,16 @@
                 }
             }
         },
+        "node_modules/tsdown/node_modules/@babel/helper-string-parser": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.5.tgz",
+            "integrity": "sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
         "node_modules/tsdown/node_modules/@babel/helper-validator-identifier": {
             "version": "8.0.0-rc.4",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.4.tgz",
@@ -20033,358 +18994,44 @@
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
-        "node_modules/tsdown/node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
-            }
-        },
-        "node_modules/tsdown/node_modules/@oxc-project/types": {
-            "version": "0.129.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
-            "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/Boshen"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
-            "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
-            "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
-            "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
-            "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
-            "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
-            "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
-            "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
-            "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
-            "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
-            "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
-            "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
-            "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
-            "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
-            "cpu": [
-                "wasm32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/core": "1.10.0",
-                "@emnapi/runtime": "1.10.0",
-                "@napi-rs/wasm-runtime": "^1.1.4"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
-            "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
-            "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
-            "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/tsdown/node_modules/@tybys/wasm-util": {
-            "version": "0.10.2",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/tsdown/node_modules/get-tsconfig": {
-            "version": "5.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.5.tgz",
-            "integrity": "sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==",
+        "node_modules/tsdown/node_modules/@babel/parser": {
+            "version": "8.0.0-rc.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.4.tgz",
+            "integrity": "sha512-0S/1yefMa15N4i2v3t8Fw9pgMHhf2gF6Lc1UEXI96Ls6FNAjqvHHZouZ2ZS/deqLhbMFtmfVeFac6iTsvFbLwA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "resolve-pkg-maps": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=20.20.0"
-            },
-            "funding": {
-                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-            }
-        },
-        "node_modules/tsdown/node_modules/rolldown": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
-            "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@oxc-project/types": "=0.129.0",
-                "@rolldown/pluginutils": "1.0.0"
+                "@babel/types": "^8.0.0-rc.4"
             },
             "bin": {
-                "rolldown": "bin/cli.mjs"
+                "parser": "bin/babel-parser.js"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/tsdown/node_modules/@babel/types": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.5.tgz",
+            "integrity": "sha512-JeSVu/m8x/zpp4CLjYHVNXuhEyOkhPXuxM8YOXjh6L4LlvQNKuUNOTo5KdBuKAcTDHw8DquToTaEkhsBqPXOaA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-string-parser": "^8.0.0-rc.5",
+                "@babel/helper-validator-identifier": "^8.0.0-rc.5"
             },
-            "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0",
-                "@rolldown/binding-darwin-arm64": "1.0.0",
-                "@rolldown/binding-darwin-x64": "1.0.0",
-                "@rolldown/binding-freebsd-x64": "1.0.0",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0",
-                "@rolldown/binding-linux-x64-musl": "1.0.0",
-                "@rolldown/binding-openharmony-arm64": "1.0.0",
-                "@rolldown/binding-wasm32-wasi": "1.0.0",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0"
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
+            }
+        },
+        "node_modules/tsdown/node_modules/@babel/types/node_modules/@babel/helper-validator-identifier": {
+            "version": "8.0.0-rc.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.5.tgz",
+            "integrity": "sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^22.18.0 || >=24.11.0"
             }
         },
         "node_modules/tsdown/node_modules/rolldown-plugin-dts": {
@@ -20455,6 +19102,503 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.3"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/esbuild": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
+            }
+        },
+        "node_modules/tsx/node_modules/get-tsconfig": {
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+            "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "resolve-pkg-maps": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
         },
         "node_modules/type-check": {
@@ -21030,61 +20174,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/unbuild/node_modules/@rollup/plugin-alias": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-5.1.1.tgz",
-            "integrity": "sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
-            },
-            "peerDependenciesMeta": {
-                "rollup": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/unbuild/node_modules/@rollup/plugin-commonjs": {
-            "version": "28.0.9",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.9.tgz",
-            "integrity": "sha512-PIR4/OHZ79romx0BVVll/PkwWpJ7e5lsqFa3gFfcrFPWwLXLV39JVUzQV9RKjWerE7B845Hqjj9VYlQeieZ2dA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@rollup/pluginutils": "^5.0.1",
-                "commondir": "^1.0.1",
-                "estree-walker": "^2.0.2",
-                "fdir": "^6.2.0",
-                "is-reference": "1.2.1",
-                "magic-string": "^0.30.3",
-                "picomatch": "^4.0.2"
-            },
-            "engines": {
-                "node": ">=16.0.0 || 14 >= 14.17"
-            },
-            "peerDependencies": {
-                "rollup": "^2.68.0||^3.0.0||^4.0.0"
-            },
-            "peerDependenciesMeta": {
-                "rollup": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/unbuild/node_modules/citty": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-            "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "consola": "^3.2.3"
-            }
-        },
         "node_modules/unbuild/node_modules/esbuild": {
             "version": "0.25.12",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -21126,13 +20215,6 @@
                 "@esbuild/win32-ia32": "0.25.12",
                 "@esbuild/win32-x64": "0.25.12"
             }
-        },
-        "node_modules/unbuild/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/unbuild/node_modules/hookable": {
             "version": "5.5.3",
@@ -21200,9 +20282,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.19.2",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-            "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+            "version": "7.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+            "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
             "dev": true,
             "license": "MIT",
             "peer": true
@@ -21531,16 +20613,6 @@
                 "untun": "bin/untun.mjs"
             }
         },
-        "node_modules/untun/node_modules/citty": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-            "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "consola": "^3.2.3"
-            }
-        },
         "node_modules/untun/node_modules/pathe": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -21562,15 +20634,6 @@
             },
             "bin": {
                 "untyped": "dist/cli.mjs"
-            }
-        },
-        "node_modules/untyped/node_modules/citty": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-            "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-            "license": "MIT",
-            "dependencies": {
-                "consola": "^3.2.3"
             }
         },
         "node_modules/unwasm": {
@@ -21674,9 +20737,617 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.3.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-            "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+            "version": "8.0.12",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+            "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.14",
+                "rolldown": "1.0.0",
+                "tinyglobby": "^0.2.16"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.18",
+                "esbuild": "^0.27.0 || ^0.28.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "jiti": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-hot-client": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/vite-hot-client/-/vite-hot-client-2.2.0.tgz",
+            "integrity": "sha512-76Zs9zrHbH7M7wqeyooGQKdX+yg0pQ0xuQ1PbFp4z5a0Lzn2e5IPFoCswnmqZ4GiwqB4Jo3WcDAMO9jARTJl8w==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "vite": "^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0 || ^8.0.0"
+            }
+        },
+        "node_modules/vite-node": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-5.3.0.tgz",
+            "integrity": "sha512-8f20COPYJujc3OKPX6OuyBy3ZIv2det4eRRU4GY1y2MjbeGSUmPjedxg1b72KnTagCofwvZ65ThzjxDW2AtQFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "es-module-lexer": "^2.0.0",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "vite": "^7.3.1"
+            },
+            "bin": {
+                "vite-node": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/antfu"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vite-node/node_modules/cac": {
+            "version": "6.7.14",
+            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/vite-node/node_modules/esbuild": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
+            }
+        },
+        "node_modules/vite-node/node_modules/vite": {
+            "version": "7.3.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+            "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -21746,79 +21417,6 @@
                 "yaml": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/vite-dev-rpc": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/vite-dev-rpc/-/vite-dev-rpc-1.1.0.tgz",
-            "integrity": "sha512-pKXZlgoXGoE8sEKiKJSng4hI1sQ4wi5YT24FCrwrLt6opmkjlqPPVmiPWWJn8M8byMxRGzp1CrFuqQs4M/Z39A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "birpc": "^2.4.0",
-                "vite-hot-client": "^2.1.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.1 || ^7.0.0-0"
-            }
-        },
-        "node_modules/vite-dev-rpc/node_modules/birpc": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
-            "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            }
-        },
-        "node_modules/vite-hot-client": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/vite-hot-client/-/vite-hot-client-2.1.0.tgz",
-            "integrity": "sha512-7SpgZmU7R+dDnSmvXE1mfDtnHLHQSisdySVR7lO8ceAXvM0otZeuQQ6C8LrS5d/aYyP/QZ0hI0L+dIPrm4YlFQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "vite": "^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0"
-            }
-        },
-        "node_modules/vite-node": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-5.3.0.tgz",
-            "integrity": "sha512-8f20COPYJujc3OKPX6OuyBy3ZIv2det4eRRU4GY1y2MjbeGSUmPjedxg1b72KnTagCofwvZ65ThzjxDW2AtQFQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cac": "^6.7.14",
-                "es-module-lexer": "^2.0.0",
-                "obug": "^2.1.1",
-                "pathe": "^2.0.3",
-                "vite": "^7.3.1"
-            },
-            "bin": {
-                "vite-node": "dist/cli.mjs"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/antfu"
-            }
-        },
-        "node_modules/vite-node/node_modules/cac": {
-            "version": "6.7.14",
-            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/vite-plugin-checker": {
@@ -21958,123 +21556,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/vite-plugin-inspect": {
-            "version": "11.3.3",
-            "resolved": "https://registry.npmjs.org/vite-plugin-inspect/-/vite-plugin-inspect-11.3.3.tgz",
-            "integrity": "sha512-u2eV5La99oHoYPHE6UvbwgEqKKOQGz86wMg40CCosP6q8BkB6e5xPneZfYagK4ojPJSj5anHCrnvC20DpwVdRA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansis": "^4.1.0",
-                "debug": "^4.4.1",
-                "error-stack-parser-es": "^1.0.5",
-                "ohash": "^2.0.11",
-                "open": "^10.2.0",
-                "perfect-debounce": "^2.0.0",
-                "sirv": "^3.0.1",
-                "unplugin-utils": "^0.3.0",
-                "vite-dev-rpc": "^1.1.0"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "vite": "^6.0.0 || ^7.0.0-0"
-            },
-            "peerDependenciesMeta": {
-                "@nuxt/kit": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/vite-plugin-inspect/node_modules/define-lazy-prop": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/vite-plugin-inspect/node_modules/is-wsl": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-inside-container": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/vite-plugin-inspect/node_modules/open": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "default-browser": "^5.2.1",
-                "define-lazy-prop": "^3.0.0",
-                "is-inside-container": "^1.0.0",
-                "wsl-utils": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/vite-plugin-inspect/node_modules/wsl-utils": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-wsl": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/vite-plugin-vue-tracer": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/vite-plugin-vue-tracer/-/vite-plugin-vue-tracer-1.3.0.tgz",
-            "integrity": "sha512-Cgfce6VikzOw5MUJTpeg50s5rRjzU1Vr61ZjuHunVVHLjZZ5AUlgyExHthZ3r59vtoz9W2rDt23FYG81avYBKw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "estree-walker": "^3.0.3",
-                "exsolve": "^1.0.8",
-                "magic-string": "^0.30.21",
-                "pathe": "^2.0.3",
-                "source-map-js": "^1.2.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/antfu"
-            },
-            "peerDependencies": {
-                "vite": "^6.0.0 || ^7.0.0",
-                "vue": "^3.5.0"
             }
         },
         "node_modules/vitepress": {
@@ -22760,16 +22241,16 @@
             "license": "MIT"
         },
         "node_modules/vue": {
-            "version": "3.5.33",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
-            "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
+            "version": "3.5.34",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
+            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
             "license": "MIT",
             "dependencies": {
-                "@vue/compiler-dom": "3.5.33",
-                "@vue/compiler-sfc": "3.5.33",
-                "@vue/runtime-dom": "3.5.33",
-                "@vue/server-renderer": "3.5.33",
-                "@vue/shared": "3.5.33"
+                "@vue/compiler-dom": "3.5.34",
+                "@vue/compiler-sfc": "3.5.34",
+                "@vue/runtime-dom": "3.5.34",
+                "@vue/server-renderer": "3.5.34",
+                "@vue/shared": "3.5.34"
             },
             "peerDependencies": {
                 "typescript": "*"
@@ -22791,9 +22272,9 @@
             }
         },
         "node_modules/vue-component-type-helpers": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.7.tgz",
-            "integrity": "sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==",
+            "version": "3.2.8",
+            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.8.tgz",
+            "integrity": "sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==",
             "dev": true,
             "license": "MIT"
         },
@@ -22830,15 +22311,15 @@
             }
         },
         "node_modules/vue-router": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.6.tgz",
-            "integrity": "sha512-9+kmUTGbKMyW9Asoy98IXXYIzrTMT7JDAdpDDeEkorHvybpUvBI2wsrSM5jFOXrFydpzRFJ9vAh+80DN2PGu9w==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.7.tgz",
+            "integrity": "sha512-dqfk8kvRbCutmCOCj/XLDqDEYxc1wBdAOGLuVy5M93ifYMsBd5fIjfaPN4tQAbxr5IprdBDIox1gr4wYyOx/SA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/generator": "^7.28.6",
+                "@babel/generator": "^8.0.0-rc.4",
                 "@vue-macros/common": "^3.1.1",
-                "@vue/devtools-api": "^8.0.6",
+                "@vue/devtools-api": "^8.1.1",
                 "ast-walker-scope": "^0.8.3",
                 "chokidar": "^5.0.0",
                 "json5": "^2.2.3",
@@ -22859,9 +22340,9 @@
             },
             "peerDependencies": {
                 "@pinia/colada": ">=0.21.2",
-                "@vue/compiler-sfc": "^3.5.17",
+                "@vue/compiler-sfc": "^3.5.34",
                 "pinia": "^3.0.4",
-                "vue": "^3.5.0"
+                "vue": "^3.5.34"
             },
             "peerDependenciesMeta": {
                 "@pinia/colada": {
@@ -22875,129 +22356,30 @@
                 }
             }
         },
-        "node_modules/vue-router/node_modules/@babel/generator": {
-            "version": "7.29.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.0",
-                "@babel/types": "^7.29.0",
-                "@jridgewell/gen-mapping": "^0.3.12",
-                "@jridgewell/trace-mapping": "^0.3.28",
-                "jsesc": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/vue-router/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/vue-router/node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/vue-router/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/vue-router/node_modules/@vue/devtools-api": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.1.tgz",
-            "integrity": "sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.2.tgz",
+            "integrity": "sha512-vA0O112YqyDuNA1s7Yb2gCgToQ/OxOWiFDO5ThLCcDy0ldHnSd1dUTaSYhOldbqoNgumE4dxtGAoAaSUKUD1Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vue/devtools-kit": "^8.1.1"
+                "@vue/devtools-kit": "^8.1.2"
             }
         },
-        "node_modules/vue-sfc-transformer": {
-            "version": "0.1.17",
-            "resolved": "https://registry.npmjs.org/vue-sfc-transformer/-/vue-sfc-transformer-0.1.17.tgz",
-            "integrity": "sha512-0mpkDTWm1ybtp/Mp3vhrXP4r8yxcGF+quxGyJfrHDl2tl5naQjK3xkIGaVR5BtR5KG1LWJbdCrqn7I6f460j9A==",
+        "node_modules/vue-router/node_modules/yaml": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.27.0"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            },
-            "peerDependencies": {
-                "@vue/compiler-core": "^3.5.13",
-                "esbuild": "*",
-                "vue": "^3.5.13"
-            }
-        },
-        "node_modules/vue-sfc-transformer/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/vue-sfc-transformer/node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
+            "license": "ISC",
             "bin": {
-                "parser": "bin/babel-parser.js"
+                "yaml": "bin.mjs"
             },
             "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "node_modules/vue-sfc-transformer/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "node": ">= 14.6"
             },
-            "engines": {
-                "node": ">=6.9.0"
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/vue-tsc": {
@@ -23051,11 +22433,14 @@
             }
         },
         "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
             "dev": true,
-            "license": "BSD-2-Clause"
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
         },
         "node_modules/webpack-virtual-modules": {
             "version": "0.6.2",
@@ -23074,14 +22459,18 @@
             }
         },
         "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/which": {
@@ -23172,9 +22561,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.20.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "version": "8.20.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -23194,17 +22583,16 @@
             }
         },
         "node_modules/wsl-utils": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-            "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-wsl": "^3.1.0",
-                "powershell-utils": "^0.1.0"
+                "is-wsl": "^3.1.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -23264,9 +22652,9 @@
             }
         },
         "node_modules/yaml": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+            "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -23274,9 +22662,6 @@
             },
             "engines": {
                 "node": ">= 14.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yargs": {
@@ -23439,184 +22824,6 @@
                 "vue": "^3.x"
             }
         },
-        "packages/button/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/button/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "packages/button/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/button/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/button/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/button/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/button/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/button/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/button/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/button/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/button/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/button/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/button/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/button/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "packages/core": {
             "name": "@vuecs/core",
             "version": "2.0.0",
@@ -23635,184 +22842,6 @@
                 "vue": "^3.5.34"
             }
         },
-        "packages/core/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/core/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "packages/core/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/core/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/core/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/core/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/core/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/core/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/core/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/core/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/core/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/core/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/core/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/core/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "packages/countdown": {
             "name": "@vuecs/countdown",
             "version": "1.0.1",
@@ -23827,184 +22856,6 @@
             "peerDependencies": {
                 "@vuecs/core": "^2.0.0",
                 "vue": "^3.x"
-            }
-        },
-        "packages/countdown/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/countdown/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "packages/countdown/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/countdown/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/countdown/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/countdown/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/countdown/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/countdown/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/countdown/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/countdown/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/countdown/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/countdown/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/countdown/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/countdown/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
             }
         },
         "packages/design": {
@@ -24027,199 +22878,6 @@
                 "vue": "^3.x"
             }
         },
-        "packages/design-system": {
-            "name": "@vuecs/design-system",
-            "version": "0.0.0",
-            "extraneous": true,
-            "devDependencies": {
-                "jsdom": "^29.0.2",
-                "vue": "^3.5.28"
-            },
-            "engines": {
-                "node": ">=22.0.0"
-            },
-            "peerDependencies": {
-                "vue": "^3.x"
-            }
-        },
-        "packages/design/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/design/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "packages/design/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/design/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/design/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/design/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/design/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/design/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/design/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/design/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/design/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/design/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/design/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/design/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "packages/elements": {
             "name": "@vuecs/elements",
             "version": "0.0.0",
@@ -24232,206 +22890,6 @@
                 "@vuecs/core": "^2.0.0",
                 "jsdom": "^29.0.2",
                 "vue": "^3.5.34"
-            },
-            "engines": {
-                "node": ">=22.0.0"
-            },
-            "peerDependencies": {
-                "@vuecs/core": "^2.0.0",
-                "vue": "^3.x"
-            }
-        },
-        "packages/elements/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/elements/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "packages/elements/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/elements/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/elements/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/elements/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/elements/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/elements/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/elements/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/elements/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/elements/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/elements/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/elements/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/elements/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/form-controls": {
-            "name": "@vuecs/form-controls",
-            "version": "2.5.0",
-            "extraneous": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@vueuse/core": "^14.2.1"
-            },
-            "devDependencies": {
-                "@vue/test-utils": "^2.4.6",
-                "@vuecs/core": "^2.0.0",
-                "jsdom": "^29.0.2",
-                "vue": "^3.5.28"
             },
             "engines": {
                 "node": ">=22.0.0"
@@ -24463,184 +22921,6 @@
                 "vue": "^3.x"
             }
         },
-        "packages/forms/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/forms/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "packages/forms/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/forms/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/forms/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/forms/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/forms/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/forms/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/forms/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/forms/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/forms/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/forms/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/forms/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/forms/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "packages/gravatar": {
             "name": "@vuecs/gravatar",
             "version": "1.0.2",
@@ -24663,184 +22943,6 @@
                 "vue": "^3.x"
             }
         },
-        "packages/gravatar/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/gravatar/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "packages/gravatar/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/gravatar/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/gravatar/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/gravatar/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/gravatar/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/gravatar/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/gravatar/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/gravatar/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/gravatar/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/gravatar/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/gravatar/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/gravatar/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "packages/icon": {
             "name": "@vuecs/icon",
             "version": "0.0.0",
@@ -24858,184 +22960,6 @@
                 "vue": "^3.x"
             }
         },
-        "packages/icon/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/icon/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "packages/icon/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/icon/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/icon/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/icon/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/icon/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/icon/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/icon/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/icon/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/icon/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/icon/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/icon/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/icon/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "packages/link": {
             "name": "@vuecs/link",
             "version": "1.0.1",
@@ -25048,184 +22972,6 @@
             },
             "peerDependencies": {
                 "vue": "^3.x"
-            }
-        },
-        "packages/link/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/link/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "packages/link/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/link/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/link/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/link/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/link/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/link/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/link/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/link/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/link/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/link/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/link/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/link/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
             }
         },
         "packages/list": {
@@ -25247,205 +22993,6 @@
             "peerDependencies": {
                 "@vuecs/core": "^2.0.0",
                 "vue": "^3.x"
-            }
-        },
-        "packages/list-controls": {
-            "name": "@vuecs/list-controls",
-            "version": "2.0.1",
-            "extraneous": true,
-            "license": "Apache-2.0",
-            "devDependencies": {
-                "@vue/test-utils": "^2.4.6",
-                "@vuecs/core": "^2.0.0",
-                "jsdom": "^29.0.2",
-                "smob": "^1.6.1",
-                "vue": "^3.5.28"
-            },
-            "engines": {
-                "node": ">=22.0.0"
-            },
-            "peerDependencies": {
-                "@vuecs/core": "^2.0.0",
-                "smob": "^1.6.1",
-                "vue": "^3.x"
-            }
-        },
-        "packages/list/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/list/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "packages/list/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/list/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/list/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/list/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/list/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/list/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/list/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/list/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/list/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/list/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/list/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/list/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
             }
         },
         "packages/navigation": {
@@ -25474,184 +23021,6 @@
                 "vue-router": "^4.x || ^5.x"
             }
         },
-        "packages/navigation/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/navigation/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "packages/navigation/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/navigation/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/navigation/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/navigation/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/navigation/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/navigation/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/navigation/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/navigation/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/navigation/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/navigation/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/navigation/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/navigation/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "packages/nuxt": {
             "name": "@vuecs/nuxt",
             "version": "0.0.0",
@@ -25675,177 +23044,48 @@
                 "vue": "^3.x"
             }
         },
-        "packages/nuxt/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/nuxt/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+        "packages/nuxt/node_modules/@nuxt/module-builder": {
+            "version": "1.0.2",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.0"
+                "citty": "^0.1.6",
+                "consola": "^3.4.2",
+                "defu": "^6.1.4",
+                "jiti": "^2.5.1",
+                "magic-regexp": "^0.10.0",
+                "mkdist": "^2.3.0",
+                "mlly": "^1.7.4",
+                "pathe": "^2.0.3",
+                "pkg-types": "^2.2.0",
+                "tsconfck": "^3.1.6",
+                "unbuild": "^3.6.0",
+                "vue-sfc-transformer": "^0.1.16"
             },
             "bin": {
-                "parser": "bin/babel-parser.js"
+                "nuxt-build-module": "dist/cli.mjs",
+                "nuxt-module-build": "dist/cli.mjs"
             },
             "engines": {
-                "node": ">=6.0.0"
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "peerDependencies": {
+                "@nuxt/cli": "^3.26.4",
+                "typescript": "^5.8.3"
             }
         },
-        "packages/nuxt/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+        "packages/nuxt/node_modules/tsconfck": {
+            "version": "3.1.6",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+            "bin": {
+                "tsconfck": "bin/tsconfck.js"
             },
             "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/nuxt/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/nuxt/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/nuxt/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/nuxt/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/nuxt/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/nuxt/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/nuxt/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/nuxt/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
+                "node": "^18 || >=20"
             },
             "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/nuxt/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/nuxt/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/nuxt/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
+                "typescript": "^5.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -25874,184 +23114,6 @@
                 "vue": "^3.x"
             }
         },
-        "packages/overlays/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/overlays/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "packages/overlays/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/overlays/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/overlays/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/overlays/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/overlays/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/overlays/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/overlays/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/overlays/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/overlays/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/overlays/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/overlays/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/overlays/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "packages/pagination": {
             "name": "@vuecs/pagination",
             "version": "1.3.1",
@@ -26075,226 +23137,6 @@
                 "vue": "^3.x"
             }
         },
-        "packages/pagination/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/pagination/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "packages/pagination/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/pagination/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/pagination/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/pagination/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/pagination/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/pagination/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/pagination/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/pagination/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/pagination/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/pagination/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/pagination/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/pagination/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "packages/preset-bootstrap-v4": {
-            "name": "@vuecs/preset-bootstrap-v4",
-            "version": "1.0.1",
-            "extraneous": true,
-            "devDependencies": {
-                "@vuecs/core": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=22.0.0"
-            },
-            "peerDependencies": {
-                "@vuecs/core": "^2.0.0"
-            }
-        },
-        "packages/preset-bootstrap-v5": {
-            "name": "@vuecs/preset-bootstrap-v5",
-            "version": "2.0.1",
-            "extraneous": true,
-            "devDependencies": {
-                "@vuecs/core": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=22.0.0"
-            },
-            "peerDependencies": {
-                "@vuecs/core": "^2.0.0"
-            }
-        },
-        "packages/preset-font-awesome": {
-            "name": "@vuecs/preset-font-awesome",
-            "version": "1.1.1",
-            "extraneous": true,
-            "devDependencies": {
-                "@vuecs/core": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=22.0.0"
-            },
-            "peerDependencies": {
-                "@vuecs/core": "^2.0.0"
-            }
-        },
         "packages/timeago": {
             "name": "@vuecs/timeago",
             "version": "1.1.2",
@@ -26313,184 +23155,6 @@
                 "vue": "^3.x"
             }
         },
-        "packages/timeago/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/timeago/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "packages/timeago/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "packages/timeago/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/timeago/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/timeago/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "packages/timeago/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/timeago/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/timeago/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "packages/timeago/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "packages/timeago/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "packages/timeago/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/timeago/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "packages/timeago/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "tests/visual-regression": {
             "name": "@vuecs-tests/visual-regression",
             "version": "0.0.0",
@@ -26503,184 +23167,6 @@
             },
             "engines": {
                 "node": ">=22.0.0"
-            }
-        },
-        "tests/visual-regression/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "tests/visual-regression/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "tests/visual-regression/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "tests/visual-regression/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "tests/visual-regression/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "tests/visual-regression/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "tests/visual-regression/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "tests/visual-regression/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "tests/visual-regression/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "tests/visual-regression/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "tests/visual-regression/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "tests/visual-regression/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "tests/visual-regression/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "tests/visual-regression/node_modules/vue/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
             }
         },
         "themes/bootstrap": {
@@ -26699,36 +23185,6 @@
                 "@vuecs/overlays": "^0.0.0",
                 "@vuecs/pagination": "^1.3.1",
                 "@vuecs/timeago": "^1.1.2"
-            },
-            "engines": {
-                "node": ">=22.0.0"
-            },
-            "peerDependencies": {
-                "@vuecs/core": "^2.0.0"
-            }
-        },
-        "themes/bootstrap-v4": {
-            "name": "@vuecs/theme-bootstrap-v4",
-            "version": "1.0.1",
-            "extraneous": true,
-            "license": "Apache-2.0",
-            "devDependencies": {
-                "@vuecs/core": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=22.0.0"
-            },
-            "peerDependencies": {
-                "@vuecs/core": "^2.0.0"
-            }
-        },
-        "themes/bootstrap-v5": {
-            "name": "@vuecs/theme-bootstrap-v5",
-            "version": "2.0.1",
-            "extraneous": true,
-            "license": "Apache-2.0",
-            "devDependencies": {
-                "@vuecs/core": "^2.0.0"
             },
             "engines": {
                 "node": ">=22.0.0"
@@ -26770,199 +23226,6 @@
                 "vue": "^3.x"
             }
         },
-        "themes/bulma/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "themes/bulma/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "themes/bulma/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "themes/bulma/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "themes/bulma/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "themes/bulma/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "themes/bulma/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "themes/bulma/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "themes/bulma/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "themes/bulma/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "themes/bulma/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "themes/bulma/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "themes/bulma/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "themes/bulma/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "themes/font-awesome": {
-            "name": "@vuecs/theme-font-awesome",
-            "version": "1.1.1",
-            "extraneous": true,
-            "license": "Apache-2.0",
-            "devDependencies": {
-                "@vuecs/core": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=22.0.0"
-            },
-            "peerDependencies": {
-                "@vuecs/core": "^2.0.0"
-            }
-        },
         "themes/tailwind": {
             "name": "@vuecs/theme-tailwind",
             "version": "0.0.0",
@@ -26996,385 +23259,6 @@
                 "@vueuse/core": "^13.0.0 || ^14.0.0",
                 "tailwindcss": "^4.3.0",
                 "vue": "^3.x"
-            }
-        },
-        "themes/tailwind-nuxt": {
-            "name": "@vuecs/theme-tailwind-nuxt",
-            "version": "0.0.0",
-            "extraneous": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@nuxt/kit": "^4.4.5",
-                "@vuecs/design": "^0.0.0",
-                "@vuecs/theme-tailwind": "^0.0.0"
-            },
-            "devDependencies": {
-                "@nuxt/module-builder": "^1.0.1",
-                "@nuxt/schema": "^4.4.5",
-                "nuxt": "^4.4.5",
-                "vue": "^3.5.34"
-            },
-            "engines": {
-                "node": ">=22.0.0"
-            },
-            "peerDependencies": {
-                "vue": "^3.x"
-            }
-        },
-        "themes/tailwind-nuxt/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "themes/tailwind-nuxt/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "themes/tailwind-nuxt/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "themes/tailwind-nuxt/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "themes/tailwind-nuxt/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "themes/tailwind-nuxt/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "themes/tailwind-nuxt/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "themes/tailwind-nuxt/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "themes/tailwind-nuxt/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "themes/tailwind-nuxt/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "themes/tailwind-nuxt/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "themes/tailwind-nuxt/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "themes/tailwind-nuxt/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "themes/tailwind-nuxt/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "themes/tailwind/node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "themes/tailwind/node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.29.0"
-            },
-            "bin": {
-                "parser": "bin/babel-parser.js"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
-        "themes/tailwind/node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "themes/tailwind/node_modules/@vue/compiler-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
-            "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/shared": "3.5.34",
-                "entities": "^7.0.1",
-                "estree-walker": "^2.0.2",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "themes/tailwind/node_modules/@vue/compiler-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
-            "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-core": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "themes/tailwind/node_modules/@vue/compiler-sfc": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
-            "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/parser": "^7.29.3",
-                "@vue/compiler-core": "3.5.34",
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "estree-walker": "^2.0.2",
-                "magic-string": "^0.30.21",
-                "postcss": "^8.5.14",
-                "source-map-js": "^1.2.1"
-            }
-        },
-        "themes/tailwind/node_modules/@vue/compiler-ssr": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
-            "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "themes/tailwind/node_modules/@vue/reactivity": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
-            "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "themes/tailwind/node_modules/@vue/runtime-core": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
-            "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/shared": "3.5.34"
-            }
-        },
-        "themes/tailwind/node_modules/@vue/runtime-dom": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
-            "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "3.5.34",
-                "@vue/runtime-core": "3.5.34",
-                "@vue/shared": "3.5.34",
-                "csstype": "^3.2.3"
-            }
-        },
-        "themes/tailwind/node_modules/@vue/server-renderer": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
-            "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-ssr": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "vue": "3.5.34"
-            }
-        },
-        "themes/tailwind/node_modules/@vue/shared": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
-            "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "themes/tailwind/node_modules/estree-walker": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "themes/tailwind/node_modules/vue": {
-            "version": "3.5.34",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
-            "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/compiler-dom": "3.5.34",
-                "@vue/compiler-sfc": "3.5.34",
-                "@vue/runtime-dom": "3.5.34",
-                "@vue/server-renderer": "3.5.34",
-                "@vue/shared": "3.5.34"
-            },
-            "peerDependencies": {
-                "typescript": "*"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@tada5hi/eslint-config": "^2.3.0",
         "@tada5hi/tsconfig": "^0.7.2",
         "@tsdown/css": "^0.22.0",
-        "@vitejs/plugin-vue": "^6.0.4",
+        "@vitejs/plugin-vue": "^6.0.6",
         "@vitest/coverage-v8": "^4.1.6",
         "eslint": "^10.3.0",
         "eslint-plugin-vue": "^10.9.1",
@@ -55,6 +55,7 @@
         "tsdown": "^0.22.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.59.3",
+        "unbuild": "^3.6.1",
         "vitest": "^4.1.2",
         "vue-tsc": "^3.2.8"
     },

--- a/packages/button/tsconfig.build.json
+++ b/packages/button/tsconfig.build.json
@@ -3,10 +3,11 @@
     "compilerOptions": {
         "lib": ["ESNext", "DOM"],
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "jsx": "preserve",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
 }

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -2,9 +2,10 @@
     "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts", "src/**/*.vue"]
+    "include": ["src/**/*.ts", "src/**/*.vue", "../../types/**/*.d.ts"]
 }

--- a/packages/countdown/tsconfig.build.json
+++ b/packages/countdown/tsconfig.build.json
@@ -3,10 +3,11 @@
     "compilerOptions": {
         "lib": ["ESNext", "DOM"],
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "jsx": "preserve",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
 }

--- a/packages/design/tsconfig.build.json
+++ b/packages/design/tsconfig.build.json
@@ -2,9 +2,10 @@
     "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
 }

--- a/packages/elements/tsconfig.build.json
+++ b/packages/elements/tsconfig.build.json
@@ -3,10 +3,11 @@
     "compilerOptions": {
         "lib": ["ESNext", "DOM"],
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "jsx": "preserve",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts", "src/**/*.vue"]
+    "include": ["src/**/*.ts", "src/**/*.vue", "../../types/**/*.d.ts"]
 }

--- a/packages/forms/tsconfig.build.json
+++ b/packages/forms/tsconfig.build.json
@@ -3,10 +3,11 @@
     "compilerOptions": {
         "lib": ["ESNext", "DOM"],
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "jsx": "preserve",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts", "src/**/*.vue"]
+    "include": ["src/**/*.ts", "src/**/*.vue", "../../types/**/*.d.ts"]
 }

--- a/packages/gravatar/tsconfig.build.json
+++ b/packages/gravatar/tsconfig.build.json
@@ -3,10 +3,11 @@
     "compilerOptions": {
         "lib": ["ESNext", "DOM"],
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "jsx": "preserve",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
 }

--- a/packages/icon/tsconfig.build.json
+++ b/packages/icon/tsconfig.build.json
@@ -3,10 +3,11 @@
     "compilerOptions": {
         "lib": ["ESNext", "DOM"],
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "jsx": "preserve",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts", "src/**/*.vue"]
+    "include": ["src/**/*.ts", "src/**/*.vue", "../../types/**/*.d.ts"]
 }

--- a/packages/link/tsconfig.build.json
+++ b/packages/link/tsconfig.build.json
@@ -3,10 +3,11 @@
     "compilerOptions": {
         "lib": ["ESNext", "DOM"],
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "jsx": "preserve",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
 }

--- a/packages/list/src/components/list/List.vue
+++ b/packages/list/src/components/list/List.vue
@@ -45,7 +45,10 @@ export type ListProps = ExtractPublicPropTypes<typeof listProps>;
 
 const SHORTHAND_SLOT_NAMES = ['header', 'item', 'loading', 'empty', 'footer'] as const;
 
-const isDev = typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production';
+const isDev = (() => {
+    const p = (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process;
+    return p !== undefined && p.env?.NODE_ENV !== 'production';
+})();
 
 export const listThemeDefaults: ComponentThemeDefinition<ListThemeClasses> = { classes: { root: 'vc-list' } };
 

--- a/packages/list/tsconfig.build.json
+++ b/packages/list/tsconfig.build.json
@@ -2,9 +2,10 @@
     "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
 }

--- a/packages/list/tsconfig.build.json
+++ b/packages/list/tsconfig.build.json
@@ -7,5 +7,5 @@
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
+    "include": ["src/**/*.ts", "src/**/*.vue", "../../types/**/*.d.ts"]
 }

--- a/packages/navigation/tsconfig.build.json
+++ b/packages/navigation/tsconfig.build.json
@@ -3,10 +3,11 @@
     "compilerOptions": {
         "lib": ["ESNext", "DOM"],
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "jsx": "preserve",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts", "src/**/*.vue"]
+    "include": ["src/**/*.ts", "src/**/*.vue", "../../types/**/*.d.ts"]
 }

--- a/packages/overlays/tsconfig.build.json
+++ b/packages/overlays/tsconfig.build.json
@@ -3,10 +3,11 @@
     "compilerOptions": {
         "lib": ["ESNext", "DOM"],
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "jsx": "preserve",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts", "src/**/*.vue"]
+    "include": ["src/**/*.ts", "src/**/*.vue", "../../types/**/*.d.ts"]
 }

--- a/packages/pagination/tsconfig.build.json
+++ b/packages/pagination/tsconfig.build.json
@@ -3,10 +3,11 @@
     "compilerOptions": {
         "lib": ["ESNext", "DOM"],
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "jsx": "preserve",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts", "src/**/*.vue"]
+    "include": ["src/**/*.ts", "src/**/*.vue", "../../types/**/*.d.ts"]
 }

--- a/packages/timeago/tsconfig.build.json
+++ b/packages/timeago/tsconfig.build.json
@@ -3,10 +3,11 @@
     "compilerOptions": {
         "lib": ["ESNext", "DOM"],
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "jsx": "preserve",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
 }

--- a/themes/bootstrap/tsconfig.build.json
+++ b/themes/bootstrap/tsconfig.build.json
@@ -2,9 +2,10 @@
     "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
 }

--- a/themes/bulma/tsconfig.build.json
+++ b/themes/bulma/tsconfig.build.json
@@ -2,9 +2,10 @@
     "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
 }

--- a/themes/tailwind/tsconfig.build.json
+++ b/themes/tailwind/tsconfig.build.json
@@ -2,9 +2,10 @@
     "extends": "../../tsconfig.build.json",
     "compilerOptions": {
         "outDir": "./dist",
+        "rootDir": "./src",
         "declarationDir": "./dist",
         "skipLibCheck": true
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["src/**/*.ts"]
+    "include": ["src/**/*.ts", "../../types/**/*.d.ts"]
 }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,16 @@
+// Workspace-level ambient declarations consumed by every per-package
+// `tsconfig.build.json` (via the `../../types/**/*.d.ts` glob in their
+// `include` arrays). TS 6 flagged side-effect CSS imports (TS2882)
+// without these.
+
+declare module '*.css';
+declare module '*.scss';
+declare module '*.sass';
+declare module '*.less';
+
+declare module '*.vue' {
+    import type { DefineComponent } from 'vue';
+
+    const component: DefineComponent;
+    export default component;
+}

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -2,15 +2,17 @@
 // `tsconfig.build.json` (via the `../../types/**/*.d.ts` glob in their
 // `include` arrays). TS 6 flagged side-effect CSS imports (TS2882)
 // without these.
+//
+// The shim deliberately covers ONLY style assets — no `*.vue` shim
+// here. Vue-using packages drive their builds through `vue-tsc`, which
+// has native SFC support; a shared `*.vue` shim that imports from
+// `vue` would force every package that includes this file (icons,
+// theme-bootstrap, …) to also resolve `vue` types, breaking isolated
+// workspace builds for non-Vue packages. Per-package vue shims (see
+// e.g. `packages/forms/types/vue.shim.d.ts`) handle the cases where
+// a local SFC import outside vue-tsc's purview needs typing.
 
 declare module '*.css';
 declare module '*.scss';
 declare module '*.sass';
 declare module '*.less';
-
-declare module '*.vue' {
-    import type { DefineComponent } from 'vue';
-
-    const component: DefineComponent;
-    export default component;
-}


### PR DESCRIPTION
Bumps:
- @vitejs/plugin-vue 6.0.4 → 6.0.6 (root + 3 vanilla examples)
- vite 7.1.0 → 8.0.12 (3 vanilla examples; major bump)
- TypeScript stays at ^5.9.3 — TS 6.0.3 is released but unbuild@3.6.1 (transitive dep of @nuxt/module-builder) declares peer `typescript: ^5.9.2`, so bumping breaks the whole nuxt build toolchain. Revisit when unbuild ships a TS 6 release.

Pipeline fixes:
- Add `unbuild@^3.6.1` to root devDependencies. Workaround for an npm 11.12 hoisting bug where unbuild's transitive deps (mkdist, rollup-plugin-dts, fix-dts-default-cjs-exports, ...) silently weren't installed when unbuild was only reached transitively via @nuxt/module-builder. Hoisting it to the root forces npm to install the full sub-tree so `nuxt-module-build` actually runs.
- Add explicit `rootDir: "./src"` to every per-package `tsconfig.build.json`. Future-proof against TS 6's stricter `rootDir` enforcement (it errors when `outDir` is set but `rootDir` is inferred). Harmless on TS 5.9.
- Add workspace-level `types/global.d.ts` with `*.css` / `*.scss` / `*.sass` / `*.less` / `*.vue` ambient module declarations, then wire `../../types/**/*.d.ts` into every per-package `tsconfig.build.json` include. TS 6 will error TS2882 on side-effect CSS imports without these.
- Rewrite `typeof process !== 'undefined'` in `List.vue` to read `process` off `globalThis` with a typed projection. TS 6 errors on unguarded `process` references without `@types/node`.

Net effect: `npm install` is reproducible on a fresh checkout, `npm run build` is green across all 25 projects, `npm run lint` errors are zero, `npm run test` is green across all 11 projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Vite and Vue build plugin dev-dependencies to newer versions.
  * Broadened build configurations across packages to include shared type declarations and set package source roots.
  * Added a new build tool dev-dependency.
  * Added workspace-wide type shims for style imports and removed the global Vue SFC shim.

* **Bug Fixes**
  * Improved environment detection in the list component for safer runtime behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1560)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->