### PR TITLE
feat(table): semantic-HTML compound + columns driver (plan 028)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -221,6 +221,12 @@ unless the variant is structural (e.g. orientation-driven layout).
 | Tag | `size` | sm/md/lg | Matches badge sizing |
 | Avatar | `size` | sm/md/lg | Theme-bootstrap uses `vc-avatar-{sm,lg}` helpers |
 | Pagination | `variant` × `size` | outline/soft/ghost × sm/md/lg | |
+| Table | `density` × `striped` × `bordered` × `hover` × `stickyHeader` | compact/normal/spacious × boolean × boolean × boolean × boolean | Whole-table chrome; sortable headers driven by per-column `:sortable` |
+| TableRow | `disabled` / `selected` / `focused` / `rowVariant` | boolean × boolean × boolean × success/warning/error/info/neutral/primary | `rowVariant` resolved from `row._rowVariant` (plan 028) |
+| TableCell | `align` / `stickyColumn` / `cellVariant` | left/center/right × boolean × six semantic colors | `cellVariant` resolved from `row._cellVariants[columnKey]` |
+| TableHeadCell | `align` / `stickyColumn` / `sorted` | left/center/right × boolean × asc/desc/none | `sorted` drives the indicator span + `aria-sort` |
+| TableEmpty | `filtered` | boolean | Distinct copy / style for empty-after-filter vs empty-no-data |
+| TableLoading | `overlay` | boolean | In-table band default vs absolute overlay for refresh-feedback |
 | FormInput / FormTextarea / FormSelect / FormNumber / FormTags | `size` | sm/md/lg | theme-tailwind uses padding+font utilities; theme-bootstrap uses `form-control-{sm,lg}` (and input-group-{sm,lg} for groups) |
 | FormCheckbox / FormSwitch / FormRadio | `size` | sm/md/lg | theme-bootstrap uses `vc-form-{checkbox,switch,radio}-{sm,lg}` helpers from @vuecs/forms structural CSS |
 | Modal | `size` | sm/md/lg/xl | theme-tailwind uses `max-w-*`; theme-bootstrap uses `modal-{sm,lg,xl}` |
@@ -1717,6 +1723,171 @@ Theme entries ship in `@vuecs/theme-tailwind` (uses
 prefixes, scoped via the `group` utility added by `<VCStepperItem>`) and
 `@vuecs/theme-bootstrap` (Bootstrap utility classes only, with
 data-state visualization handled by the bridge CSS as noted above).
+
+## Table compound (@vuecs/table, plan 028)
+
+Semantic-HTML compound for entity-list pages. Outer `<VCTable>` + eight
+parts (`<VCTableHeader>` / `<VCTableBody>` / `<VCTableFooter>` /
+`<VCTableRow>` / `<VCTableCell>` / `<VCTableHeadCell>` / `<VCTableEmpty>` /
+`<VCTableLoading>`). Layer 1 — `@vuecs/core` peer dep only; no Reka dep
+(no Reka table primitive exists, semantic HTML covers it).
+
+### Two authoring shapes
+
+- **`:columns :data` driver** (primary): consumer passes `:columns`
+  (array of `TableColumn` or bare-string shorthand) + `:data`; uses
+  `#cell-<key>` / `#header-<key>` slots for per-column overrides.
+  Direct lift-and-shift from `<BTable :fields :items>`.
+- **Manual compound markup** (escape hatch): consumer writes
+  `<VCTableHeader>` + `<VCTableBody>` + `<VCTableRow>` etc by hand for
+  layouts that don't fit the driver (merged cells, custom row
+  groupings, multi-line rows).
+
+Both shapes can mix — pass `:columns` AND write `<VCTableHeader>` to
+override only the header band, etc.
+
+### Column shape (excerpt)
+
+```ts
+type TableColumnRaw<Row> = string | TableColumn<Row>;  // bare-string shorthand
+interface TableColumn<Row, K extends string = string> {
+    key: K;
+    label?: string;                              // defaults to startCase(key)
+    class?: VNodeClass;                           // applied to both <th> AND <td>
+    headerClass?: VNodeClass;                     // additive on <th>
+    cellClass?: VNodeClass;                       // additive on <td>
+    sortable?: boolean;
+    accessor?: string | ((row: Row) => unknown); // string supports dot-paths
+    formatter?: (ctx: { value, key, row }) => string;
+    isRowHeader?: boolean;                        // <th scope="row"> instead of <td>
+    cellAttrs?: ... | (ctx) => ...;               // per-cell data-* / aria-* escape hatch
+    headerAttrs?: ... | (ctx) => ...;             // per-header escape hatch
+    headerTitle?: string;                         // native <th title>
+    headerAbbr?: string;                          // native <th abbr>
+    stickyColumn?: boolean;
+    initialSortDirection?: 'asc' | 'desc';
+}
+```
+
+Near-superset of bootstrap-vue-next's `TableField` so most field
+entries copy verbatim from a migration. Auto-derive: when `:columns`
+is omitted and `data[0]` is an object, columns come from
+`Object.keys(data[0])` (skipping underscore-prefixed row-meta keys).
+
+### Row-meta convention (`_rowVariant` / `_cellVariants`)
+
+Underscore-prefixed fields on the data row tint rows / specific cells
+without a function prop. Resolved by `<VCTableRow>` (via row context)
+and `<VCTableCell>` (via `columnKey` lookup in `_cellVariants`):
+
+```ts
+const users: WithRowMeta<User>[] = [
+    { id: 1, name: 'Alice', _rowVariant: 'warning' },
+    { id: 2, name: 'Bob', _cellVariants: { email: 'error' } },
+];
+```
+
+### Sorting
+
+Single-column controlled sort via `v-model:sort`. The table never
+sorts data — `setSort` cycles state (`null → asc → desc → null` or
+`null → asc → desc → asc` when `:must-sort`) and emits intent.
+Consumer sorts (typically via server-side query refetch). Clicks +
+Enter/Space on a `:sortable` `<VCTableHeadCell>` cycle the state;
+`aria-sort` flips to `"ascending"` / `"descending"` / `"none"` to
+match.
+
+Per-column `initialSortDirection` (`'asc'` default) sets the first
+direction on activation. Defer to v1.x: client-side sort, multi-column,
+custom comparators.
+
+### Row click + keyboard navigation (D5 + plan 028 row-nav adoption)
+
+`:row-clickable` opt-in adds `tabindex="0"` + `cursor-pointer` per row
+and wires the keyboard ladder (`↓` / `↑` / `Home` / `End` + Shift, plus
+Enter / Space for activation). The click handler runs through a shared
+`filterRowClickEvent()` helper that suppresses the row-click when the
+event originates inside an interactive descendant — `<a>`, `<button>`,
+`<input>`, `<select>`, `<textarea>`, `<label for>`, `[role=button]`,
+`[role=link]`, `[contenteditable]`, `[tabindex]:not([tabindex="-1"])`,
+or `.vc-overlay-portal-content`. Ported from bootstrap-vue-next's
+`utils/filterEvent.ts`; intended to migrate into `@vuecs/core/utils`
+so `<VCListItem>`'s selection click can share it.
+
+`useTable().focusedRow` tracks the current focus index — forward-compat
+hook for future selection v1.x.
+
+### Colspan resolution (D3 reversal)
+
+`<VCTableEmpty>` and the default-mode `<VCTableLoading>` resolve their
+`<td colspan="N">` from two parallel paths:
+
+1. **Shape A** — `columns.length` when `:columns` is set on `<VCTable>`.
+2. **Shape B** — auto-count from `<VCTableHeadCell>` siblings via a
+   render-time `provide`/`inject` ref. `<VCTableFooter>` provides a
+   no-op variant so footer cells don't double-register.
+
+Per-instance `:colspan` on Empty / Loading wins over both. The originally-
+proposed sentinel `9999` fallback was reversed during the bvnext research
+pass — Firefox honors literal `colspan` values (no clamping), so
+auto-counting + explicit prop covers every case correctly.
+
+### Sortable header role (D4 reversal)
+
+Sortable `<VCTableHeadCell>` renders as
+`<th tabindex="0" role="columnheader" aria-sort="…">` — native
+column-header semantics rather than a nested `<button>`. JAWS / NVDA /
+VoiceOver announce column-header context more strongly than a wrapped
+button; one focus stop per cell; DOM matches `<BTable>`'s output so
+visual-regression baselines don't drift on migration. The originally-
+proposed `<button>` wrapper was reversed during the bvnext research.
+
+### Free-win a11y attributes
+
+Applied unconditionally:
+
+- `<table aria-busy="true">` while `:busy`.
+- `aria-sort="ascending" | "descending" | "none"` on sortable `<th>`.
+- Smart `<th scope>` default — `colgroup` for `colspan > 1`,
+  `rowgroup` for `rowspan > 1`, else `'col'`.
+- `data-label="<column.label>"` on every `<td>` — forward-compat for
+  future stacked-mode CSS (responsive collapse to cards), out of
+  scope for v0.1 but adding the attribute now means consumers don't
+  rewrite cells later.
+- `role="alert" aria-live="polite"` on `<VCTableEmpty>` and
+  `role="status" aria-live="polite" aria-busy="true"` on
+  `<VCTableLoading>`.
+
+### Theme entries
+
+Theme entries ship in **all three** shipping themes (tailwind /
+bootstrap / bulma). theme-bootstrap composes Bootstrap's native
+`.table` family (`table-striped`, `table-bordered`, `table-hover`,
+`table-sm`, `table-success`, …). theme-bulma composes Bulma's
+`.table` family (`is-striped`, `is-bordered`, `is-hoverable`,
+`is-narrow`, `has-background-success-light`, …). theme-tailwind
+emits utility classes via `@vuecs/design` semantic tokens
+(`bg-bg-muted`, `border-border`, `text-fg`).
+
+Bootstrap + Bulma theme strings can't carry `[aria-sort=…]` attribute
+selectors, so sort-indicator state lives in dedicated
+`vc-table-sort-{asc,desc}` helpers in each bridge's `assets/index.css`.
+Sticky-header / sticky-column / row-focused / row-disabled use the
+same gap-fill helper pattern (`vc-table-sticky-{header,column}`,
+`vc-table-row-{focused,disabled}`) — Bootstrap's `.table-active`
+inverts on hover and `.table-success/-warning/-danger` use Bootstrap's
+runtime variables, both of which bridge correctly through
+`--bs-*` → `--vc-color-*`.
+
+### Out of scope for v0.1
+
+Selection v-model + listbox / treegrid a11y (deferred to v1.x —
+`<VCList>`'s selection precedent applies, but tables need a different
+a11y model and authup doesn't use it today); expandable rows + nested
+tables; virtual scrolling (tanstack-virtual on top of the compound is
+the doctrinal path); drag-and-drop column reordering; the
+`Simple`/`Lite`/Full three-tier layering (consider for v0.2 — adding
+later is non-breaking).
 
 ## Visual regression CI (@vuecs-tests/visual-regression, plan 015 P2)
 

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -18,6 +18,7 @@ vuecs/
     nuxt/             # @vuecs/nuxt — theme-agnostic Nuxt module: tokens injection + SSR colorMode + palette plugins + useColorMode / useColorPalette auto-imports + optional themes: string[] auto-load plugin (plan 025 collapsed the per-theme Nuxt sub-module split)
     overlays/         # @vuecs/overlays — Modal (+ useModal view-stack), Popover, HoverCard (plan 013), Tooltip (+ TooltipProvider), DropdownMenu, ContextMenu — all on Reka primitives
     pagination/       # @vuecs/pagination
+    table/            # @vuecs/table — compound table (Table / Header / Body / Footer / Row / Cell / HeadCell / Empty / Loading) + :columns :data driver, controlled sort, row-meta variants, row keyboard nav (plan 028)
     timeago/          # @vuecs/timeago
   themes/             # Theme packages (npm workspaces) — pure data, no Vue runtime deps
     bootstrap/        # @vuecs/theme-bootstrap — Bootstrap (currently v5) theme + design-token bridge (assets/index.css)

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -13,6 +13,7 @@
     "packages/nuxt": "0.0.0",
     "packages/overlays": "0.0.0",
     "packages/pagination": "1.3.1",
+    "packages/table": "0.0.0",
     "themes/bootstrap": "3.0.0",
     "themes/bulma": "0.0.0",
     "themes/tailwind": "0.0.0",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ npm run lint:fix       # Auto-fix lint issues
 | `@vuecs/nuxt` | Theme-agnostic Nuxt module — auto-imports `@vuecs/design` tokens, ships SSR-safe color-mode + palette plugins (`useColorMode` / `useColorPalette` auto-imports). Dispatches palette + colorMode runtime hooks through whichever themes the consumer installs (plan 025). Optional `themes: string[]` config auto-generates a plugin that installs listed theme packages. | 0.0.0 |
 | `@vuecs/overlays` | Compound overlays on Reka primitives — Modal (+ `useModal()` view-stack composable), Popover, HoverCard, Tooltip, DropdownMenu, ContextMenu | 0.0.0 |
 | `@vuecs/pagination` | Pagination component | 1.3.1 |
+| `@vuecs/table` | Compound table (`VCTable` + Header / Body / Footer / Row / Cell / HeadCell / Empty / Loading) with a `:columns :data` driver, controlled `v-model:sort`, opt-in row-click + row keyboard nav, `_rowVariant` / `_cellVariants` row-meta, and 9 themable component slots. Layer 1 — `@vuecs/core` peer dep only; semantic HTML, no Reka primitive. (plan 028) | 0.0.0 |
 | `@vuecs/theme-bootstrap` | Bootstrap theme (currently targets v5; renamed from `@vuecs/theme-bootstrap-v5` in 3.0) | 3.0.0 |
 | `@vuecs/theme-bulma` | Bulma 1.0+ theme + design-token bridge | 0.0.0 |
 | `@vuecs/theme-tailwind` | Tailwind v4 theme (class strings + `merge: ClassesMergeFn`) + Tailwind palette runtime (`setColorPalette`, `renderColorPaletteStyles`) + Tailwind rebind / `@theme` block / `@source inline()` safelist. Contributes its renderer via `palette.handle` so `useColorPalette()` from `@vuecs/design` dispatches through it. `useColorPalette` / `ColorPaletteConfig` now live in `@vuecs/design` (plan 026); deprecated re-exports remain for one release cycle. (plan 017, plan 026) | 0.0.0 |
@@ -58,7 +59,7 @@ npm run lint:fix       # Auto-fix lint issues
 
 ```text
 Layer 0 (no internal deps):  core, countdown, design, icon, link, timeago
-Layer 1 (depends on core):   button, elements, forms, list, navigation, overlays, pagination
+Layer 1 (depends on core):   button, elements, forms, list, navigation, overlays, pagination, table
 Layer 1' (depends on elements + core):   gravatar (composes VCAvatar)
 Layer 2 (depends on Layer 0): themes (@vuecs/core peer dep only — pure data that targets component packages at runtime)
                               theme-tailwind also depends on @vuecs/design (composes its generic palette primitives)

--- a/docs/demos/src/table.html
+++ b/docs/demos/src/table.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>VCTable demo</title>
+    <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+    <div id="app"></div>
+    <script type="module" src="./table.ts"></script>
+</body>
+</html>

--- a/docs/demos/src/table.ts
+++ b/docs/demos/src/table.ts
@@ -1,0 +1,54 @@
+import table from '@vuecs/table';
+import Table from '@vuecs-examples/shared/views/Table.vue';
+import { createApp, h } from 'vue';
+import { announceProps, installIframeBridge, propState } from './iframe-bridge';
+import { installVuecs } from './shared';
+
+const app = createApp({
+    setup() {
+        return () => h(Table, propState.value);
+    },
+});
+installVuecs(app);
+app.use(table);
+app.mount('#app');
+
+announceProps(
+    {
+        density: {
+            type: 'enum',
+            default: 'normal',
+            options: ['compact', 'normal', 'spacious'],
+            section: 'Variant',
+        },
+        striped: {
+            type: 'boolean',
+            default: false,
+            section: 'Variant',
+        },
+        bordered: {
+            type: 'boolean',
+            default: false,
+            section: 'Variant',
+        },
+        hover: {
+            type: 'boolean',
+            default: true,
+            section: 'Variant',
+        },
+        rowClickable: {
+            type: 'boolean',
+            default: false,
+            section: 'Behavior',
+        },
+    },
+    {
+        density: 'normal',
+        striped: false,
+        bordered: false,
+        hover: true,
+        rowClickable: false,
+    },
+);
+
+installIframeBridge();

--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -177,6 +177,12 @@ export default defineConfig({
                     ],
                 },
                 {
+                    text: '@vuecs/table',
+                    items: [
+                        { text: 'Table', link: '/components/table' },
+                    ],
+                },
+                {
                     text: '@vuecs/timeago',
                     items: [
                         { text: 'Timeago', link: '/components/timeago' },

--- a/docs/src/components/index.md
+++ b/docs/src/components/index.md
@@ -90,6 +90,12 @@ vuecs ships its components across separate packages — install only what you us
 |-----------|-------|
 | [Pagination](/components/pagination) | Offset/limit page navigation |
 
+## @vuecs/table
+
+| Component | Notes |
+|-----------|-------|
+| [Table](/components/table) | Compound table — `<VCTable>` + 8 parts (Header / Body / Footer / Row / Cell / HeadCell / Empty / Loading) with a `:columns :data` driver, controlled sort, row-meta variants, and opt-in row keyboard nav |
+
 ## @vuecs/timeago
 
 | Component | Notes |

--- a/docs/src/components/table.md
+++ b/docs/src/components/table.md
@@ -1,6 +1,6 @@
 # Table
 
-Compound table — `<VCTable>` outer + nine semantic-HTML parts (`Header` / `Body` / `Footer` / `Row` / `Cell` / `HeadCell` / `Empty` / `Loading`). A `:columns :data` driver covers the common entity-list shape; manual compound markup is an escape hatch for custom layouts. Single-column controlled sort via `v-model:sort`; opt-in row-click affordance with full keyboard navigation. Row-meta variants (`_rowVariant` / `_cellVariants`) tint rows + cells declaratively from the data.
+Compound table — `<VCTable>` outer + eight semantic-HTML parts (`Header` / `Body` / `Footer` / `Row` / `Cell` / `HeadCell` / `Empty` / `Loading`). A `:columns :data` driver covers the common entity-list shape; manual compound markup is an escape hatch for custom layouts. Single-column controlled sort via `v-model:sort`; opt-in row-click affordance with full keyboard navigation. Row-meta variants (`_rowVariant` / `_cellVariants`) tint rows + cells declaratively from the data.
 
 ```bash
 npm install @vuecs/table

--- a/docs/src/components/table.md
+++ b/docs/src/components/table.md
@@ -1,0 +1,165 @@
+# Table
+
+Compound table — `<VCTable>` outer + nine semantic-HTML parts (`Header` / `Body` / `Footer` / `Row` / `Cell` / `HeadCell` / `Empty` / `Loading`). A `:columns :data` driver covers the common entity-list shape; manual compound markup is an escape hatch for custom layouts. Single-column controlled sort via `v-model:sort`; opt-in row-click affordance with full keyboard navigation. Row-meta variants (`_rowVariant` / `_cellVariants`) tint rows + cells declaratively from the data.
+
+```bash
+npm install @vuecs/table
+```
+
+<Playground name="table">
+  <template #code>
+
+::: code-group
+
+```vue [Vue]
+<script setup lang="ts">
+import { ref } from 'vue';
+import {
+    VCTable,
+    VCTableBody,
+    VCTableCell,
+    VCTableEmpty,
+    VCTableHeadCell,
+    VCTableHeader,
+    VCTableRow,
+} from '@vuecs/table';
+import type { TableColumn, TableSortState } from '@vuecs/table';
+
+type User = { id: number; name: string; email: string; role: string };
+
+const sort = ref<TableSortState>(null);
+const columns: TableColumn<User>[] = [
+    { key: 'name', label: 'Name', sortable: true, isRowHeader: true },
+    { key: 'email', label: 'Email', sortable: true },
+    { key: 'role', label: 'Role' },
+];
+const data: User[] = [
+    { id: 1, name: 'Alice', email: 'alice@example.com', role: 'admin' },
+    { id: 2, name: 'Bob', email: 'bob@example.com', role: 'editor' },
+];
+</script>
+
+<template>
+    <VCTable v-model:sort="sort" :columns :data>
+        <VCTableHeader>
+            <VCTableRow>
+                <VCTableHeadCell
+                    v-for="col in columns" :key="col.key"
+                    :column-key="col.key" :sortable="col.sortable"
+                >{{ col.label }}</VCTableHeadCell>
+            </VCTableRow>
+        </VCTableHeader>
+        <VCTableBody>
+            <template #row="{ row, index }">
+                <VCTableRow :row :index>
+                    <VCTableCell
+                        v-for="col in columns" :key="col.key"
+                        :column-key="col.key" :is-row-header="col.isRowHeader"
+                    >{{ row[col.key as keyof User] }}</VCTableCell>
+                </VCTableRow>
+            </template>
+        </VCTableBody>
+        <VCTableEmpty>No users yet.</VCTableEmpty>
+    </VCTable>
+</template>
+```
+
+```css [CSS]
+@import "tailwindcss";
+@import "@vuecs/design";
+@import "@vuecs/table";
+
+@custom-variant dark (&:where(.dark, .dark *));
+```
+
+:::
+
+  </template>
+</Playground>
+
+## `<VCTable>` props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `data` | `Row[]` | `[]` | Row payload. |
+| `columns` | `TableColumnRaw<Row>[]` | `undefined` | Column definitions (object form or bare-string shorthand). When omitted, columns are derived from `Object.keys(data[0])`. |
+| `busy` | `boolean` | `false` | Sets `aria-busy="true"` on the `<table>` and gates the loading-band render. |
+| `sort` | `{ key, direction } \| null` | `null` | Controlled sort state. Use `v-model:sort`. |
+| `mustSort` | `boolean` | `false` | When true, the cycle skips the `null` step (`null → asc → desc → asc`). |
+| `scrollable` | `boolean` | `false` | Wrap the `<table>` in an overflow scroll container. |
+| `stickyHeader` | `boolean` | `false` | Stick the `<thead>` to the top of the scroll container. Requires `:scrollable`. |
+| `maxHeight` | `string` | `undefined` | CSS length applied to the scroll container's `max-height`. |
+| `rowClickable` | `boolean` | `false` | Opt-in: each row becomes focusable + clickable. Emits `@row-click`; row keyboard nav activates. |
+| `density` | `'compact' \| 'normal' \| 'spacious'` | `'normal'` | Theme variant shorthand. |
+| `striped` / `bordered` / `hover` | `boolean` | `undefined` | Theme variant shorthands. |
+
+## Column shape
+
+```ts
+interface TableColumn<Row, K extends string = string> {
+    key: K;
+    label?: string;          // defaults to startCase(key)
+    class?: VNodeClass;      // applied to <th> AND <td>
+    headerClass?: VNodeClass;
+    cellClass?: VNodeClass;
+    sortable?: boolean;
+    accessor?: string | ((row: Row) => unknown); // string supports dot-paths
+    formatter?: (ctx: { value, key, row }) => string;
+    isRowHeader?: boolean;   // <th scope="row"> instead of <td>
+    cellAttrs?: Record<string, unknown> | ((ctx) => Record<string, unknown>);
+    headerAttrs?: Record<string, unknown> | ((ctx) => Record<string, unknown>);
+    headerTitle?: string;
+    headerAbbr?: string;
+    stickyColumn?: boolean;
+    initialSortDirection?: 'asc' | 'desc';
+}
+```
+
+A bare-string shorthand normalises to `{ key, label: startCase(key) }`:
+
+```ts
+columns: ['id', 'name', 'email']
+// ≡ [{ key: 'id', label: 'Id' }, { key: 'name', label: 'Name' }, ...]
+```
+
+## Row meta — `_rowVariant` / `_cellVariants`
+
+Underscore-prefixed fields on the data row tint the row / specific cells without forcing a function prop:
+
+```ts
+const users: WithRowMeta<User>[] = [
+    { id: 1, name: 'Alice', _rowVariant: 'warning' },
+    { id: 2, name: 'Bob', _cellVariants: { email: 'error' } },
+];
+```
+
+## Sort
+
+Single-column controlled sort via `v-model:sort`. The table never sorts data — it emits intent. Consumer sorts (typically via server-side query refetch).
+
+```vue
+<VCTable v-model:sort="sort" :columns :data />
+```
+
+Clicking a `:sortable` header cycles `null → asc → desc → null`. `Enter` / `Space` on a focused `<th>` does the same. `aria-sort` flips to `ascending` / `descending` / `none`.
+
+## Theme keys
+
+| Component | Slot keys |
+|---|---|
+| `table` | `root`, `scrollContainer` |
+| `tableHeader` / `tableBody` / `tableFooter` / `tableRow` / `tableEmpty` | `root` |
+| `tableCell` | `root` |
+| `tableHeadCell` | `root`, `sortIcon` |
+| `tableLoading` | `root`, `overlay` |
+
+## Variant axes opted-into per theme
+
+| Component | Axis | Values |
+|---|---|---|
+| `table` | `density` × `striped` × `bordered` × `hover` × `stickyHeader` | `compact`/`normal`/`spacious` × boolean × boolean × boolean × boolean |
+| `tableRow` | `disabled` / `selected` / `focused` / `rowVariant` | boolean × boolean × boolean × `success` / `warning` / `error` / `info` / `neutral` / `primary` |
+| `tableCell` | `align` / `stickyColumn` / `cellVariant` | `left`/`center`/`right` × boolean × six semantic colors |
+| `tableHeadCell` | `align` / `stickyColumn` / `sorted` | `left`/`center`/`right` × boolean × `asc`/`desc`/`none` |
+| `tableEmpty` | `filtered` | boolean (distinct copy / style for empty-after-filter vs empty-no-data) |
+| `tableLoading` | `overlay` | boolean (in-table band vs absolute overlay for refresh-feedback) |

--- a/examples/_shared/src/routes.ts
+++ b/examples/_shared/src/routes.ts
@@ -197,6 +197,12 @@ export const sharedRoutes: SharedRoute[] = [
         view: () => import('./views/Stepper.vue').then((m) => m.default),
     },
     {
+        path: '/table',
+        name: 'table',
+        label: 'Table',
+        view: () => import('./views/Table.vue').then((m) => m.default),
+    },
+    {
         path: '/tag',
         name: 'tag',
         label: 'Tag',

--- a/examples/_shared/src/views/Table.vue
+++ b/examples/_shared/src/views/Table.vue
@@ -1,0 +1,213 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import {
+    VCTable,
+    VCTableBody,
+    VCTableCell,
+    VCTableEmpty,
+    VCTableHeadCell,
+    VCTableHeader,
+    VCTableLoading,
+    VCTableRow,
+} from '@vuecs/table';
+import type { TableColumn, TableSortState, WithRowMeta } from '@vuecs/table';
+
+type User = {
+    id: number;
+    name: string;
+    email: string;
+    role: string;
+    createdAt: string;
+};
+
+withDefaults(defineProps<{
+    density?: 'compact' | 'normal' | 'spacious';
+    striped?: boolean;
+    bordered?: boolean;
+    hover?: boolean;
+    rowClickable?: boolean;
+}>(), {
+    density: 'normal',
+    striped: false,
+    bordered: false,
+    hover: true,
+    rowClickable: false,
+});
+
+const sort = ref<TableSortState>(null);
+
+const columns: TableColumn<User>[] = [
+    {
+        key: 'name', 
+        label: 'Name', 
+        sortable: true, 
+        isRowHeader: true, 
+    },
+    {
+        key: 'email', 
+        label: 'Email', 
+        sortable: true, 
+    },
+    {
+        key: 'role', 
+        label: 'Role', 
+        class: 'w-24', 
+    },
+    {
+        key: 'createdAt', 
+        label: 'Created', 
+        sortable: true, 
+        class: 'w-32', 
+    },
+];
+
+const data: WithRowMeta<User>[] = [
+    {
+        id: 1, 
+        name: 'Alice', 
+        email: 'alice@example.com', 
+        role: 'admin', 
+        createdAt: '2026-01-15', 
+    },
+    {
+        id: 2, 
+        name: 'Bob', 
+        email: 'bob@example.com', 
+        role: 'editor', 
+        createdAt: '2026-02-03', 
+        _rowVariant: 'success', 
+    },
+    {
+        id: 3, 
+        name: 'Carol', 
+        email: 'carol@example.com', 
+        role: 'viewer', 
+        createdAt: '2026-02-19', 
+    },
+    {
+        id: 4, 
+        name: 'Dave', 
+        email: 'dave@example.com', 
+        role: 'viewer', 
+        createdAt: '2026-03-08', 
+        _cellVariants: { role: 'warning' }, 
+    },
+    {
+        id: 5, 
+        name: 'Eve', 
+        email: 'eve@example.com', 
+        role: 'admin', 
+        createdAt: '2026-04-22', 
+    },
+];
+
+const lastClicked = ref<User | null>(null);
+function onRowClick(row: User) { lastClicked.value = row; }
+</script>
+
+<template>
+    <div style="display: flex; flex-direction: column; gap: 1.5rem;">
+        <!-- Driver shape: :columns + :data — most common form. -->
+        <div>
+            <span style="font-size: 0.75rem; color: var(--vc-color-fg-muted);">
+                driver — `:columns :data` + `v-model:sort` + row meta
+            </span>
+            <VCTable
+                v-model:sort="sort"
+                :columns="columns"
+                :data="data"
+                :density="density"
+                :striped="striped"
+                :bordered="bordered"
+                :hover="hover"
+                :row-clickable="rowClickable"
+                @row-click="onRowClick"
+            >
+                <VCTableHeader>
+                    <VCTableRow>
+                        <VCTableHeadCell
+                            v-for="col in columns"
+                            :key="col.key"
+                            :column-key="col.key"
+                            :sortable="col.sortable"
+                        >
+                            {{ col.label }}
+                        </VCTableHeadCell>
+                    </VCTableRow>
+                </VCTableHeader>
+                <VCTableBody>
+                    <template #row="{ row, index }">
+                        <VCTableRow
+                            :row="row"
+                            :index="index"
+                        >
+                            <VCTableCell
+                                v-for="col in columns"
+                                :key="col.key"
+                                :column-key="col.key"
+                                :is-row-header="col.isRowHeader"
+                                :data-label="col.label"
+                            >
+                                {{ (row as User)[col.key as keyof User] }}
+                            </VCTableCell>
+                        </VCTableRow>
+                    </template>
+                </VCTableBody>
+                <VCTableEmpty>No users yet.</VCTableEmpty>
+            </VCTable>
+            <div
+                v-if="lastClicked"
+                style="margin-top: 0.5rem; font-size: 0.75rem; color: var(--vc-color-fg-muted);"
+            >
+                Last clicked: <strong>{{ lastClicked.name }}</strong>
+            </div>
+        </div>
+
+        <!-- Empty / loading states -->
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; padding-top: 0.5rem; border-top: 1px dashed var(--vc-color-border);">
+            <div>
+                <span style="font-size: 0.75rem; color: var(--vc-color-fg-muted);">
+                    empty state
+                </span>
+                <VCTable
+                    :columns="columns"
+                    :data="[]"
+                >
+                    <VCTableHeader>
+                        <VCTableRow>
+                            <VCTableHeadCell
+                                v-for="col in columns"
+                                :key="col.key"
+                            >
+                                {{ col.label }}
+                            </VCTableHeadCell>
+                        </VCTableRow>
+                    </VCTableHeader>
+                    <VCTableEmpty>No users to display.</VCTableEmpty>
+                </VCTable>
+            </div>
+            <div>
+                <span style="font-size: 0.75rem; color: var(--vc-color-fg-muted);">
+                    loading state (first load)
+                </span>
+                <VCTable
+                    :columns="columns"
+                    :data="[]"
+                    busy
+                >
+                    <VCTableHeader>
+                        <VCTableRow>
+                            <VCTableHeadCell
+                                v-for="col in columns"
+                                :key="col.key"
+                            >
+                                {{ col.label }}
+                            </VCTableHeadCell>
+                        </VCTableRow>
+                    </VCTableHeader>
+                    <VCTableLoading>Loading…</VCTableLoading>
+                </VCTable>
+            </div>
+        </div>
+    </div>
+</template>

--- a/examples/nuxt/config/layout/module.ts
+++ b/examples/nuxt/config/layout/module.ts
@@ -59,6 +59,12 @@ const generalItems: NavigationItem[] = [
         url: '/pagination',
     },
     {
+        name: 'Table',
+        type: 'link',
+        icon: 'fa6-solid:table',
+        url: '/table',
+    },
+    {
         name: 'Timeago',
         type: 'link',
         icon: 'fa6-solid:hourglass',

--- a/examples/nuxt/pages/table.vue
+++ b/examples/nuxt/pages/table.vue
@@ -1,0 +1,12 @@
+<script lang="ts">
+import DemoView from '@vuecs-examples/shared/views/Table.vue';
+import { defineNuxtComponent } from '#app';
+
+export default defineNuxtComponent({ components: { DemoView } });
+</script>
+
+<template>
+    <div class="mx-auto max-w-5xl">
+        <DemoView />
+    </div>
+</template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9666,6 +9666,10 @@
             "resolved": "packages/pagination",
             "link": true
         },
+        "node_modules/@vuecs/table": {
+            "resolved": "packages/table",
+            "link": true
+        },
         "node_modules/@vuecs/theme-bootstrap": {
             "resolved": "themes/bootstrap",
             "link": true
@@ -23746,6 +23750,24 @@
             "peerDependencies": {
                 "@vuecs/core": "^2.0.0",
                 "@vuecs/icon": "^0.0.0",
+                "vue": "^3.x"
+            }
+        },
+        "packages/table": {
+            "name": "@vuecs/table",
+            "version": "0.0.0",
+            "license": "Apache-2.0",
+            "devDependencies": {
+                "@vue/test-utils": "^2.4.10",
+                "@vuecs/core": "^2.0.0",
+                "jsdom": "^29.1.1",
+                "vue": "^3.5.34"
+            },
+            "engines": {
+                "node": ">=22.0.0"
+            },
+            "peerDependencies": {
+                "@vuecs/core": "^2.0.0",
                 "vue": "^3.x"
             }
         },

--- a/packages/table/CHANGELOG.md
+++ b/packages/table/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/table/LICENSE
+++ b/packages/table/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2021-2026 Peter Placzek
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -1,0 +1,59 @@
+# @vuecs/table
+
+Compound table for vuecs — `<VCTable>` outer + nine semantic-HTML parts (`Header` / `Body` / `Footer` / `Row` / `Cell` / `HeadCell` / `Empty` / `Loading`) with a columns/data driver, single-column controlled sort, optional row keyboard navigation, and row-meta variants. Layered on top of `@vuecs/core`'s theme system.
+
+## Installation
+
+```bash
+npm install @vuecs/table
+```
+
+## Usage
+
+See the [vuecs.dev documentation](https://vuecs.dev/components/table) for full API + theme reference.
+
+### Driver shape (recommended)
+
+```vue
+<script setup lang="ts">
+import { VCTable, VCTableEmpty } from '@vuecs/table';
+</script>
+
+<template>
+    <VCTable
+        :columns="[
+            { key: 'name', label: 'Name', sortable: true, isRowHeader: true },
+            { key: 'email', label: 'Email' },
+        ]"
+        :data="users"
+        v-model:sort="sort"
+        :busy="loading"
+    >
+        <template #cell-email="{ value }">
+            <a :href="`mailto:${value}`">{{ value }}</a>
+        </template>
+        <VCTableEmpty>No users yet.</VCTableEmpty>
+    </VCTable>
+</template>
+```
+
+### Compound shape (escape hatch)
+
+```vue
+<VCTable :data="orders">
+    <VCTableHeader>
+        <VCTableRow>
+            <VCTableHeadCell>Order</VCTableHeadCell>
+            <VCTableHeadCell>Customer</VCTableHeadCell>
+        </VCTableRow>
+    </VCTableHeader>
+    <VCTableBody>
+        <template #row="{ row }">
+            <VCTableRow>
+                <VCTableCell>#{{ row.id }}</VCTableCell>
+                <VCTableCell>{{ row.customer }}</VCTableCell>
+            </VCTableRow>
+        </template>
+    </VCTableBody>
+</VCTable>
+```

--- a/packages/table/assets/index.css
+++ b/packages/table/assets/index.css
@@ -1,0 +1,76 @@
+/*
+ * @vuecs/table — structural defaults.
+ *
+ * Themes layer visual styling (borders, hover, density) on top. These
+ * rules cover element-level baselines that don't depend on a theme:
+ * box-sizing, default layout, sort-indicator helpers, and scroll
+ * container shape.
+ */
+
+.vc-table {
+    width: 100%;
+    border-collapse: collapse;
+    box-sizing: border-box;
+}
+
+.vc-table-scroll-container {
+    position: relative;
+    overflow: auto;
+}
+
+.vc-table-header,
+.vc-table-body,
+.vc-table-footer {
+    /* Native table sections — no structural overrides. */
+}
+
+.vc-table-row[tabindex="0"] {
+    cursor: pointer;
+}
+
+.vc-table-row[tabindex="0"]:focus-visible {
+    outline: 2px solid currentcolor;
+    outline-offset: -2px;
+}
+
+.vc-table-cell,
+.vc-table-head-cell {
+    box-sizing: border-box;
+    text-align: left;
+    vertical-align: middle;
+}
+
+/* Sortable head cells — cursor + alignment for the sort indicator span.
+ * Themes paint the visual sort-state via `aria-sort`. */
+.vc-table-head-cell[role="columnheader"][tabindex="0"] {
+    cursor: pointer;
+    user-select: none;
+}
+
+.vc-table-head-cell-sort-icon {
+    display: inline-block;
+    margin-left: 0.25rem;
+    font-size: 0.75em;
+    line-height: 1;
+    vertical-align: baseline;
+}
+
+/* Loading overlay variant — covers the table area for refresh-feedback
+ * mode without unmounting the existing rows. Theme controls colors. */
+.vc-table-loading-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: auto;
+    z-index: 1;
+}
+
+/* Sticky-column / sticky-header placement. Theme owns the background
+ * + z-index ladder; we set position only. */
+.vc-table-head-cell[data-sticky-column],
+.vc-table-cell[data-sticky-column] {
+    position: sticky;
+    left: 0;
+}

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -2,7 +2,7 @@
     "name": "@vuecs/table",
     "version": "0.0.0",
     "type": "module",
-    "description": "Compound table for vuecs (Table / Header / Body / Footer / Row / Cell / HeadCell / Empty / Loading) + columns/data driver with sortable headers, row-meta variants, and row keyboard navigation. Semantic-HTML on top of reka-ui's Primitive.",
+    "description": "Compound table for vuecs (Table / Header / Body / Footer / Row / Cell / HeadCell / Empty / Loading) + columns/data driver with sortable headers, row-meta variants, and row keyboard navigation. Semantic-HTML compound — no Reka primitive dependency.",
     "exports": {
         "./package.json": "./package.json",
         ".": {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,0 +1,62 @@
+{
+    "name": "@vuecs/table",
+    "version": "0.0.0",
+    "type": "module",
+    "description": "Compound table for vuecs (Table / Header / Body / Footer / Row / Cell / HeadCell / Empty / Loading) + columns/data driver with sortable headers, row-meta variants, and row keyboard navigation. Semantic-HTML on top of reka-ui's Primitive.",
+    "exports": {
+        "./package.json": "./package.json",
+        ".": {
+            "types": "./dist/index.d.ts",
+            "style": "./dist/style.css",
+            "import": "./dist/index.mjs"
+        },
+        "./style.css": "./dist/style.css",
+        "./dist/style.css": "./dist/style.css"
+    },
+    "style": "./dist/style.css",
+    "files": [
+        "dist"
+    ],
+    "keywords": [
+        "vue",
+        "vuecs",
+        "table",
+        "compound",
+        "columns",
+        "sortable"
+    ],
+    "author": {
+        "name": "Peter Placzek",
+        "email": "contact@tada5hi.net",
+        "url": "https://tada5hi.net"
+    },
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/tada5hi/vuecs.git",
+        "directory": "packages/table"
+    },
+    "scripts": {
+        "build:js": "tsdown",
+        "build:types": "vue-tsc --declaration --emitDeclarationOnly -p tsconfig.build.json",
+        "build": "rimraf dist && npm run build:js && npm run build:types",
+        "test": "vitest --config test/vitest.config.ts --run",
+        "test:coverage": "vitest --config test/vitest.config.ts --run --coverage"
+    },
+    "devDependencies": {
+        "@vue/test-utils": "^2.4.10",
+        "@vuecs/core": "^2.0.0",
+        "jsdom": "^29.1.1",
+        "vue": "^3.5.34"
+    },
+    "peerDependencies": {
+        "@vuecs/core": "^2.0.0",
+        "vue": "^3.x"
+    },
+    "engines": {
+        "node": ">=22.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/table/src/components/Table.vue
+++ b/packages/table/src/components/Table.vue
@@ -131,6 +131,8 @@ export default defineComponent({
             emit('row-click', row, index, event);
         };
 
+        const wrapperEl = ref<globalThis.HTMLElement | null>(null);
+
         provideTableContext({
             data: dataRef,
             busy: toRef(props, 'busy'),
@@ -142,6 +144,7 @@ export default defineComponent({
             setFocusedRow,
             colspan,
             emitRowClick,
+            wrapperEl,
         });
 
         const slotProps = computed<TableSlotProps>(() => ({
@@ -152,37 +155,55 @@ export default defineComponent({
             setSort: sortMachine.setSort,
         }));
 
+        const setWrapperRef = (el: unknown) => {
+            wrapperEl.value = (el as globalThis.HTMLElement | null) ?? null;
+        };
+
         return () => {
             const inner: unknown[] = [];
             if (slots.caption) inner.push(h('caption', null, slots.caption() as never));
             if (slots.colgroup) inner.push(h('colgroup', null, slots.colgroup() as never));
             inner.push(slots.default?.(slotProps.value));
 
+            // `attrs` always forward to the `<table>` itself — consumers'
+            // `:class` / `@click` / etc target the same element regardless
+            // of whether `:scrollable` is set.
             const tableNode = h(
                 props.tag,
-                props.scrollable ?
-                    {
-                        class: theme.value.root || undefined,
-                        'aria-busy': props.busy ? 'true' : undefined,
-                    } :
-                    mergeProps(attrs, {
-                        class: theme.value.root || undefined,
-                        'aria-busy': props.busy ? 'true' : undefined,
-                    }),
+                mergeProps(attrs, {
+                    class: theme.value.root || undefined,
+                    'aria-busy': props.busy ? 'true' : undefined,
+                }),
                 inner as never,
             );
 
-            if (!props.scrollable) return tableNode;
+            // Always wrap the `<table>` in a positioned wrapper. This is
+            // the teleport target for `<VCTableLoading :overlay>` — a
+            // `<div>` inside a `<table>` is foster-parented out by the
+            // HTML parser, breaking the overlay; rendering it as a
+            // sibling of the `<table>` (inside this wrapper) keeps the
+            // overlay correctly sized against the table area.
+            const wrapper = h(
+                'div',
+                {
+                    ref: setWrapperRef,
+                    class: 'vc-table-wrapper',
+                    style: { position: 'relative' },
+                },
+                [tableNode],
+            );
+
+            if (!props.scrollable) return wrapper;
 
             return h(
                 'div',
-                mergeProps(attrs, {
+                {
                     class: theme.value.scrollContainer || undefined,
                     style: props.maxHeight ?
                         { maxHeight: props.maxHeight, overflow: 'auto' } :
                         { overflow: 'auto' },
-                }),
-                [tableNode],
+                },
+                [wrapper],
             );
         };
     },

--- a/packages/table/src/components/Table.vue
+++ b/packages/table/src/components/Table.vue
@@ -1,0 +1,190 @@
+<script lang="ts">
+import { 
+    computed, 
+    defineComponent, 
+    h, 
+    mergeProps, 
+    ref, 
+    toRef, 
+    watch, 
+} from 'vue';
+import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
+import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
+import {
+    provideHeadCellCountContext,
+    provideTableContext,
+} from '../composables/context';
+import { useSortMachine } from '../composables/sort';
+import type {
+    SortDirection,
+    TableColumn,
+    TableColumnRaw,
+    TableSlotProps,
+    TableSortState,
+    TableThemeClasses,
+} from '../types';
+import { normalizeColumns } from '../utils/render-utils';
+
+const tableThemeDefaults = {
+    classes: {
+        root: 'vc-table',
+        scrollContainer: 'vc-table-scroll-container',
+    },
+};
+
+const tableProps = {
+    /** Row data array. */
+    data: { type: Array as PropType<unknown[]>, default: () => [] },
+    /** Column definitions (TableColumn or bare-string shorthand). When omitted, columns are derived from `Object.keys(data[0])`. */
+    columns: { type: Array as PropType<TableColumnRaw<unknown>[]>, default: undefined },
+    /** Busy flag — drives `aria-busy` on the `<table>` and gates the loading-band render. */
+    busy: { type: Boolean, default: false },
+    /** Controlled sort state (single column). Use `v-model:sort`. */
+    sort: { type: [Object, null] as PropType<TableSortState>, default: null },
+    /** When `true`, the cycle skips the `null` step: `null → asc → desc → asc`. */
+    mustSort: { type: Boolean, default: false },
+    /** Wrap the `<table>` in an overflow scroll container. */
+    scrollable: { type: Boolean, default: false },
+    /** When `:scrollable`, sticks the `<thead>` to the top of the scroll container. */
+    stickyHeader: { type: Boolean, default: false },
+    /** When `:scrollable`, applied as `max-height` on the scroll container (any CSS length, e.g. `'24rem'`). */
+    maxHeight: { type: String, default: undefined },
+    /** Opt-in row-click affordance — adds `tabindex` + cursor-pointer on every row and emits `@row-click`. */
+    rowClickable: { type: Boolean, default: false },
+    /** Density shorthand for `themeVariant.density`. */
+    density: { type: String as PropType<'compact' | 'normal' | 'spacious'>, default: undefined },
+    /** Alternating row backgrounds — shorthand for `themeVariant.striped`. */
+    striped: { type: Boolean, default: undefined },
+    /** Cell borders — shorthand for `themeVariant.bordered`. */
+    bordered: { type: Boolean, default: undefined },
+    /** Row hover highlight — shorthand for `themeVariant.hover`. */
+    hover: { type: Boolean, default: undefined },
+    /** HTML tag to render. */
+    tag: { type: String, default: 'table' },
+    ...themableProps<TableThemeClasses>(),
+};
+
+export type TableProps = ExtractPublicPropTypes<typeof tableProps>;
+
+export default defineComponent({
+    name: 'VCTable',
+    inheritAttrs: false,
+    props: tableProps,
+    emits: ['update:sort', 'row-click'],
+    slots: Object as SlotsType<{
+        default(props: TableSlotProps): unknown;
+        caption(): unknown;
+        colgroup(): unknown;
+    }>,
+    setup(props, {
+        attrs, 
+        slots, 
+        emit, 
+    }) {
+        const themeProps = useThemeProps(
+            props,
+            'density',
+            'striped',
+            'bordered',
+            'hover',
+            'stickyHeader',
+        );
+        const theme = useComponentTheme('table', themeProps, tableThemeDefaults);
+
+        const dataRef = toRef(props, 'data');
+        const rawColumns = toRef(props, 'columns');
+        const columns = computed<TableColumn<unknown>[]>(
+            () => normalizeColumns(rawColumns.value, dataRef.value),
+        );
+
+        const sortSource = toRef(props, 'sort');
+        const mustSortRef = toRef(props, 'mustSort');
+        const sortMachine = useSortMachine({
+            source: sortSource,
+            columns,
+            mustSort: mustSortRef,
+            emit: (next) => emit('update:sort', next),
+        });
+
+        // D3 — Shape B colspan auto-counting from <VCTableHeadCell> siblings
+        // that register via context. Shape A overrides via `columns.length`.
+        const childCellCount = ref(0);
+        provideHeadCellCountContext({
+            register: () => { childCellCount.value += 1; },
+            unregister: () => { childCellCount.value = Math.max(0, childCellCount.value - 1); },
+        });
+        const colspan = computed(() => {
+            if (columns.value.length > 0) return columns.value.length;
+            return Math.max(1, childCellCount.value);
+        });
+        watch(
+            () => columns.value.length > 0,
+            (hasColumns) => {
+                if (hasColumns) childCellCount.value = 0;
+            },
+        );
+
+        const focusedRow = ref<number | null>(null);
+        const setFocusedRow = (index: number | null) => { focusedRow.value = index; };
+
+        const emitRowClick = (row: unknown, index: number, event: Event) => {
+            emit('row-click', row, index, event);
+        };
+
+        provideTableContext({
+            data: dataRef,
+            busy: toRef(props, 'busy'),
+            columns,
+            sort: sortMachine.state,
+            setSort: (key: string, direction?: SortDirection) => sortMachine.setSort(key, direction),
+            rowClickable: toRef(props, 'rowClickable'),
+            focusedRow,
+            setFocusedRow,
+            colspan,
+            emitRowClick,
+        });
+
+        const slotProps = computed<TableSlotProps>(() => ({
+            data: dataRef.value as unknown[],
+            busy: props.busy,
+            columns: columns.value,
+            sort: sortMachine.state.value,
+            setSort: sortMachine.setSort,
+        }));
+
+        return () => {
+            const inner: unknown[] = [];
+            if (slots.caption) inner.push(h('caption', null, slots.caption() as never));
+            if (slots.colgroup) inner.push(h('colgroup', null, slots.colgroup() as never));
+            inner.push(slots.default?.(slotProps.value));
+
+            const tableNode = h(
+                props.tag,
+                props.scrollable ?
+                    {
+                        class: theme.value.root || undefined,
+                        'aria-busy': props.busy ? 'true' : undefined,
+                    } :
+                    mergeProps(attrs, {
+                        class: theme.value.root || undefined,
+                        'aria-busy': props.busy ? 'true' : undefined,
+                    }),
+                inner as never,
+            );
+
+            if (!props.scrollable) return tableNode;
+
+            return h(
+                'div',
+                mergeProps(attrs, {
+                    class: theme.value.scrollContainer || undefined,
+                    style: props.maxHeight ?
+                        { maxHeight: props.maxHeight, overflow: 'auto' } :
+                        { overflow: 'auto' },
+                }),
+                [tableNode],
+            );
+        };
+    },
+});
+</script>

--- a/packages/table/src/components/TableBody.vue
+++ b/packages/table/src/components/TableBody.vue
@@ -28,21 +28,23 @@ export default defineComponent({
         const ctx = useTable();
 
         return () => {
-            // Render condition: only when there's data. Empty / Loading
-            // sit as siblings under `<VCTable>` and render based on their
-            // own predicates — they don't share the body's `<tbody>`.
-            // Decoupled per plan 028 D1 / D6.
-            const data = ctx?.data.value ?? [];
-            if (data.length === 0) return null;
-
             const rowSlot = slots.row;
+            const data = ctx?.data.value ?? [];
 
             let children: unknown[];
             if (rowSlot) {
+                // Driver path — auto-iterate `<VCTable>` data. Suppress
+                // the entire `<tbody>` when there's nothing to render so
+                // `<VCTableEmpty>` / `<VCTableLoading>` get the spotlight
+                // (decoupled render conditions per the compound layout).
+                if (data.length === 0) return null;
                 children = data.map((row, index) => rowSlot({ row, index } as TableBodyRowSlotProps));
             } else {
-                // Default slot fallback — consumers writing Shape B manual
-                // markup put their `<VCTableRow>` chain directly inside.
+                // Manual Shape B markup — consumers writing their own
+                // `<VCTableRow>` chain inside the default slot drive the
+                // content directly. Render whatever they wrote, even if
+                // `ctx.data` is empty (their markup might not depend on
+                // it).
                 children = [slots.default?.() ?? null];
             }
 

--- a/packages/table/src/components/TableBody.vue
+++ b/packages/table/src/components/TableBody.vue
@@ -1,0 +1,57 @@
+<script lang="ts">
+import { defineComponent, h, mergeProps } from 'vue';
+import type { ExtractPublicPropTypes, SlotsType } from 'vue';
+import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
+import { useTable } from '../composables/context';
+import type { TableBodyRowSlotProps, TableBodyThemeClasses } from '../types';
+
+const tableBodyThemeDefaults = { classes: { root: 'vc-table-body' } };
+
+const tableBodyProps = { ...themableProps<TableBodyThemeClasses>() };
+
+export type TableBodyProps = ExtractPublicPropTypes<typeof tableBodyProps>;
+
+export default defineComponent({
+    name: 'VCTableBody',
+    inheritAttrs: false,
+    props: tableBodyProps,
+    slots: Object as SlotsType<{
+        row(props: TableBodyRowSlotProps): unknown;
+        default(): unknown;
+    }>,
+    setup(props, { attrs, slots }) {
+        const theme = useComponentTheme(
+            'tableBody',
+            useThemeProps(props),
+            tableBodyThemeDefaults,
+        );
+        const ctx = useTable();
+
+        return () => {
+            // Render condition: only when there's data. Empty / Loading
+            // sit as siblings under `<VCTable>` and render based on their
+            // own predicates — they don't share the body's `<tbody>`.
+            // Decoupled per plan 028 D1 / D6.
+            const data = ctx?.data.value ?? [];
+            if (data.length === 0) return null;
+
+            const rowSlot = slots.row;
+
+            let children: unknown[];
+            if (rowSlot) {
+                children = data.map((row, index) => rowSlot({ row, index } as TableBodyRowSlotProps));
+            } else {
+                // Default slot fallback — consumers writing Shape B manual
+                // markup put their `<VCTableRow>` chain directly inside.
+                children = [slots.default?.() ?? null];
+            }
+
+            return h(
+                'tbody',
+                mergeProps(attrs, { class: theme.value.root || undefined }),
+                children as never,
+            );
+        };
+    },
+});
+</script>

--- a/packages/table/src/components/TableCell.vue
+++ b/packages/table/src/components/TableCell.vue
@@ -1,0 +1,60 @@
+<script lang="ts">
+import { defineComponent, h, mergeProps } from 'vue';
+import type { ExtractPublicPropTypes, PropType } from 'vue';
+import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
+import { useTableRow } from '../composables/context';
+import type { TableCellThemeClasses } from '../types';
+
+const tableCellThemeDefaults = { classes: { root: 'vc-table-cell' } };
+
+const tableCellProps = {
+    /** Render as `<th scope="row">` instead of `<td>` (mirror of `column.isRowHeader`). */
+    isRowHeader: { type: Boolean, default: false },
+    /** Column key this cell corresponds to — used to resolve `_cellVariants[key]` from row meta. */
+    columnKey: { type: String, default: undefined },
+    /** Forward-compat for stacked-mode CSS — emitted as `data-label`. */
+    dataLabel: { type: String, default: undefined },
+    /** Alignment helper — selects the `align.<value>` theme variant. */
+    align: { type: String as PropType<'left' | 'center' | 'right'>, default: undefined },
+    /** `position: sticky` on this cell. Forwarded as `themeVariant.stickyColumn`. */
+    stickyColumn: { type: Boolean, default: undefined },
+    ...themableProps<TableCellThemeClasses>(),
+};
+
+export type TableCellProps = ExtractPublicPropTypes<typeof tableCellProps>;
+
+export default defineComponent({
+    name: 'VCTableCell',
+    inheritAttrs: false,
+    props: tableCellProps,
+    setup(props, { attrs, slots }) {
+        const rowCtx = useTableRow();
+        const themeProps = useThemeProps(props, 'align', 'stickyColumn');
+
+        const mergedThemeProps = {
+            get themeClass() { return themeProps.themeClass; },
+            get themeVariant() {
+                const cellVariant = props.columnKey ?
+                    rowCtx?.cellVariants.value[props.columnKey] ?? undefined :
+                    undefined;
+                return {
+                    ...(themeProps.themeVariant ?? {}),
+                    ...(cellVariant ? { cellVariant } : {}),
+                };
+            },
+        };
+        const theme = useComponentTheme('tableCell', mergedThemeProps, tableCellThemeDefaults);
+
+        return () => h(
+            props.isRowHeader ? 'th' : 'td',
+            mergeProps(attrs, {
+                class: theme.value.root || undefined,
+                'data-label': props.dataLabel || undefined,
+                'data-sticky-column': props.stickyColumn ? '' : undefined,
+                scope: props.isRowHeader ? 'row' : undefined,
+            }),
+            slots.default?.(),
+        );
+    },
+});
+</script>

--- a/packages/table/src/components/TableEmpty.vue
+++ b/packages/table/src/components/TableEmpty.vue
@@ -1,0 +1,88 @@
+<script lang="ts">
+import { 
+    computed, 
+    defineComponent, 
+    h, 
+    mergeProps, 
+} from 'vue';
+import type { ExtractPublicPropTypes } from 'vue';
+import {
+    themableProps,
+    useComponentDefaults,
+    useComponentTheme,
+    useThemeProps,
+} from '@vuecs/core';
+import { useTable } from '../composables/context';
+import type { TableEmptyThemeClasses } from '../types';
+
+const tableEmptyThemeDefaults = { classes: { root: 'vc-table-empty' } };
+
+const behavioralDefaults = {
+    content: 'No results.',
+    filteredContent: 'No matches.',
+};
+
+const tableEmptyProps = {
+    /** Override the auto-derived `colspan`. When omitted, uses the table's resolved colspan. */
+    colspan: { type: Number, default: undefined },
+    /** Mark this as the empty-after-filter case (distinct copy / icon vs empty-no-data). */
+    filtered: { type: Boolean, default: false },
+    /** Override the rendered text. Falls back to global defaults / hardcoded. */
+    content: { type: String, default: undefined },
+    /** Override the rendered text for the filtered case. */
+    filteredContent: { type: String, default: undefined },
+    ...themableProps<TableEmptyThemeClasses>(),
+};
+
+export type TableEmptyProps = ExtractPublicPropTypes<typeof tableEmptyProps>;
+
+export default defineComponent({
+    name: 'VCTableEmpty',
+    inheritAttrs: false,
+    props: tableEmptyProps,
+    setup(props, { attrs, slots }) {
+        const ctx = useTable();
+        const defaults = useComponentDefaults('tableEmpty', props, behavioralDefaults);
+
+        const themeProps = useThemeProps(props);
+        const mergedThemeProps = {
+            get themeClass() { return themeProps.themeClass; },
+            get themeVariant() {
+                return {
+                    ...(themeProps.themeVariant ?? {}),
+                    filtered: props.filtered,
+                };
+            },
+        };
+        const theme = useComponentTheme('tableEmpty', mergedThemeProps, tableEmptyThemeDefaults);
+
+        const shouldRender = computed(() => {
+            // Empty band renders only when there's no data AND we're not busy
+            // (busy + no-data is the loading-band's first-load case).
+            if (!ctx) return true;
+            return ctx.data.value.length === 0 && !ctx.busy.value;
+        });
+
+        const resolvedColspan = computed(() => props.colspan ?? ctx?.colspan.value ?? 1);
+
+        return () => {
+            if (!shouldRender.value) return null;
+            const cellContent = slots.default?.() ??
+                (props.filtered ? defaults.value.filteredContent : defaults.value.content);
+            return h(
+                'tbody',
+                mergeProps(attrs, {
+                    class: theme.value.root || undefined,
+                    role: 'alert',
+                    'aria-live': 'polite',
+                }),
+                [
+                    h('tr', null, [
+                        h('td', { colspan: resolvedColspan.value }, cellContent as never),
+                    ]),
+                ],
+            );
+        };
+    },
+});
+</script>

--- a/packages/table/src/components/TableEmpty.vue
+++ b/packages/table/src/components/TableEmpty.vue
@@ -69,16 +69,21 @@ export default defineComponent({
             if (!shouldRender.value) return null;
             const cellContent = slots.default?.() ??
                 (props.filtered ? defaults.value.filteredContent : defaults.value.content);
+            // ARIA live-region attributes (`role`, `aria-live`) do NOT
+            // belong on `<tbody>` — they override the native `rowgroup`
+            // semantics and break table-structure recognition for
+            // assistive tech. The live region lives inside the `<td>`
+            // as a wrapper `<div>` instead, where it announces the
+            // empty-state message without corrupting the table's
+            // accessibility tree.
             return h(
                 'tbody',
-                mergeProps(attrs, {
-                    class: theme.value.root || undefined,
-                    role: 'alert',
-                    'aria-live': 'polite',
-                }),
+                mergeProps(attrs, { class: theme.value.root || undefined }),
                 [
                     h('tr', null, [
-                        h('td', { colspan: resolvedColspan.value }, cellContent as never),
+                        h('td', { colspan: resolvedColspan.value }, [
+                            h('div', { role: 'status', 'aria-live': 'polite' }, cellContent as never),
+                        ]),
                     ]),
                 ],
             );

--- a/packages/table/src/components/TableFooter.vue
+++ b/packages/table/src/components/TableFooter.vue
@@ -1,0 +1,37 @@
+<script lang="ts">
+import { defineComponent, h, mergeProps } from 'vue';
+import type { ExtractPublicPropTypes } from 'vue';
+import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
+import { provideHeadCellCountContext } from '../composables/context';
+import type { TableFooterThemeClasses } from '../types';
+
+const tableFooterThemeDefaults = { classes: { root: 'vc-table-footer' } };
+
+const tableFooterProps = { ...themableProps<TableFooterThemeClasses>() };
+
+export type TableFooterProps = ExtractPublicPropTypes<typeof tableFooterProps>;
+
+export default defineComponent({
+    name: 'VCTableFooter',
+    inheritAttrs: false,
+    props: tableFooterProps,
+    setup(props, { attrs, slots }) {
+        const theme = useComponentTheme(
+            'tableFooter',
+            useThemeProps(props),
+            tableFooterThemeDefaults,
+        );
+
+        // Provide a no-op head-cell-count context so `<VCTableHeadCell>`s
+        // inside `<tfoot>` don't double-register against the colspan auto-count
+        // (which is meant to reflect the header band, not the footer band).
+        provideHeadCellCountContext({ register: () => {}, unregister: () => {} });
+
+        return () => h(
+            'tfoot',
+            mergeProps(attrs, { class: theme.value.root || undefined }),
+            slots.default?.(),
+        );
+    },
+});
+</script>

--- a/packages/table/src/components/TableHeadCell.vue
+++ b/packages/table/src/components/TableHeadCell.vue
@@ -1,0 +1,140 @@
+<script lang="ts">
+import { 
+    computed, 
+    defineComponent, 
+    h, 
+    mergeProps, 
+    onBeforeUnmount, 
+    onMounted, 
+} from 'vue';
+import type { ExtractPublicPropTypes, PropType } from 'vue';
+import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
+import { useHeadCellCountContext, useTable } from '../composables/context';
+import type { SortDirection, TableHeadCellThemeClasses } from '../types';
+
+const tableHeadCellThemeDefaults = {
+    classes: {
+        root: 'vc-table-head-cell',
+        sortIcon: 'vc-table-head-cell-sort-icon',
+    },
+};
+
+const tableHeadCellProps = {
+    /** Column key — required for sort wiring (omit for purely presentational heads). */
+    columnKey: { type: String, default: undefined },
+    /** Mark this header sortable. When set, click + Enter/Space cycle sort state. */
+    sortable: { type: Boolean, default: false },
+    /** Override scope ("col" / "colgroup" / "row" / "rowgroup"). Smart default: colspan→colgroup, rowspan→rowgroup, else col. */
+    scope: { type: String as PropType<'col' | 'colgroup' | 'row' | 'rowgroup'>, default: undefined },
+    /** Native `<th colspan>` (forwarded; also drives the smart scope default). */
+    colspan: { type: Number, default: undefined },
+    /** Native `<th rowspan>` (forwarded; also drives the smart scope default). */
+    rowspan: { type: Number, default: undefined },
+    /** Native `<th title>`. */
+    title: { type: String, default: undefined },
+    /** Native `<th abbr>`. */
+    abbr: { type: String, default: undefined },
+    /** Alignment helper — selects the `align.<value>` theme variant. */
+    align: { type: String as PropType<'left' | 'center' | 'right'>, default: undefined },
+    /** `position: sticky` on this header cell. Forwarded as `themeVariant.stickyColumn`. */
+    stickyColumn: { type: Boolean, default: undefined },
+    ...themableProps<TableHeadCellThemeClasses>(),
+};
+
+export type TableHeadCellProps = ExtractPublicPropTypes<typeof tableHeadCellProps>;
+
+export default defineComponent({
+    name: 'VCTableHeadCell',
+    inheritAttrs: false,
+    props: tableHeadCellProps,
+    setup(props, { attrs, slots }) {
+        const ctx = useTable();
+
+        // Register against the head-cell-count context so Shape B
+        // (manual <VCTableHeader>) can auto-resolve the empty / loading
+        // colspan. The `<VCTableFooter>` provides a no-op variant, so
+        // cells in the footer skip this.
+        const countCtx = useHeadCellCountContext();
+        onMounted(() => countCtx?.register());
+        onBeforeUnmount(() => countCtx?.unregister());
+
+        // Theme — fold sorted state + stickyColumn into themeVariant
+        const themeProps = useThemeProps(props, 'align', 'stickyColumn');
+        const sortDirection = computed<SortDirection | null>(() => {
+            if (!props.sortable || !props.columnKey || !ctx) return null;
+            const s = ctx.sort.value;
+            return s && s.key === props.columnKey ? s.direction : null;
+        });
+
+        const mergedThemeProps = {
+            get themeClass() { return themeProps.themeClass; },
+            get themeVariant() {
+                return {
+                    ...(themeProps.themeVariant ?? {}),
+                    sorted: sortDirection.value ?? 'none',
+                };
+            },
+        };
+        const theme = useComponentTheme('tableHeadCell', mergedThemeProps, tableHeadCellThemeDefaults);
+
+        // Smart scope default — col / colgroup / rowgroup per the multi-axis
+        // span hints. Consumers can still override via `:scope`.
+        const resolvedScope = computed(() => {
+            if (props.scope) return props.scope;
+            if (props.colspan && props.colspan > 1) return 'colgroup';
+            if (props.rowspan && props.rowspan > 1) return 'rowgroup';
+            return 'col';
+        });
+
+        const ariaSort = computed(() => {
+            if (!props.sortable) return undefined;
+            const d = sortDirection.value;
+            if (d === 'asc') return 'ascending';
+            if (d === 'desc') return 'descending';
+            return 'none';
+        });
+
+        function onClick(event: globalThis.MouseEvent) {
+            if (!props.sortable || !props.columnKey) return;
+            event.preventDefault();
+            ctx?.setSort(props.columnKey);
+        }
+
+        function onKeydown(event: globalThis.KeyboardEvent) {
+            if (!props.sortable || !props.columnKey) return;
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                ctx?.setSort(props.columnKey);
+            }
+        }
+
+        return () => h(
+            'th',
+            mergeProps(attrs, {
+                class: theme.value.root || undefined,
+                scope: resolvedScope.value,
+                'data-sticky-column': props.stickyColumn ? '' : undefined,
+                colspan: props.colspan,
+                rowspan: props.rowspan,
+                title: props.title,
+                abbr: props.abbr,
+                'aria-sort': ariaSort.value,
+                tabindex: props.sortable ? 0 : undefined,
+                role: props.sortable ? 'columnheader' : undefined,
+                onClick: props.sortable ? onClick : undefined,
+                onKeydown: props.sortable ? onKeydown : undefined,
+            }),
+            [
+                slots.default?.(),
+                props.sortable && sortDirection.value ?
+                    h('span', {
+                        class: theme.value.sortIcon || undefined,
+                        'aria-hidden': 'true',
+                        'data-sort': sortDirection.value,
+                    }, sortDirection.value === 'asc' ? '↑' : '↓') :
+                    null,
+            ],
+        );
+    },
+});
+</script>

--- a/packages/table/src/components/TableHeader.vue
+++ b/packages/table/src/components/TableHeader.vue
@@ -1,0 +1,30 @@
+<script lang="ts">
+import { defineComponent, h, mergeProps } from 'vue';
+import type { ExtractPublicPropTypes } from 'vue';
+import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
+import type { TableHeaderThemeClasses } from '../types';
+
+const tableHeaderThemeDefaults = { classes: { root: 'vc-table-header' } };
+
+const tableHeaderProps = { ...themableProps<TableHeaderThemeClasses>() };
+
+export type TableHeaderProps = ExtractPublicPropTypes<typeof tableHeaderProps>;
+
+export default defineComponent({
+    name: 'VCTableHeader',
+    inheritAttrs: false,
+    props: tableHeaderProps,
+    setup(props, { attrs, slots }) {
+        const theme = useComponentTheme(
+            'tableHeader',
+            useThemeProps(props),
+            tableHeaderThemeDefaults,
+        );
+        return () => h(
+            'thead',
+            mergeProps(attrs, { class: theme.value.root || undefined }),
+            slots.default?.(),
+        );
+    },
+});
+</script>

--- a/packages/table/src/components/TableLoading.vue
+++ b/packages/table/src/components/TableLoading.vue
@@ -1,9 +1,10 @@
 <script lang="ts">
-import { 
-    computed, 
-    defineComponent, 
-    h, 
-    mergeProps, 
+import {
+    Teleport,
+    computed,
+    defineComponent,
+    h,
+    mergeProps,
 } from 'vue';
 import type { ExtractPublicPropTypes } from 'vue';
 import {
@@ -67,7 +68,15 @@ export default defineComponent({
             const cellContent = slots.default?.() ?? defaults.value.content;
 
             if (props.overlay) {
-                return h(
+                // Teleport the overlay into `<VCTable>`'s positioned
+                // wrapper. Rendering a `<div>` directly as a child of the
+                // `<table>` is invalid HTML — the parser foster-parents
+                // it OUT of the table, breaking the intended absolute
+                // positioning. The wrapper is a sibling-of-`<table>`
+                // `<div style="position:relative">` provided by
+                // `<VCTable>`. If we're rendered outside `<VCTable>` (no
+                // ctx, no wrapper), fall back to rendering inline.
+                const overlayNode = h(
                     'div',
                     mergeProps(attrs, {
                         class: [theme.value.root || undefined, theme.value.overlay || undefined],
@@ -77,19 +86,33 @@ export default defineComponent({
                     }),
                     cellContent as never,
                 );
+                if (ctx?.wrapperEl.value) {
+                    return h(Teleport, { to: ctx.wrapperEl.value }, [overlayNode]);
+                }
+                return overlayNode;
             }
 
+            // ARIA live-region attributes (`role`, `aria-live`,
+            // `aria-busy`) do NOT belong on `<tbody>` — they override
+            // the native `rowgroup` semantics and break table-structure
+            // recognition for AT. Wrap the cell content in a `<div>`
+            // that carries the live region instead.
             return h(
                 'tbody',
-                mergeProps(attrs, {
-                    class: theme.value.root || undefined,
-                    role: 'status',
-                    'aria-live': 'polite',
-                    'aria-busy': 'true',
-                }),
+                mergeProps(attrs, { class: theme.value.root || undefined }),
                 [
                     h('tr', null, [
-                        h('td', { colspan: resolvedColspan.value }, cellContent as never),
+                        h('td', { colspan: resolvedColspan.value }, [
+                            h(
+                                'div',
+                                {
+                                    role: 'status',
+                                    'aria-live': 'polite',
+                                    'aria-busy': 'true',
+                                },
+                                cellContent as never,
+                            ),
+                        ]),
                     ]),
                 ],
             );

--- a/packages/table/src/components/TableLoading.vue
+++ b/packages/table/src/components/TableLoading.vue
@@ -1,0 +1,99 @@
+<script lang="ts">
+import { 
+    computed, 
+    defineComponent, 
+    h, 
+    mergeProps, 
+} from 'vue';
+import type { ExtractPublicPropTypes } from 'vue';
+import {
+    themableProps,
+    useComponentDefaults,
+    useComponentTheme,
+    useThemeProps,
+} from '@vuecs/core';
+import { useTable } from '../composables/context';
+import type { TableLoadingThemeClasses } from '../types';
+
+const tableLoadingThemeDefaults = { classes: { root: 'vc-table-loading', overlay: 'vc-table-loading-overlay' } };
+
+const behavioralDefaults = { content: 'Loading…' };
+
+const tableLoadingProps = {
+    /** Override the auto-derived `colspan` (default mode only — ignored in overlay mode). */
+    colspan: { type: Number, default: undefined },
+    /** Render as a positioned overlay on top of the existing `<tbody>` (refresh feedback). Default mode is a centered tbody/tr/td placeholder. */
+    overlay: { type: Boolean, default: false },
+    /** Override the rendered text. Falls back to global defaults. */
+    content: { type: String, default: undefined },
+    ...themableProps<TableLoadingThemeClasses>(),
+};
+
+export type TableLoadingProps = ExtractPublicPropTypes<typeof tableLoadingProps>;
+
+export default defineComponent({
+    name: 'VCTableLoading',
+    inheritAttrs: false,
+    props: tableLoadingProps,
+    setup(props, { attrs, slots }) {
+        const ctx = useTable();
+        const defaults = useComponentDefaults('tableLoading', props, behavioralDefaults);
+
+        const themeProps = useThemeProps(props);
+        const mergedThemeProps = {
+            get themeClass() { return themeProps.themeClass; },
+            get themeVariant() {
+                return {
+                    ...(themeProps.themeVariant ?? {}),
+                    overlay: props.overlay,
+                };
+            },
+        };
+        const theme = useComponentTheme('tableLoading', mergedThemeProps, tableLoadingThemeDefaults);
+
+        const shouldRender = computed(() => {
+            if (!ctx) return true;
+            const busy = ctx.busy.value;
+            const hasData = ctx.data.value.length > 0;
+            // Default mode: render on first load (busy + no data).
+            // Overlay mode: render whenever busy (refresh-on-existing-data pattern).
+            return props.overlay ? busy : busy && !hasData;
+        });
+
+        const resolvedColspan = computed(() => props.colspan ?? ctx?.colspan.value ?? 1);
+
+        return () => {
+            if (!shouldRender.value) return null;
+            const cellContent = slots.default?.() ?? defaults.value.content;
+
+            if (props.overlay) {
+                return h(
+                    'div',
+                    mergeProps(attrs, {
+                        class: [theme.value.root || undefined, theme.value.overlay || undefined],
+                        role: 'status',
+                        'aria-live': 'polite',
+                        'aria-busy': 'true',
+                    }),
+                    cellContent as never,
+                );
+            }
+
+            return h(
+                'tbody',
+                mergeProps(attrs, {
+                    class: theme.value.root || undefined,
+                    role: 'status',
+                    'aria-live': 'polite',
+                    'aria-busy': 'true',
+                }),
+                [
+                    h('tr', null, [
+                        h('td', { colspan: resolvedColspan.value }, cellContent as never),
+                    ]),
+                ],
+            );
+        };
+    },
+});
+</script>

--- a/packages/table/src/components/TableRow.vue
+++ b/packages/table/src/components/TableRow.vue
@@ -1,0 +1,146 @@
+<script lang="ts">
+import { 
+    computed, 
+    defineComponent, 
+    h, 
+    mergeProps, 
+    toRef, 
+} from 'vue';
+import type { ExtractPublicPropTypes, PropType } from 'vue';
+import { 
+    isObject, 
+    themableProps, 
+    useComponentTheme, 
+    useThemeProps, 
+} from '@vuecs/core';
+import { provideTableRowContext, useTable } from '../composables/context';
+import type { TableRowThemeClasses } from '../types';
+import { filterRowClickEvent } from '../utils/render-utils';
+
+const tableRowThemeDefaults = { classes: { root: 'vc-table-row' } };
+
+const tableRowProps = {
+    /** Current row data — used to resolve `_rowVariant` / `_cellVariants` and to emit `@row-click`. */
+    row: { type: null as unknown as PropType<unknown>, default: undefined },
+    /** Row index — used by row keyboard navigation + focused-row tracking. */
+    index: { type: Number, default: undefined },
+    /** Mark the row disabled — forwarded to `themeVariant.disabled`. */
+    disabled: { type: Boolean, default: undefined },
+    /** Mark the row selected — forwarded to `themeVariant.selected`. */
+    selected: { type: Boolean, default: undefined },
+    ...themableProps<TableRowThemeClasses>(),
+};
+
+export type TableRowProps = ExtractPublicPropTypes<typeof tableRowProps>;
+
+export default defineComponent({
+    name: 'VCTableRow',
+    inheritAttrs: false,
+    props: tableRowProps,
+    setup(props, { attrs, slots }) {
+        const ctx = useTable();
+
+        // Resolve row-meta variants from the row payload.
+        const rowVariant = computed<string | null>(() => {
+            if (!isObject(props.row)) return null;
+            const v = (props.row as Record<string, unknown>)._rowVariant;
+            return typeof v === 'string' ? v : null;
+        });
+        const cellVariants = computed<Record<string, string>>(() => {
+            if (!isObject(props.row)) return {};
+            const v = (props.row as Record<string, unknown>)._cellVariants;
+            return isObject(v) ? (v as Record<string, string>) : {};
+        });
+        const focused = computed(() => {
+            if (props.index === undefined) return false;
+            return ctx?.focusedRow.value === props.index;
+        });
+
+        // Theme — fold row-meta variant + per-row flags into themeVariant
+        const themeProps = useThemeProps(props, 'disabled', 'selected');
+        const mergedThemeProps = {
+            get themeClass() { return themeProps.themeClass; },
+            get themeVariant() {
+                return {
+                    ...(themeProps.themeVariant ?? {}),
+                    ...(rowVariant.value ? { rowVariant: rowVariant.value } : {}),
+                    focused: focused.value,
+                };
+            },
+        };
+        const theme = useComponentTheme('tableRow', mergedThemeProps, tableRowThemeDefaults);
+
+        // Provide row context for child cells (needed for cellVariants resolution).
+        if (props.index !== undefined) {
+            provideTableRowContext({
+                row: toRef(props, 'row'),
+                index: toRef(props, 'index') as unknown as import('vue').Ref<number>,
+                rowVariant,
+                cellVariants,
+                focused,
+            });
+        }
+
+        const isClickable = computed(() => ctx?.rowClickable.value && props.index !== undefined && !props.disabled);
+
+        function onClick(event: globalThis.MouseEvent) {
+            if (!isClickable.value) return;
+            if (filterRowClickEvent(event)) return;
+            if (props.index === undefined) return;
+            ctx?.setFocusedRow(props.index);
+            ctx?.emitRowClick(props.row, props.index, event);
+        }
+
+        function onKeydown(event: globalThis.KeyboardEvent) {
+            if (!isClickable.value || props.index === undefined) return;
+            const total = ctx?.data.value.length ?? 0;
+            const i = props.index;
+            const move = (target: number) => {
+                event.preventDefault();
+                const clamped = Math.max(0, Math.min(total - 1, target));
+                ctx?.setFocusedRow(clamped);
+                // Focus the next/prev row's DOM element.
+                const tr = event.currentTarget as globalThis.HTMLElement | null;
+                if (!tr) return;
+                const direction = clamped > i ? 'nextElementSibling' : 'previousElementSibling';
+                let sibling: globalThis.Element | null = tr;
+                const steps = Math.abs(clamped - i);
+                for (let s = 0; s < steps; s += 1) {
+                    sibling = sibling ? sibling[direction] : null;
+                }
+                if (sibling instanceof globalThis.HTMLElement) sibling.focus();
+            };
+            if (event.key === 'ArrowDown') {
+                move(event.shiftKey ? total - 1 : i + 1);
+            } else if (event.key === 'ArrowUp') {
+                move(event.shiftKey ? 0 : i - 1);
+            } else if (event.key === 'Home') {
+                move(0);
+            } else if (event.key === 'End') {
+                move(total - 1);
+            } else if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                ctx?.emitRowClick(props.row, i, event);
+            }
+        }
+
+        function onFocus() {
+            if (!isClickable.value || props.index === undefined) return;
+            ctx?.setFocusedRow(props.index);
+        }
+
+        return () => h(
+            'tr',
+            mergeProps(attrs, {
+                class: theme.value.root || undefined,
+                tabindex: isClickable.value ? 0 : undefined,
+                'data-row-variant': rowVariant.value || undefined,
+                onClick: isClickable.value ? onClick : undefined,
+                onKeydown: isClickable.value ? onKeydown : undefined,
+                onFocus: isClickable.value ? onFocus : undefined,
+            }),
+            slots.default?.(),
+        );
+    },
+});
+</script>

--- a/packages/table/src/components/TableRow.vue
+++ b/packages/table/src/components/TableRow.vue
@@ -85,7 +85,8 @@ export default defineComponent({
 
         function onClick(event: globalThis.MouseEvent) {
             if (!isClickable.value) return;
-            if (filterRowClickEvent(event)) return;
+            const rowEl = event.currentTarget as globalThis.Element | null;
+            if (filterRowClickEvent(event, rowEl)) return;
             if (props.index === undefined) return;
             ctx?.setFocusedRow(props.index);
             ctx?.emitRowClick(props.row, props.index, event);

--- a/packages/table/src/components/index.ts
+++ b/packages/table/src/components/index.ts
@@ -1,0 +1,19 @@
+export { default as VCTable } from './Table.vue';
+export { default as VCTableHeader } from './TableHeader.vue';
+export { default as VCTableBody } from './TableBody.vue';
+export { default as VCTableFooter } from './TableFooter.vue';
+export { default as VCTableRow } from './TableRow.vue';
+export { default as VCTableCell } from './TableCell.vue';
+export { default as VCTableHeadCell } from './TableHeadCell.vue';
+export { default as VCTableEmpty } from './TableEmpty.vue';
+export { default as VCTableLoading } from './TableLoading.vue';
+
+export type { TableProps } from './Table.vue';
+export type { TableHeaderProps } from './TableHeader.vue';
+export type { TableBodyProps } from './TableBody.vue';
+export type { TableFooterProps } from './TableFooter.vue';
+export type { TableRowProps } from './TableRow.vue';
+export type { TableCellProps } from './TableCell.vue';
+export type { TableHeadCellProps } from './TableHeadCell.vue';
+export type { TableEmptyProps } from './TableEmpty.vue';
+export type { TableLoadingProps } from './TableLoading.vue';

--- a/packages/table/src/composables/context.ts
+++ b/packages/table/src/composables/context.ts
@@ -1,0 +1,85 @@
+import type { InjectionKey, Ref } from 'vue';
+import { inject, provide } from 'vue';
+import type {
+    SortDirection,
+    TableColumn,
+    TableSortState,
+} from '../types';
+
+// ──────────────────────────────────────────────────────────────────────────
+// Table-scope context (provided by <VCTable>, consumed by every descendant)
+// ──────────────────────────────────────────────────────────────────────────
+
+export type TableContext<Row = unknown> = {
+    data: Ref<Row[]>;
+    busy: Ref<boolean>;
+    columns: Ref<TableColumn<Row>[]>;
+    sort: Ref<TableSortState>;
+    setSort: (key: string, direction?: SortDirection) => void;
+    /** Whether `<VCTable>` was passed `:rowClickable`. */
+    rowClickable: Ref<boolean>;
+    /** Currently focused row index (row keyboard nav). `null` when nothing focused. */
+    focusedRow: Ref<number | null>;
+    setFocusedRow: (index: number | null) => void;
+    /** Resolved colspan (Shape A: `columns.length`; Shape B: auto-counted from `<VCTableHeadCell>` siblings). */
+    colspan: Ref<number>;
+    /** Emit a `row-click` event from inside a body row. */
+    emitRowClick: (row: Row, index: number, event: Event) => void;
+};
+
+const TABLE_CONTEXT_KEY: InjectionKey<TableContext<unknown>> = Symbol('vcTableContext');
+
+export function provideTableContext<Row>(ctx: TableContext<Row>): void {
+    provide(TABLE_CONTEXT_KEY, ctx as TableContext<unknown>);
+}
+
+export function useTable<Row = unknown>(): TableContext<Row> | null {
+    return inject(TABLE_CONTEXT_KEY, null) as TableContext<Row> | null;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Row-scope context (provided by <VCTableRow> inside <VCTableBody>'s iteration)
+// ──────────────────────────────────────────────────────────────────────────
+
+export type TableRowContext<Row = unknown> = {
+    row: Ref<Row>;
+    index: Ref<number>;
+    /** Resolved row-level variant from `row._rowVariant`. */
+    rowVariant: Ref<string | null>;
+    /** Resolved per-cell variants from `row._cellVariants`. */
+    cellVariants: Ref<Record<string, string>>;
+    /** `true` when `useTable().focusedRow === index`. */
+    focused: Ref<boolean>;
+};
+
+const TABLE_ROW_CONTEXT_KEY: InjectionKey<TableRowContext<unknown>> = Symbol('vcTableRowContext');
+
+export function provideTableRowContext<Row>(ctx: TableRowContext<Row>): void {
+    provide(TABLE_ROW_CONTEXT_KEY, ctx as TableRowContext<unknown>);
+}
+
+export function useTableRow<Row = unknown>(): TableRowContext<Row> | null {
+    return inject(TABLE_ROW_CONTEXT_KEY, null) as TableRowContext<Row> | null;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Head-cell count context (D3 — auto-count <VCTableHeadCell> siblings in
+// <VCTableHeader>'s first row, used as the Shape B colspan fallback)
+// ──────────────────────────────────────────────────────────────────────────
+
+export type HeadCellCountContext = {
+    register: () => void;
+    unregister: () => void;
+};
+
+const TABLE_HEAD_CELL_COUNT_CONTEXT_KEY: InjectionKey<HeadCellCountContext> = Symbol(
+    'vcTableHeadCellCountContext',
+);
+
+export function provideHeadCellCountContext(ctx: HeadCellCountContext): void {
+    provide(TABLE_HEAD_CELL_COUNT_CONTEXT_KEY, ctx);
+}
+
+export function useHeadCellCountContext(): HeadCellCountContext | null {
+    return inject(TABLE_HEAD_CELL_COUNT_CONTEXT_KEY, null);
+}

--- a/packages/table/src/composables/context.ts
+++ b/packages/table/src/composables/context.ts
@@ -25,6 +25,13 @@ export type TableContext<Row = unknown> = {
     colspan: Ref<number>;
     /** Emit a `row-click` event from inside a body row. */
     emitRowClick: (row: Row, index: number, event: Event) => void;
+    /**
+     * The positioned wrapper element that wraps the `<table>` in the DOM.
+     * `<VCTableLoading :overlay>` teleports here so its `<div>` isn't
+     * fostered out of the table by the HTML parser AND so it has a real
+     * positioning context for `position: absolute; inset: 0`.
+     */
+    wrapperEl: Ref<globalThis.HTMLElement | null>;
 };
 
 const TABLE_CONTEXT_KEY: InjectionKey<TableContext<unknown>> = Symbol('vcTableContext');

--- a/packages/table/src/composables/define-table.ts
+++ b/packages/table/src/composables/define-table.ts
@@ -1,4 +1,4 @@
-import { computed, ref, shallowRef } from 'vue';
+import { computed, ref } from 'vue';
 import type { ComputedRef, Ref } from 'vue';
 import type {
     SortDirection,
@@ -6,6 +6,7 @@ import type {
     TableColumnRaw,
     TableSortState,
 } from '../types';
+import { useSortMachine } from './sort';
 import { normalizeColumns } from '../utils/render-utils';
 
 export type DefineTableOptions<Row> = {
@@ -17,6 +18,8 @@ export type DefineTableOptions<Row> = {
     busy?: boolean;
     /** Initial sort state. */
     sort?: TableSortState;
+    /** When `true`, the sort cycle skips the `null` step. Mirrors `<VCTable :must-sort>`. */
+    mustSort?: boolean;
 };
 
 export type TableState<Row> = {
@@ -24,6 +27,7 @@ export type TableState<Row> = {
     columns: ComputedRef<TableColumn<Row>[]>;
     rawColumns: Ref<TableColumnRaw<Row>[]>;
     busy: Ref<boolean>;
+    mustSort: Ref<boolean>;
     sort: Ref<TableSortState>;
     setSort: (key: string, direction?: SortDirection) => void;
 };
@@ -41,38 +45,43 @@ export type TableState<Row> = {
  *   });
  *
  *   <VCTable :data="usersTable.data" :columns="usersTable.columns" ... />
+ *
+ * The sort cycle composes `useSortMachine` internally — same semantics
+ * as the `<VCTable>` SFC path (honors per-column `initialSortDirection`
+ * + `mustSort`).
  */
 export function defineTable<Row = unknown>(
     options: DefineTableOptions<Row> = {},
 ): TableState<Row> {
-    const data = shallowRef<Row[]>(options.data ?? []);
-    const rawColumns = shallowRef<TableColumnRaw<Row>[]>(options.columns ?? []);
+    // Deep `ref` (not `shallowRef`) for `data` + `rawColumns` so
+    // in-place array mutations (`.push`, `.splice`, item-property
+    // updates) flow through to dependent computeds. `shallowRef` would
+    // silently swallow these in normal state-store usage.
+    const data = ref(options.data ?? []) as Ref<Row[]>;
+    const rawColumns = ref(options.columns ?? []) as Ref<TableColumnRaw<Row>[]>;
     const busy = ref(options.busy ?? false);
-    const sort = shallowRef<TableSortState>(options.sort ?? null);
+    const mustSort = ref(options.mustSort ?? false);
+    const sort = ref<TableSortState>(options.sort ?? null);
 
     const columns = computed(() => normalizeColumns(rawColumns.value, data.value));
 
-    const setSort = (key: string, direction?: SortDirection) => {
-        if (direction !== undefined) {
-            sort.value = { key, direction };
-            return;
-        }
-        const current = sort.value;
-        if (!current || current.key !== key) {
-            sort.value = { key, direction: 'asc' };
-        } else if (current.direction === 'asc') {
-            sort.value = { key, direction: 'desc' };
-        } else {
-            sort.value = null;
-        }
-    };
+    // Compose `useSortMachine` so the cycle (initialSortDirection +
+    // mustSort handling) matches the SFC path bit-for-bit. The local
+    // `sort` ref serves as both source-of-truth and emit-target.
+    const sortMachine = useSortMachine<Row>({
+        source: sort as unknown as Ref<TableSortState | undefined>,
+        columns,
+        mustSort,
+        emit: (next) => { sort.value = next; },
+    });
 
     return {
-        data, 
-        columns, 
-        rawColumns, 
-        busy, 
-        sort, 
-        setSort, 
+        data,
+        columns,
+        rawColumns,
+        busy,
+        mustSort,
+        sort,
+        setSort: sortMachine.setSort,
     };
 }

--- a/packages/table/src/composables/define-table.ts
+++ b/packages/table/src/composables/define-table.ts
@@ -1,0 +1,78 @@
+import { computed, ref, shallowRef } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import type {
+    SortDirection,
+    TableColumn,
+    TableColumnRaw,
+    TableSortState,
+} from '../types';
+import { normalizeColumns } from '../utils/render-utils';
+
+export type DefineTableOptions<Row> = {
+    /** Initial data array. */
+    data?: Row[];
+    /** Initial column definitions (TableColumn or bare-string shorthand). */
+    columns?: TableColumnRaw<Row>[];
+    /** Initial busy flag. */
+    busy?: boolean;
+    /** Initial sort state. */
+    sort?: TableSortState;
+};
+
+export type TableState<Row> = {
+    data: Ref<Row[]>;
+    columns: ComputedRef<TableColumn<Row>[]>;
+    rawColumns: Ref<TableColumnRaw<Row>[]>;
+    busy: Ref<boolean>;
+    sort: Ref<TableSortState>;
+    setSort: (key: string, direction?: SortDirection) => void;
+};
+
+/**
+ * Pinia-style factory mirroring `defineList()`. Returns reactive state
+ * containers + a `setSort` mutator. Useful when a consumer wants to share
+ * a table's state across multiple components without prop drilling, or
+ * when wiring a controlled table outside the SFC.
+ *
+ *   const usersTable = defineTable<User>({
+ *       columns: ['id', 'name', 'email'],
+ *       data: [],
+ *       busy: false,
+ *   });
+ *
+ *   <VCTable :data="usersTable.data" :columns="usersTable.columns" ... />
+ */
+export function defineTable<Row = unknown>(
+    options: DefineTableOptions<Row> = {},
+): TableState<Row> {
+    const data = shallowRef<Row[]>(options.data ?? []);
+    const rawColumns = shallowRef<TableColumnRaw<Row>[]>(options.columns ?? []);
+    const busy = ref(options.busy ?? false);
+    const sort = shallowRef<TableSortState>(options.sort ?? null);
+
+    const columns = computed(() => normalizeColumns(rawColumns.value, data.value));
+
+    const setSort = (key: string, direction?: SortDirection) => {
+        if (direction !== undefined) {
+            sort.value = { key, direction };
+            return;
+        }
+        const current = sort.value;
+        if (!current || current.key !== key) {
+            sort.value = { key, direction: 'asc' };
+        } else if (current.direction === 'asc') {
+            sort.value = { key, direction: 'desc' };
+        } else {
+            sort.value = null;
+        }
+    };
+
+    return {
+        data, 
+        columns, 
+        rawColumns, 
+        busy, 
+        sort, 
+        setSort, 
+    };
+}

--- a/packages/table/src/composables/index.ts
+++ b/packages/table/src/composables/index.ts
@@ -1,0 +1,3 @@
+export * from './context';
+export * from './define-table';
+export * from './sort';

--- a/packages/table/src/composables/sort.ts
+++ b/packages/table/src/composables/sort.ts
@@ -1,0 +1,95 @@
+import { computed, ref, watch } from 'vue';
+import type { ComputedRef, Ref } from 'vue';
+import type { SortDirection, TableColumn, TableSortState } from '../types';
+
+export type UseSortMachineOptions<Row = unknown> = {
+    /** Reactive source-of-truth from the consumer's `v-model:sort`. May be `undefined`. */
+    source: Ref<TableSortState | undefined>;
+    /** Reactive column list — needed to resolve `initialSortDirection`. */
+    columns: Ref<TableColumn<Row>[]>;
+    /** When `true`, the cycle skips the `null` step → `null → asc → desc → asc`. */
+    mustSort: Ref<boolean>;
+    /** Emit handler that propagates each change back to the consumer. */
+    emit: (next: TableSortState) => void;
+};
+
+export type SortMachine = {
+    state: ComputedRef<TableSortState>;
+    /**
+     * Cycle the sort state for `key`.
+     * - First activation uses the column's `initialSortDirection` (default `'asc'`).
+     * - Subsequent activations cycle `asc → desc → null (or asc when mustSort)`.
+     * - Passing an explicit `direction` jumps straight to it.
+     */
+    setSort: (key: string, direction?: SortDirection) => void;
+    /** Sort direction for a key, or `null` when this column isn't the current sort. */
+    directionFor: (key: string) => SortDirection | null;
+};
+
+/**
+ * Controlled single-column sort machine. The consumer owns the sort state
+ * via `v-model:sort` — the table never sorts data, only emits intent.
+ *
+ * v0.1 scope: single-column. Multi-column / custom comparators deferred to
+ * v1.x. Matches BTable's controlled mode.
+ */
+export function useSortMachine<Row = unknown>(
+    options: UseSortMachineOptions<Row>,
+): SortMachine {
+    const {
+        source, 
+        columns, 
+        mustSort, 
+        emit, 
+    } = options;
+
+    // Mirror the source into a local ref so we can react to undefined→null,
+    // but the source remains the single source of truth.
+    const local = ref<TableSortState>(source.value ?? null);
+    watch(source, (next) => {
+        local.value = next ?? null;
+    });
+
+    const state = computed<TableSortState>(() => local.value);
+
+    function findInitialDirection(key: string): SortDirection {
+        const col = columns.value.find((c) => c.key === key);
+        return col?.initialSortDirection ?? 'asc';
+    }
+
+    function setSort(key: string, direction?: SortDirection) {
+        const current = local.value;
+
+        let next: TableSortState;
+        if (direction !== undefined) {
+            next = { key, direction };
+        } else if (!current || current.key !== key) {
+            next = { key, direction: findInitialDirection(key) };
+        } else if (current.direction === findInitialDirection(key)) {
+            next = {
+                key,
+                direction: current.direction === 'asc' ? 'desc' : 'asc',
+            };
+        } else {
+            // We're on the "second" direction — cycle to null unless mustSort.
+            next = mustSort.value ?
+                { key, direction: findInitialDirection(key) } :
+                null;
+        }
+
+        local.value = next;
+        emit(next);
+    }
+
+    function directionFor(key: string): SortDirection | null {
+        const cur = local.value;
+        if (!cur || cur.key !== key) return null;
+        return cur.direction;
+    }
+
+    return {
+        state, 
+        setSort, 
+        directionFor, 
+    };
+}

--- a/packages/table/src/defaults.ts
+++ b/packages/table/src/defaults.ts
@@ -1,0 +1,20 @@
+import type { ComponentDefaultValues } from '@vuecs/core';
+
+export type TableEmptyDefaults = {
+    /** Default text rendered when `data.length === 0 && !busy && !filtered`. */
+    content: string;
+    /** Default text rendered when `:filtered` is set (empty-after-filter case). */
+    filteredContent: string;
+};
+
+export type TableLoadingDefaults = {
+    /** Default text rendered during the first-load placeholder + overlay variant. */
+    content: string;
+};
+
+declare module '@vuecs/core' {
+    interface ComponentDefaults {
+        tableEmpty?: ComponentDefaultValues<TableEmptyDefaults>;
+        tableLoading?: ComponentDefaultValues<TableLoadingDefaults>;
+    }
+}

--- a/packages/table/src/index.ts
+++ b/packages/table/src/index.ts
@@ -1,0 +1,49 @@
+import type { App, Plugin } from 'vue';
+import { installDefaultsManager, installThemeManager } from '@vuecs/core';
+import type { CoreOptions } from '@vuecs/core';
+
+import '../assets/index.css';
+import './defaults';
+import './vue';
+
+import {
+    VCTable,
+    VCTableBody,
+    VCTableCell,
+    VCTableEmpty,
+    VCTableFooter,
+    VCTableHeadCell,
+    VCTableHeader,
+    VCTableLoading,
+    VCTableRow,
+} from './components';
+
+export * from './components';
+export * from './composables';
+export * from './theme';
+export * from './types';
+export * from './utils';
+export type * from './defaults';
+
+export type Options = CoreOptions;
+
+export function install(app: App, options: Options = {}): void {
+    installThemeManager(app, options);
+    installDefaultsManager(app, options);
+
+    Object.entries({
+        VCTable,
+        VCTableHeader,
+        VCTableBody,
+        VCTableFooter,
+        VCTableRow,
+        VCTableCell,
+        VCTableHeadCell,
+        VCTableEmpty,
+        VCTableLoading,
+    }).forEach(([name, component]) => {
+        app.component(name, component);
+    });
+}
+
+export default { install } satisfies Plugin<[Options?]>;

--- a/packages/table/src/theme.ts
+++ b/packages/table/src/theme.ts
@@ -1,0 +1,45 @@
+import type { ComponentThemeDefinition } from '@vuecs/core';
+import type {
+    TableBodyThemeClasses,
+    TableCellThemeClasses,
+    TableEmptyThemeClasses,
+    TableFooterThemeClasses,
+    TableHeadCellThemeClasses,
+    TableHeaderThemeClasses,
+    TableLoadingThemeClasses,
+    TableRowThemeClasses,
+    TableThemeClasses,
+} from './types';
+
+export const tableThemeDefaults: ComponentThemeDefinition<TableThemeClasses> = {
+    classes: {
+        root: 'vc-table',
+        scrollContainer: 'vc-table-scroll-container',
+    },
+};
+
+export const tableHeaderThemeDefaults: ComponentThemeDefinition<TableHeaderThemeClasses> = { classes: { root: 'vc-table-header' } };
+
+export const tableBodyThemeDefaults: ComponentThemeDefinition<TableBodyThemeClasses> = { classes: { root: 'vc-table-body' } };
+
+export const tableFooterThemeDefaults: ComponentThemeDefinition<TableFooterThemeClasses> = { classes: { root: 'vc-table-footer' } };
+
+export const tableRowThemeDefaults: ComponentThemeDefinition<TableRowThemeClasses> = { classes: { root: 'vc-table-row' } };
+
+export const tableCellThemeDefaults: ComponentThemeDefinition<TableCellThemeClasses> = { classes: { root: 'vc-table-cell' } };
+
+export const tableHeadCellThemeDefaults: ComponentThemeDefinition<TableHeadCellThemeClasses> = {
+    classes: {
+        root: 'vc-table-head-cell',
+        sortIcon: 'vc-table-head-cell-sort-icon',
+    },
+};
+
+export const tableEmptyThemeDefaults: ComponentThemeDefinition<TableEmptyThemeClasses> = { classes: { root: 'vc-table-empty' } };
+
+export const tableLoadingThemeDefaults: ComponentThemeDefinition<TableLoadingThemeClasses> = {
+    classes: {
+        root: 'vc-table-loading',
+        overlay: 'vc-table-loading-overlay',
+    },
+};

--- a/packages/table/src/types.ts
+++ b/packages/table/src/types.ts
@@ -1,0 +1,244 @@
+import type { ThemeElementDefinition, VNodeClass } from '@vuecs/core';
+
+// ──────────────────────────────────────────────────────────────────────────
+// Column shape (plan 028 §"Column definition shape")
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Bare-string shorthand: `'name'` is equivalent to
+ * `{ key: 'name', label: startCase('name') }`.
+ */
+export type TableColumnRaw<Row = unknown, K extends string = string> =    | K |
+    TableColumn<Row, K>;
+
+export type TableColumnFormatterCtx<Row, K extends string = string> = {
+    value: unknown;
+    key: K;
+    row: Row;
+};
+
+export type TableColumnHeaderAttrsCtx<K extends string = string> = {
+    key: K;
+    type: 'top' | 'bottom';
+};
+
+export interface TableColumn<Row = unknown, K extends string = string> {
+    /** Key into the row object. Used as the cell value default and the slot suffix. */
+    key: K;
+
+    /** Heading text. Defaults to `startCase(key)`. Override per-column via `#header-<key>` slot. */
+    label?: string;
+
+    /** Optional class string applied to BOTH `<th>` AND `<td>` for this column. */
+    class?: VNodeClass;
+
+    /** Class concatenated onto the `<th>` (in addition to `class`). Additive, not replacing. */
+    headerClass?: VNodeClass;
+
+    /** Class concatenated onto the `<td>` (in addition to `class`). Additive, not replacing. */
+    cellClass?: VNodeClass;
+
+    /** Marks the column sortable. Click / Enter / Space cycles sort state and emits `update:sort`. */
+    sortable?: boolean;
+
+    /**
+     * Value accessor when the row's value isn't `row[key]`.
+     * - String: dot-path (e.g. `'profile.email'`) — resolved against `row` at render time.
+     * - Function: `(row) => unknown` — full custom resolution.
+     */
+    accessor?: string | ((row: Row) => unknown);
+
+    /**
+     * Default cell renderer when `#cell-<key>` slot isn't provided.
+     * Object-arg shape (matches `cellAttrs` / `headerAttrs`).
+     */
+    formatter?: (ctx: TableColumnFormatterCtx<Row, K>) => string;
+
+    /**
+     * Render this column's `<td>` as `<th scope="row">` instead.
+     * Highest-leverage a11y switch for entity-name columns: screen readers
+     * announce row-header + column-header for every other cell in the row.
+     */
+    isRowHeader?: boolean;
+
+    /**
+     * Per-cell attribute escape hatch — applied to the `<td>` (or `<th>` when
+     * `isRowHeader`). Object form is static; function form receives the same
+     * ctx as `formatter`. Common uses: `data-testid`, ARIA labels.
+     */
+    cellAttrs?:
+        | Record<string, unknown> |
+        ((ctx: TableColumnFormatterCtx<Row, K>) => Record<string, unknown>);
+
+    /**
+     * Per-header attribute escape hatch — applied to the `<th>`. Object form
+     * is static; function form receives `{ key, type }` where `type` is
+     * `'top'` (header band) or `'bottom'` (footer band, when present).
+     */
+    headerAttrs?:
+        | Record<string, unknown> |
+        ((ctx: TableColumnHeaderAttrsCtx<K>) => Record<string, unknown>);
+
+    /** Native `<th title="…">`. */
+    headerTitle?: string;
+
+    /** Native `<th abbr="…">`. */
+    headerAbbr?: string;
+
+    /**
+     * `position: sticky; left: 0` on this column's `<th>` + `<td>`. Theme owns
+     * the CSS (each shipping theme adds a `stickyColumn` variant axis on
+     * `tableCell` / `tableHeadCell`).
+     */
+    stickyColumn?: boolean;
+
+    /** Default direction when this column is sorted for the first time. Defaults to `'asc'`. */
+    initialSortDirection?: 'asc' | 'desc';
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Row-meta convention (plan 028 §"Row-meta escape hatch")
+// ──────────────────────────────────────────────────────────────────────────
+
+export type RowVariant =    | 'success' |
+    'warning' |
+    'error' |
+    'info' |
+    'neutral' |
+    'primary';
+
+/**
+ * Row-meta escape hatch. Underscore-prefixed fields on the data row itself
+ * control visual state without forcing consumers to wire a function prop or
+ * additional column.
+ *
+ *   const users: WithRowMeta<User>[] = [
+ *       { id: 1, name: 'Alice', _rowVariant: 'warning' },
+ *       { id: 2, name: 'Bob',   _cellVariants: { email: 'error' } },
+ *   ];
+ *
+ * Underscore prefix prevents collision with real data keys. Consumers that
+ * send rows back to a server should strip these client-side fields.
+ */
+export type WithRowMeta<T> = T & {
+    /** Applied to the entire `<tr>` via `tableRow.rowVariant.<value>`. */
+    _rowVariant?: RowVariant | null;
+    /** Applied per-cell — keyed by column key — via `tableCell.cellVariant.<value>`. */
+    _cellVariants?: Partial<Record<keyof T & string, RowVariant>>;
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// Sort
+// ──────────────────────────────────────────────────────────────────────────
+
+export type SortDirection = 'asc' | 'desc';
+
+export type TableSortState = {
+    key: string;
+    direction: SortDirection;
+} | null;
+
+// ──────────────────────────────────────────────────────────────────────────
+// Theme class maps (one per shipping component — 9 total)
+// ──────────────────────────────────────────────────────────────────────────
+
+export type TableThemeClasses = {
+    /** The outer `<table>` (or its `<div class="scrollContainer">` wrapper when `:scrollable`). */
+    root: string;
+    /** The overflow wrapper rendered when `:scrollable` is set. */
+    scrollContainer: string;
+};
+
+export type TableHeaderThemeClasses = {
+    /** The `<thead>` band. */
+    root: string;
+};
+
+export type TableBodyThemeClasses = {
+    /** The `<tbody>` band. */
+    root: string;
+};
+
+export type TableFooterThemeClasses = {
+    /** The `<tfoot>` band. */
+    root: string;
+};
+
+export type TableRowThemeClasses = {
+    /** The `<tr>` element. */
+    root: string;
+};
+
+export type TableCellThemeClasses = {
+    /** The `<td>` element. */
+    root: string;
+};
+
+export type TableHeadCellThemeClasses = {
+    /** The `<th>` element. */
+    root: string;
+    /** The sort-indicator wrapper rendered alongside the label when `sortable`. */
+    sortIcon: string;
+};
+
+export type TableEmptyThemeClasses = {
+    /** The `<tbody>` (or `<td>` child) carrying the empty-state message. */
+    root: string;
+};
+
+export type TableLoadingThemeClasses = {
+    /** The `<tbody>` band (default) OR the overlay `<div>` (when `:overlay`). */
+    root: string;
+    /** Applied only in overlay mode. */
+    overlay: string;
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// Theme element registry augmentation
+// ──────────────────────────────────────────────────────────────────────────
+
+declare module '@vuecs/core' {
+    interface ThemeElements {
+        table?: ThemeElementDefinition<TableThemeClasses>;
+        tableHeader?: ThemeElementDefinition<TableHeaderThemeClasses>;
+        tableBody?: ThemeElementDefinition<TableBodyThemeClasses>;
+        tableFooter?: ThemeElementDefinition<TableFooterThemeClasses>;
+        tableRow?: ThemeElementDefinition<TableRowThemeClasses>;
+        tableCell?: ThemeElementDefinition<TableCellThemeClasses>;
+        tableHeadCell?: ThemeElementDefinition<TableHeadCellThemeClasses>;
+        tableEmpty?: ThemeElementDefinition<TableEmptyThemeClasses>;
+        tableLoading?: ThemeElementDefinition<TableLoadingThemeClasses>;
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Slot-prop types
+// ──────────────────────────────────────────────────────────────────────────
+
+export type TableSlotProps<Row = unknown> = {
+    data: Row[];
+    busy: boolean;
+    columns: TableColumn<Row>[];
+    sort: TableSortState;
+    setSort: (key: string, direction?: SortDirection) => void;
+};
+
+export type TableBodyRowSlotProps<Row = unknown> = {
+    row: Row;
+    index: number;
+};
+
+export type TableCellSlotProps<Row = unknown> = {
+    row: Row;
+    value: unknown;
+    key: string;
+    column: TableColumn<Row>;
+    index: number;
+};
+
+export type TableHeadCellSlotProps<Row = unknown> = {
+    column: TableColumn<Row>;
+    key: string;
+    sort: SortDirection | null;
+    setSort: (direction?: SortDirection) => void;
+};

--- a/packages/table/src/utils/index.ts
+++ b/packages/table/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './render-utils';

--- a/packages/table/src/utils/render-utils.ts
+++ b/packages/table/src/utils/render-utils.ts
@@ -21,9 +21,12 @@ export function startCase(input: string): string {
 /**
  * Normalize the `:columns` prop into a uniform `TableColumn[]`.
  *
- * - **Explicit array**: pass through, fill `label` from `startCase(key)`.
+ * - **Explicit array** (including empty `[]`): pass through, fill `label`
+ *   from `startCase(key)`. Treating `[]` as authoritative lets consumers
+ *   deliberately render a header-less table during loading without the
+ *   auto-derive kicking in the moment data arrives.
  * - **Bare-string shorthand**: `['id', 'name']` → `[{ key, label }, ...]`.
- * - **Auto-derive**: when `columns` is undefined/empty AND `data[0]` is an
+ * - **Auto-derive**: only when `columns` is `undefined` AND `data[0]` is an
  *   object, derive the columns from `Object.keys(data[0])`, skipping
  *   underscore-prefixed row-meta keys (`_rowVariant` / `_cellVariants`).
  */
@@ -35,10 +38,12 @@ export function normalizeColumns<Row>(
         if (typeof col === 'string') {
             return { key: col, label: startCase(col) };
         }
-        return { label: startCase(col.key), ...col };
+        // Spread first, then fold in `label` so a consumer-passed
+        // `label: undefined` doesn't clobber the computed default.
+        return { ...col, label: col.label ?? startCase(col.key) };
     };
 
-    if (columns && columns.length > 0) {
+    if (columns !== undefined) {
         return columns.map(fromRaw);
     }
 
@@ -126,11 +131,21 @@ const INTERACTIVE_SELECTOR = [
  * portal'd overlay rendered into the document body (e.g. a
  * `<VCDropdownMenu>` action menu inside the row).
  *
- * Use at the row click handler: `if (filterRowClickEvent(event)) return;`.
+ * Pass the `<tr>` element as `rowEl` so the helper can disambiguate
+ * legitimate row clicks (where the `closest()` ancestor walk reaches the
+ * `<tr>` itself, which carries `tabindex="0"` when the row is clickable)
+ * from clicks on a genuine interactive descendant.
+ *
+ * Use at the row click handler: `if (filterRowClickEvent(event, tr)) return;`.
  */
-export function filterRowClickEvent(event: Event): boolean {
+export function filterRowClickEvent(event: Event, rowEl?: Element | null): boolean {
     const { target } = event;
     if (!(target instanceof Element)) return false;
     const hit = target.closest(INTERACTIVE_SELECTOR);
-    return hit !== null;
+    if (hit === null) return false;
+    // If the only match is the row itself (which carries `tabindex="0"`
+    // when clickable), this is a real row click, not a click on an
+    // interactive descendant — let it through.
+    if (rowEl && hit === rowEl) return false;
+    return true;
 }

--- a/packages/table/src/utils/render-utils.ts
+++ b/packages/table/src/utils/render-utils.ts
@@ -1,0 +1,136 @@
+import { isObject } from '@vuecs/core';
+import type { TableColumn, TableColumnRaw } from '../types';
+
+/**
+ * Convert a key like `'firstName'` / `'first_name'` / `'first-name'` to
+ * `'First Name'`. Used by the bare-string column shorthand to derive
+ * a label when only the key is given.
+ */
+export function startCase(input: string): string {
+    if (!input) return '';
+    return input
+        .replace(/[_-]+/g, ' ')
+        .replace(/([a-z])([A-Z])/g, '$1 $2')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .split(' ')
+        .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+        .join(' ');
+}
+
+/**
+ * Normalize the `:columns` prop into a uniform `TableColumn[]`.
+ *
+ * - **Explicit array**: pass through, fill `label` from `startCase(key)`.
+ * - **Bare-string shorthand**: `['id', 'name']` → `[{ key, label }, ...]`.
+ * - **Auto-derive**: when `columns` is undefined/empty AND `data[0]` is an
+ *   object, derive the columns from `Object.keys(data[0])`, skipping
+ *   underscore-prefixed row-meta keys (`_rowVariant` / `_cellVariants`).
+ */
+export function normalizeColumns<Row>(
+    columns: ReadonlyArray<TableColumnRaw<Row>> | undefined,
+    data: ReadonlyArray<Row>,
+): TableColumn<Row>[] {
+    const fromRaw = (col: TableColumnRaw<Row>): TableColumn<Row> => {
+        if (typeof col === 'string') {
+            return { key: col, label: startCase(col) };
+        }
+        return { label: startCase(col.key), ...col };
+    };
+
+    if (columns && columns.length > 0) {
+        return columns.map(fromRaw);
+    }
+
+    if (data.length === 0 || !isObject(data[0])) return [];
+
+    const first = data[0] as Record<string, unknown>;
+    return Object.keys(first)
+        .filter((key) => !key.startsWith('_'))
+        .map((key) => ({ key, label: startCase(key) }));
+}
+
+/**
+ * Resolve a column's value against a row.
+ *
+ * - String accessor: dot-path lookup (e.g. `'profile.email'` → `row.profile.email`)
+ * - Function accessor: invoked with the row
+ * - Falls back to `row[column.key]`
+ */
+export function resolveCellValue<Row>(column: TableColumn<Row>, row: Row): unknown {
+    const { accessor } = column;
+    if (typeof accessor === 'function') {
+        return accessor(row);
+    }
+    if (typeof accessor === 'string') {
+        return resolveDotPath(row, accessor);
+    }
+    if (isObject(row)) {
+        return (row as Record<string, unknown>)[column.key];
+    }
+    return undefined;
+}
+
+function resolveDotPath(obj: unknown, path: string): unknown {
+    if (!isObject(obj)) return undefined;
+    let cur: unknown = obj;
+    for (const part of path.split('.')) {
+        if (!isObject(cur)) return undefined;
+        cur = (cur as Record<string, unknown>)[part];
+    }
+    return cur;
+}
+
+/**
+ * Resolve attribute objects, supporting both static-object and function forms
+ * used by `cellAttrs` and `headerAttrs`.
+ */
+export function resolveAttrs<Ctx>(
+    attrs: Record<string, unknown> | ((ctx: Ctx) => Record<string, unknown>) | undefined,
+    ctx: Ctx,
+): Record<string, unknown> | undefined {
+    if (!attrs) return undefined;
+    return typeof attrs === 'function' ? attrs(ctx) : attrs;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// filterEvent — ported from bootstrap-vue-next's utils/filterEvent.ts
+// (plan 028 §"filterEvent — richer interactive-descendant exclusion")
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Selectors that mark an element (or an ancestor of it) as interactive —
+ * row-click handlers should NOT fire when the click originates inside one
+ * of these. Plan 028 D5 ships this list; the closest-ancestor matching
+ * (vs direct-match) is what catches clicks on text INSIDE a button or
+ * anchor.
+ */
+const INTERACTIVE_SELECTOR = [
+    'a',
+    'button',
+    'input',
+    'select',
+    'textarea',
+    'label[for]',
+    '[role="button"]',
+    '[role="link"]',
+    '[contenteditable]:not([contenteditable="false"])',
+    '[tabindex]:not([tabindex="-1"])',
+    '.vc-overlay-portal-content',
+].join(',');
+
+/**
+ * Returns `true` when a row-level click should be suppressed because the
+ * event originated inside an interactive descendant — a button, anchor,
+ * form input, role=button/link, an explicitly-focusable element, or a
+ * portal'd overlay rendered into the document body (e.g. a
+ * `<VCDropdownMenu>` action menu inside the row).
+ *
+ * Use at the row click handler: `if (filterRowClickEvent(event)) return;`.
+ */
+export function filterRowClickEvent(event: Event): boolean {
+    const { target } = event;
+    if (!(target instanceof Element)) return false;
+    const hit = target.closest(INTERACTIVE_SELECTOR);
+    return hit !== null;
+}

--- a/packages/table/src/vue.ts
+++ b/packages/table/src/vue.ts
@@ -1,0 +1,23 @@
+import type VCTable from './components/Table.vue';
+import type VCTableBody from './components/TableBody.vue';
+import type VCTableCell from './components/TableCell.vue';
+import type VCTableEmpty from './components/TableEmpty.vue';
+import type VCTableFooter from './components/TableFooter.vue';
+import type VCTableHeadCell from './components/TableHeadCell.vue';
+import type VCTableHeader from './components/TableHeader.vue';
+import type VCTableLoading from './components/TableLoading.vue';
+import type VCTableRow from './components/TableRow.vue';
+
+declare module '@vue/runtime-core' {
+    export interface GlobalComponents {
+        VCTable: typeof VCTable;
+        VCTableHeader: typeof VCTableHeader;
+        VCTableBody: typeof VCTableBody;
+        VCTableFooter: typeof VCTableFooter;
+        VCTableRow: typeof VCTableRow;
+        VCTableCell: typeof VCTableCell;
+        VCTableHeadCell: typeof VCTableHeadCell;
+        VCTableEmpty: typeof VCTableEmpty;
+        VCTableLoading: typeof VCTableLoading;
+    }
+}

--- a/packages/table/test/unit/column-resolution.spec.ts
+++ b/packages/table/test/unit/column-resolution.spec.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import {
+    filterRowClickEvent,
+    normalizeColumns,
+    resolveCellValue,
+    startCase,
+} from '../../src/utils/render-utils';
+
+describe('startCase', () => {
+    it('snake_case → Title Case', () => {
+        expect(startCase('first_name')).toBe('First Name');
+    });
+    it('kebab-case → Title Case', () => {
+        expect(startCase('first-name')).toBe('First Name');
+    });
+    it('camelCase → Title Case', () => {
+        expect(startCase('firstName')).toBe('First Name');
+    });
+    it('single word capitalized', () => {
+        expect(startCase('email')).toBe('Email');
+    });
+});
+
+describe('normalizeColumns', () => {
+    it('bare-string shorthand normalizes to { key, label }', () => {
+        expect(normalizeColumns(['id', 'name'], [])).toEqual([
+            { key: 'id', label: 'Id' },
+            { key: 'name', label: 'Name' },
+        ]);
+    });
+
+    it('explicit object keeps its label', () => {
+        const cols = normalizeColumns([{ key: 'name', label: 'User name' }], []);
+        expect(cols[0].label).toBe('User name');
+    });
+
+    it('explicit object without label gets startCase(key)', () => {
+        const cols = normalizeColumns([{ key: 'firstName' }], []);
+        expect(cols[0].label).toBe('First Name');
+    });
+
+    it('auto-derives from Object.keys(data[0]) when columns omitted', () => {
+        const cols = normalizeColumns(undefined, [{
+            id: 1, 
+            name: 'Alice', 
+            email: 'a@x', 
+        }]);
+        expect(cols.map((c) => c.key)).toEqual(['id', 'name', 'email']);
+    });
+
+    it('auto-derive skips underscore-prefixed row-meta keys', () => {
+        const cols = normalizeColumns(undefined, [{
+            id: 1, 
+            name: 'Alice', 
+            _rowVariant: 'success', 
+        }]);
+        expect(cols.map((c) => c.key)).toEqual(['id', 'name']);
+    });
+
+    it('returns [] when columns empty AND data empty', () => {
+        expect(normalizeColumns(undefined, [])).toEqual([]);
+    });
+});
+
+describe('resolveCellValue', () => {
+    it('direct row[key] when no accessor', () => {
+        const row = { name: 'Alice' };
+        expect(resolveCellValue({ key: 'name' }, row)).toBe('Alice');
+    });
+
+    it('string accessor with dot-path traverses nested objects', () => {
+        const row = { profile: { email: 'a@x' } };
+        expect(resolveCellValue({ key: 'email', accessor: 'profile.email' }, row)).toBe('a@x');
+    });
+
+    it('function accessor invoked with row', () => {
+        const row = { first: 'Alice', last: 'Liddell' };
+        const full = resolveCellValue({
+            key: 'full',
+            accessor: (r: typeof row) => `${r.first} ${r.last}`,
+        }, row);
+        expect(full).toBe('Alice Liddell');
+    });
+
+    it('returns undefined for missing dot-path segments', () => {
+        expect(resolveCellValue({ key: 'x', accessor: 'a.b.c' }, { a: {} })).toBeUndefined();
+    });
+});
+
+describe('filterRowClickEvent', () => {
+    function setup(html: string) {
+        document.body.innerHTML = `<table><tbody><tr id="row">${html}</tr></tbody></table>`;
+        return document.getElementById('row')!;
+    }
+
+    it('returns false for plain text clicks', () => {
+        const row = setup('<td>plain</td>');
+        const event = new MouseEvent('click', { bubbles: true });
+        Object.defineProperty(event, 'target', { value: row.firstChild });
+        expect(filterRowClickEvent(event)).toBe(false);
+    });
+
+    it('returns true when origin is a button', () => {
+        setup('<td><button id="btn">go</button></td>');
+        const event = new MouseEvent('click', { bubbles: true });
+        Object.defineProperty(event, 'target', { value: document.getElementById('btn') });
+        expect(filterRowClickEvent(event)).toBe(true);
+    });
+
+    it('returns true when origin is text inside an anchor', () => {
+        setup('<td><a href="/x"><span id="t">go</span></a></td>');
+        const event = new MouseEvent('click', { bubbles: true });
+        Object.defineProperty(event, 'target', { value: document.getElementById('t') });
+        expect(filterRowClickEvent(event)).toBe(true);
+    });
+
+    it('returns true when origin is a label[for]', () => {
+        setup('<td><label for="cb" id="lbl">x</label></td>');
+        const event = new MouseEvent('click', { bubbles: true });
+        Object.defineProperty(event, 'target', { value: document.getElementById('lbl') });
+        expect(filterRowClickEvent(event)).toBe(true);
+    });
+
+    it('returns true when click is inside a portalled overlay', () => {
+        document.body.innerHTML = '<div class="vc-overlay-portal-content"><span id="x">i</span></div>';
+        const event = new MouseEvent('click', { bubbles: true });
+        Object.defineProperty(event, 'target', { value: document.getElementById('x') });
+        expect(filterRowClickEvent(event)).toBe(true);
+    });
+});

--- a/packages/table/test/unit/define-table.spec.ts
+++ b/packages/table/test/unit/define-table.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { defineTable } from '../../src/composables/define-table';
+
+describe('defineTable factory', () => {
+    it('exposes refs for data + columns + busy + sort', () => {
+        const t = defineTable<{ id: number; name: string }>({
+            columns: ['id', 'name'],
+            data: [{ id: 1, name: 'Alice' }],
+            busy: false,
+        });
+        expect(t.data.value).toHaveLength(1);
+        expect(t.columns.value.map((c) => c.key)).toEqual(['id', 'name']);
+        expect(t.busy.value).toBe(false);
+        expect(t.sort.value).toBeNull();
+    });
+
+    it('setSort cycles null → asc → desc → null', () => {
+        const t = defineTable({ columns: ['id'] });
+        t.setSort('id');
+        expect(t.sort.value).toEqual({ key: 'id', direction: 'asc' });
+        t.setSort('id');
+        expect(t.sort.value).toEqual({ key: 'id', direction: 'desc' });
+        t.setSort('id');
+        expect(t.sort.value).toBeNull();
+    });
+
+    it('setSort with explicit direction jumps straight', () => {
+        const t = defineTable({ columns: ['id'] });
+        t.setSort('id', 'desc');
+        expect(t.sort.value).toEqual({ key: 'id', direction: 'desc' });
+    });
+
+    it('columns is reactive to rawColumns updates', () => {
+        const t = defineTable<{ id: number }>({});
+        expect(t.columns.value).toEqual([]);
+        t.rawColumns.value = ['id'];
+        expect(t.columns.value).toEqual([{ key: 'id', label: 'Id' }]);
+    });
+});

--- a/packages/table/test/unit/sort.spec.ts
+++ b/packages/table/test/unit/sort.spec.ts
@@ -1,0 +1,94 @@
+import { ref } from 'vue';
+import { 
+    describe, 
+    expect, 
+    it, 
+    vi, 
+} from 'vitest';
+import { useSortMachine } from '../../src/composables/sort';
+import type { TableColumn, TableSortState } from '../../src/types';
+
+function setup(initial: TableSortState = null) {
+    const source = ref<TableSortState | undefined>(initial);
+    const columns = ref<TableColumn<unknown>[]>([
+        { key: 'name' },
+        { key: 'createdAt', initialSortDirection: 'desc' },
+    ]);
+    const mustSort = ref(false);
+    const emit = vi.fn((next: TableSortState) => { source.value = next; });
+    const machine = useSortMachine({
+        source, 
+        columns, 
+        mustSort, 
+        emit, 
+    });
+    return {
+        machine, 
+        source, 
+        columns, 
+        mustSort, 
+        emit, 
+    };
+}
+
+describe('useSortMachine — single-column cycle', () => {
+    it('null → asc on first activation, using initialSortDirection', () => {
+        const { machine, emit } = setup();
+        machine.setSort('name');
+        expect(emit).toHaveBeenCalledWith({ key: 'name', direction: 'asc' });
+    });
+
+    it('respects per-column initialSortDirection on first activation', () => {
+        const { machine, emit } = setup();
+        machine.setSort('createdAt');
+        expect(emit).toHaveBeenLastCalledWith({ key: 'createdAt', direction: 'desc' });
+    });
+
+    it('asc → desc → null when not mustSort', () => {
+        const { machine, emit } = setup();
+        machine.setSort('name'); // → asc
+        machine.setSort('name'); // → desc
+        machine.setSort('name'); // → null
+        expect(emit.mock.calls.map((c) => c[0])).toEqual([
+            { key: 'name', direction: 'asc' },
+            { key: 'name', direction: 'desc' },
+            null,
+        ]);
+    });
+
+    it('asc → desc → asc when mustSort', () => {
+        const {
+            machine, 
+            mustSort, 
+            emit, 
+        } = setup();
+        mustSort.value = true;
+        machine.setSort('name'); // → asc
+        machine.setSort('name'); // → desc
+        machine.setSort('name'); // → asc (skip null)
+        expect(emit.mock.calls.map((c) => c[0])).toEqual([
+            { key: 'name', direction: 'asc' },
+            { key: 'name', direction: 'desc' },
+            { key: 'name', direction: 'asc' },
+        ]);
+    });
+
+    it('switching column starts at the new column initial direction', () => {
+        const { machine, emit } = setup();
+        machine.setSort('name'); // → asc
+        machine.setSort('createdAt'); // → desc (column's initialSortDirection)
+        expect(emit).toHaveBeenLastCalledWith({ key: 'createdAt', direction: 'desc' });
+    });
+
+    it('directionFor returns the current direction, null otherwise', () => {
+        const { machine } = setup({ key: 'name', direction: 'desc' });
+        expect(machine.directionFor('name')).toBe('desc');
+        expect(machine.directionFor('createdAt')).toBeNull();
+    });
+
+    it('explicit direction jumps straight to it', () => {
+        const { machine, emit } = setup();
+        machine.setSort('name', 'desc');
+        expect(emit).toHaveBeenLastCalledWith({ key: 'name', direction: 'desc' });
+    });
+});

--- a/packages/table/test/vitest.config.ts
+++ b/packages/table/test/vitest.config.ts
@@ -1,0 +1,20 @@
+import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    plugins: [vue()],
+    test: {
+        environment: 'jsdom',
+        include: ['test/unit/**/*.{test,spec}.{js,ts}'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.{ts,tsx,js,jsx,vue}'],
+            thresholds: {
+                branches: 70,
+                functions: 70,
+                lines: 70,
+                statements: 70,
+            },
+        },
+    },
+});

--- a/packages/table/tsconfig.build.json
+++ b/packages/table/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.build.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "declarationDir": "./dist",
+        "skipLibCheck": true
+    },
+    "exclude": ["node_modules", "dist"],
+    "include": ["src/**/*.ts", "src/**/*.vue", "../../types/**/*.d.ts"]
+}

--- a/packages/table/tsconfig.json
+++ b/packages/table/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "lib": [
+            "ESNext",
+            "DOM"
+        ],
+        "jsx": "preserve",
+        "skipLibCheck": true,
+        "paths": {
+            "@vuecs/core": [
+                "./packages/core/src"
+            ],
+            "@vuecs/core/*": [
+                "./packages/core/src/*"
+            ]
+        }
+    },
+    "include": [
+        "src/**/*.ts",
+        "src/**/*.vue"
+    ]
+}

--- a/packages/table/tsdown.config.ts
+++ b/packages/table/tsdown.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsdown';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+    entry: 'src/index.ts',
+    format: 'esm',
+    dts: false,
+    sourcemap: true,
+    plugins: [vue()],
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,6 +19,7 @@
         "packages/nuxt": {"component": "nuxt" },
         "packages/overlays": {"component": "overlays" },
         "packages/pagination": {"component": "pagination" },
+        "packages/table": {"component": "table" },
         "themes/bootstrap": {"component": "theme-bootstrap" },
         "themes/bulma": {"component": "theme-bulma" },
         "themes/tailwind": {"component": "theme-tailwind" },

--- a/themes/bootstrap/assets/index.css
+++ b/themes/bootstrap/assets/index.css
@@ -428,3 +428,32 @@
 .vc-stepper-separator[data-state="completed"] {
     border-top-color: var(--vc-color-primary-600) !important;
 }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * @vuecs/table — gap-fill helpers for features Bootstrap doesn't natively
+ * cover. Bootstrap's theme strings can't carry `[aria-sort=…]` attribute
+ * selectors, so sort-indicator state lives in dedicated `vc-table-sort-{asc,desc}`
+ * helpers. Same approach as the overlay animation helpers.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.vc-table-sort-asc,
+.vc-table-sort-desc {
+    color: var(--vc-color-fg);
+}
+
+.vc-table-sticky-header thead th {
+    position: sticky;
+    top: 0;
+    background: var(--vc-color-bg);
+    z-index: 10;
+}
+
+.vc-table-sticky-column {
+    background: var(--vc-color-bg);
+    z-index: 1;
+}
+
+.vc-table-row-focused {
+    outline: 2px solid var(--vc-color-primary-500);
+    outline-offset: -2px;
+}

--- a/themes/bootstrap/src/index.ts
+++ b/themes/bootstrap/src/index.ts
@@ -508,6 +508,94 @@ export default function bootstrapTheme(): Theme {
                     size: 'md',
                 },
             },
+            // Bootstrap ships `.table` family natively. Compose those
+            // utility classes plus the design-token bridge for
+            // dark-mode + runtime palette propagation.
+            table: {
+                classes: {
+                    root: 'table align-middle mb-0',
+                    scrollContainer: 'table-responsive border rounded',
+                },
+                variants: {
+                    density: {
+                        compact: { root: 'table-sm' },
+                        normal: { root: '' },
+                        spacious: { root: '' },
+                    },
+                    striped: { true: { root: 'table-striped' } },
+                    bordered: { true: { root: 'table-bordered' } },
+                    hover: { true: { root: 'table-hover' } },
+                    stickyHeader: { true: { root: 'vc-table-sticky-header' } },
+                },
+                defaultVariants: { density: 'normal' },
+            },
+            tableHeader: { classes: { root: 'text-uppercase small text-body-secondary' } },
+            tableBody: { classes: { root: '' } },
+            tableFooter: { classes: { root: 'fw-medium' } },
+            tableRow: {
+                variants: {
+                    disabled: { true: { root: 'opacity-50' } },
+                    selected: { true: { root: 'table-active' } },
+                    focused: { true: { root: 'vc-table-row-focused' } },
+                    rowVariant: {
+                        success: { root: 'table-success' },
+                        warning: { root: 'table-warning' },
+                        error: { root: 'table-danger' },
+                        info: { root: 'table-info' },
+                        neutral: { root: 'table-secondary' },
+                        primary: { root: 'table-primary' },
+                    },
+                },
+            },
+            tableCell: {
+                variants: {
+                    align: {
+                        left: { root: 'text-start' },
+                        center: { root: 'text-center' },
+                        right: { root: 'text-end' },
+                    },
+                    stickyColumn: { true: { root: 'vc-table-sticky-column' } },
+                    cellVariant: {
+                        success: { root: 'text-success' },
+                        warning: { root: 'text-warning' },
+                        error: { root: 'text-danger' },
+                        info: { root: 'text-info' },
+                        neutral: { root: 'text-body-secondary' },
+                        primary: { root: 'text-primary' },
+                    },
+                },
+            },
+            tableHeadCell: {
+                classes: { sortIcon: 'ms-1 small lh-1' },
+                variants: {
+                    align: {
+                        left: { root: 'text-start' },
+                        center: { root: 'text-center' },
+                        right: { root: 'text-end' },
+                    },
+                    stickyColumn: { true: { root: 'vc-table-sticky-column' } },
+                    sorted: {
+                        asc: { root: 'vc-table-sort-asc' },
+                        desc: { root: 'vc-table-sort-desc' },
+                        none: { root: '' },
+                    },
+                },
+            },
+            tableEmpty: {
+                classes: { root: '' },
+                variants: {
+                    filtered: {
+                        true: { root: 'text-center text-body-secondary fst-italic py-4' },
+                        false: { root: 'text-center text-body-secondary py-4' },
+                    },
+                },
+            },
+            tableLoading: {
+                classes: {
+                    root: 'text-center text-body-secondary py-4',
+                    overlay: 'bg-body bg-opacity-75 text-body-secondary',
+                },
+            },
             pagination: {
                 classes: {
                     root: 'd-flex justify-content-center pagination',

--- a/themes/bootstrap/src/index.ts
+++ b/themes/bootstrap/src/index.ts
@@ -534,7 +534,7 @@ export default function bootstrapTheme(): Theme {
             tableFooter: { classes: { root: 'fw-medium' } },
             tableRow: {
                 variants: {
-                    disabled: { true: { root: 'opacity-50' } },
+                    disabled: { true: { root: 'opacity-50 pe-none' } },
                     selected: { true: { root: 'table-active' } },
                     focused: { true: { root: 'vc-table-row-focused' } },
                     rowVariant: {

--- a/themes/bootstrap/test/unit/audit.spec.ts
+++ b/themes/bootstrap/test/unit/audit.spec.ts
@@ -58,6 +58,17 @@ import {
     tooltipThemeDefaults,
 } from '@vuecs/overlays';
 import { paginationThemeDefaults } from '@vuecs/pagination';
+import {
+    tableBodyThemeDefaults,
+    tableCellThemeDefaults,
+    tableEmptyThemeDefaults,
+    tableFooterThemeDefaults,
+    tableHeadCellThemeDefaults,
+    tableHeaderThemeDefaults,
+    tableLoadingThemeDefaults,
+    tableRowThemeDefaults,
+    tableThemeDefaults,
+} from '@vuecs/table';
 import { timeagoThemeDefaults } from '@vuecs/timeago';
 import bootstrapTheme from '../../src';
 
@@ -119,6 +130,15 @@ const expectedCatalog = {
     popover: popoverThemeDefaults,
     separator: separatorThemeDefaults,
     stepper: stepperThemeDefaults,
+    table: tableThemeDefaults,
+    tableBody: tableBodyThemeDefaults,
+    tableCell: tableCellThemeDefaults,
+    tableEmpty: tableEmptyThemeDefaults,
+    tableFooter: tableFooterThemeDefaults,
+    tableHeadCell: tableHeadCellThemeDefaults,
+    tableHeader: tableHeaderThemeDefaults,
+    tableLoading: tableLoadingThemeDefaults,
+    tableRow: tableRowThemeDefaults,
     tag: tagThemeDefaults,
     tags: tagsThemeDefaults,
     timeago: timeagoThemeDefaults,

--- a/themes/bulma/assets/index.css
+++ b/themes/bulma/assets/index.css
@@ -507,3 +507,41 @@
 .box.vc-card-soft {
     background-color: var(--vc-color-bg-muted);
 }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * @vuecs/table — gap-fill helpers. Same rationale as Bootstrap:
+ * Bulma theme strings can't carry attribute selectors, so sort-indicator
+ * state + sticky-header + disabled-row + focused-row each get a vc-*
+ * helper class instead of a `[aria-sort=…]` / `[data-state=…]` rule.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+.vc-table-sort-asc,
+.vc-table-sort-desc {
+    color: var(--vc-color-fg);
+}
+
+.vc-table-sticky-header thead th {
+    position: sticky;
+    top: 0;
+    background: var(--vc-color-bg);
+    z-index: 10;
+}
+
+.vc-table-sticky-column {
+    background: var(--vc-color-bg);
+    z-index: 1;
+}
+
+.vc-table-row-focused {
+    outline: 2px solid var(--vc-color-primary-500);
+    outline-offset: -2px;
+}
+
+.vc-table-row-disabled {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.vc-table-loading-overlay-bulma {
+    background: hsla(var(--bulma-scheme-h, 0), var(--bulma-scheme-s, 0%), var(--bulma-scheme-main-l, 100%), 0.7);
+}

--- a/themes/bulma/src/index.ts
+++ b/themes/bulma/src/index.ts
@@ -558,6 +558,92 @@ export default function bulmaTheme(): Theme {
                     size: 'md',
                 },
             },
+            // Bulma's `.table` family covers the basic chrome. Variant
+            // mappings: `.table.is-striped`, `.is-bordered`, `.is-hoverable`,
+            // `.is-narrow` (compact). Sticky-header and per-row variants
+            // come from the bridge CSS (`vc-table-*` gap-fill helpers).
+            table: {
+                classes: { root: 'table is-fullwidth' },
+                variants: {
+                    density: {
+                        compact: { root: 'is-narrow' },
+                        normal: { root: '' },
+                        spacious: { root: '' },
+                    },
+                    striped: { true: { root: 'is-striped' } },
+                    bordered: { true: { root: 'is-bordered' } },
+                    hover: { true: { root: 'is-hoverable' } },
+                    stickyHeader: { true: { root: 'vc-table-sticky-header' } },
+                },
+                defaultVariants: { density: 'normal' },
+            },
+            tableHeader: { classes: { root: 'is-uppercase has-text-grey is-size-7' } },
+            tableBody: { classes: { root: '' } },
+            tableFooter: { classes: { root: 'has-text-weight-medium' } },
+            tableRow: {
+                variants: {
+                    disabled: { true: { root: 'vc-table-row-disabled' } },
+                    selected: { true: { root: 'is-selected' } },
+                    focused: { true: { root: 'vc-table-row-focused' } },
+                    rowVariant: {
+                        success: { root: 'has-background-success-light' },
+                        warning: { root: 'has-background-warning-light' },
+                        error: { root: 'has-background-danger-light' },
+                        info: { root: 'has-background-info-light' },
+                        neutral: { root: 'has-background-light' },
+                        primary: { root: 'has-background-primary-light' },
+                    },
+                },
+            },
+            tableCell: {
+                variants: {
+                    align: {
+                        left: { root: 'has-text-left' },
+                        center: { root: 'has-text-centered' },
+                        right: { root: 'has-text-right' },
+                    },
+                    stickyColumn: { true: { root: 'vc-table-sticky-column' } },
+                    cellVariant: {
+                        success: { root: 'has-text-success' },
+                        warning: { root: 'has-text-warning' },
+                        error: { root: 'has-text-danger' },
+                        info: { root: 'has-text-info' },
+                        neutral: { root: 'has-text-grey' },
+                        primary: { root: 'has-text-primary' },
+                    },
+                },
+            },
+            tableHeadCell: {
+                classes: { sortIcon: 'ml-1 is-size-7' },
+                variants: {
+                    align: {
+                        left: { root: 'has-text-left' },
+                        center: { root: 'has-text-centered' },
+                        right: { root: 'has-text-right' },
+                    },
+                    stickyColumn: { true: { root: 'vc-table-sticky-column' } },
+                    sorted: {
+                        asc: { root: 'vc-table-sort-asc' },
+                        desc: { root: 'vc-table-sort-desc' },
+                        none: { root: '' },
+                    },
+                },
+            },
+            tableEmpty: {
+                classes: { root: '' },
+                variants: {
+                    filtered: {
+                        true: { root: 'has-text-centered has-text-grey is-italic py-5' },
+                        false: { root: 'has-text-centered has-text-grey py-5' },
+                    },
+                },
+            },
+            tableLoading: {
+                classes: {
+                    root: 'has-text-centered has-text-grey py-5',
+                    overlay: 'vc-table-loading-overlay-bulma',
+                },
+            },
             pagination: {
                 // Bulma's pagination canonical structure is
                 // `<nav class="pagination">` containing standalone

--- a/themes/bulma/test/unit/audit.spec.ts
+++ b/themes/bulma/test/unit/audit.spec.ts
@@ -58,6 +58,17 @@ import {
     tooltipThemeDefaults,
 } from '@vuecs/overlays';
 import { paginationThemeDefaults } from '@vuecs/pagination';
+import {
+    tableBodyThemeDefaults,
+    tableCellThemeDefaults,
+    tableEmptyThemeDefaults,
+    tableFooterThemeDefaults,
+    tableHeadCellThemeDefaults,
+    tableHeaderThemeDefaults,
+    tableLoadingThemeDefaults,
+    tableRowThemeDefaults,
+    tableThemeDefaults,
+} from '@vuecs/table';
 import { timeagoThemeDefaults } from '@vuecs/timeago';
 import bulmaTheme from '../../src';
 
@@ -119,6 +130,15 @@ const expectedCatalog = {
     popover: popoverThemeDefaults,
     separator: separatorThemeDefaults,
     stepper: stepperThemeDefaults,
+    table: tableThemeDefaults,
+    tableBody: tableBodyThemeDefaults,
+    tableCell: tableCellThemeDefaults,
+    tableEmpty: tableEmptyThemeDefaults,
+    tableFooter: tableFooterThemeDefaults,
+    tableHeadCell: tableHeadCellThemeDefaults,
+    tableHeader: tableHeaderThemeDefaults,
+    tableLoading: tableLoadingThemeDefaults,
+    tableRow: tableRowThemeDefaults,
     tag: tagThemeDefaults,
     tags: tagsThemeDefaults,
     timeago: timeagoThemeDefaults,

--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -432,6 +432,96 @@ export default function tailwindTheme(): Theme {
                 },
                 defaultVariants: { size: 'md' },
             },
+            table: {
+                classes: {
+                    root: 'w-full border-collapse text-sm text-fg',
+                    scrollContainer: 'relative overflow-auto rounded-md border border-border',
+                },
+                variants: {
+                    density: {
+                        compact: { root: '[&_td]:py-1 [&_th]:py-1.5' },
+                        normal: { root: '[&_td]:py-2 [&_th]:py-2.5' },
+                        spacious: { root: '[&_td]:py-3 [&_th]:py-3.5' },
+                    },
+                    striped: { true: { root: '[&_tbody_tr:nth-child(even)]:bg-bg-muted/40' } },
+                    bordered: { true: { root: '[&_td]:border [&_th]:border [&_td]:border-border [&_th]:border-border' } },
+                    hover: { true: { root: '[&_tbody_tr:hover]:bg-bg-muted/60' } },
+                    stickyHeader: { true: { root: '[&_thead_th]:sticky [&_thead_th]:top-0 [&_thead_th]:bg-bg [&_thead_th]:z-10' } },
+                },
+                defaultVariants: { density: 'normal' },
+            },
+            tableHeader: { classes: { root: 'border-b border-border bg-bg-muted/30 text-xs uppercase tracking-wide text-fg-muted' } },
+            tableBody: { classes: { root: '' } },
+            tableFooter: { classes: { root: 'border-t border-border bg-bg-muted/30 font-medium' } },
+            tableRow: {
+                classes: { root: 'border-b border-border last:border-b-0 transition-colors' },
+                variants: {
+                    disabled: { true: { root: 'opacity-50 pointer-events-none' } },
+                    selected: { true: { root: 'bg-primary-50 dark:bg-primary-950/40' } },
+                    focused: { true: { root: 'outline outline-2 outline-ring outline-offset-[-2px]' } },
+                    rowVariant: {
+                        success: { root: 'bg-success-50 dark:bg-success-950/30' },
+                        warning: { root: 'bg-warning-50 dark:bg-warning-950/30' },
+                        error: { root: 'bg-error-50 dark:bg-error-950/30' },
+                        info: { root: 'bg-info-50 dark:bg-info-950/30' },
+                        neutral: { root: 'bg-neutral-50 dark:bg-neutral-900' },
+                        primary: { root: 'bg-primary-50 dark:bg-primary-950/30' },
+                    },
+                },
+            },
+            tableCell: {
+                classes: { root: 'px-3 align-middle' },
+                variants: {
+                    align: {
+                        left: { root: 'text-left' },
+                        center: { root: 'text-center' },
+                        right: { root: 'text-right' },
+                    },
+                    stickyColumn: { true: { root: 'sticky left-0 bg-bg z-[1]' } },
+                    cellVariant: {
+                        success: { root: 'text-success-700 dark:text-success-300' },
+                        warning: { root: 'text-warning-700 dark:text-warning-300' },
+                        error: { root: 'text-error-700 dark:text-error-300' },
+                        info: { root: 'text-info-700 dark:text-info-300' },
+                        neutral: { root: 'text-neutral-700 dark:text-neutral-200' },
+                        primary: { root: 'text-primary-700 dark:text-primary-300' },
+                    },
+                },
+            },
+            tableHeadCell: {
+                classes: {
+                    root: 'px-3 text-left font-medium',
+                    sortIcon: 'ml-1 inline-block text-xs leading-none',
+                },
+                variants: {
+                    align: {
+                        left: { root: 'text-left' },
+                        center: { root: 'text-center' },
+                        right: { root: 'text-right' },
+                    },
+                    stickyColumn: { true: { root: 'sticky left-0 bg-bg-muted z-[2]' } },
+                    sorted: {
+                        asc: { root: 'text-fg' },
+                        desc: { root: 'text-fg' },
+                        none: { root: '' },
+                    },
+                },
+            },
+            tableEmpty: {
+                classes: { root: '' },
+                variants: {
+                    filtered: {
+                        true: { root: '[&_td]:py-6 [&_td]:text-center [&_td]:text-fg-muted [&_td]:italic' },
+                        false: { root: '[&_td]:py-6 [&_td]:text-center [&_td]:text-fg-muted' },
+                    },
+                },
+            },
+            tableLoading: {
+                classes: {
+                    root: '[&_td]:py-6 [&_td]:text-center [&_td]:text-fg-muted',
+                    overlay: 'bg-bg/70 backdrop-blur-[1px] text-fg-muted',
+                },
+            },
             pagination: {
                 classes: {
                     root: 'inline-flex items-center',

--- a/themes/tailwind/test/unit/audit.spec.ts
+++ b/themes/tailwind/test/unit/audit.spec.ts
@@ -58,6 +58,17 @@ import {
     tooltipThemeDefaults,
 } from '@vuecs/overlays';
 import { paginationThemeDefaults } from '@vuecs/pagination';
+import {
+    tableBodyThemeDefaults,
+    tableCellThemeDefaults,
+    tableEmptyThemeDefaults,
+    tableFooterThemeDefaults,
+    tableHeadCellThemeDefaults,
+    tableHeaderThemeDefaults,
+    tableLoadingThemeDefaults,
+    tableRowThemeDefaults,
+    tableThemeDefaults,
+} from '@vuecs/table';
 import { timeagoThemeDefaults } from '@vuecs/timeago';
 import tailwindTheme from '../../src';
 
@@ -119,6 +130,15 @@ const expectedCatalog = {
     popover: popoverThemeDefaults,
     separator: separatorThemeDefaults,
     stepper: stepperThemeDefaults,
+    table: tableThemeDefaults,
+    tableBody: tableBodyThemeDefaults,
+    tableCell: tableCellThemeDefaults,
+    tableEmpty: tableEmptyThemeDefaults,
+    tableFooter: tableFooterThemeDefaults,
+    tableHeadCell: tableHeadCellThemeDefaults,
+    tableHeader: tableHeaderThemeDefaults,
+    tableLoading: tableLoadingThemeDefaults,
+    tableRow: tableRowThemeDefaults,
     tag: tagThemeDefaults,
     tags: tagsThemeDefaults,
     timeago: timeagoThemeDefaults,


### PR DESCRIPTION
## Summary

New `@vuecs/table` package — nine semantic-HTML parts (`<VCTable>` outer + `Header` / `Body` / `Footer` / `Row` / `Cell` / `HeadCell` / `Empty` / `Loading`) backed by a columns/data driver. Implements [plan 028](.agents/plans/028-table-compound.md) including every decision and the bootstrap-vue-next research-derived adoptions:

- **Column shape** — bare-string shorthand + auto-derive from `Object.keys(data[0])`; full `TableColumn` surface with `accessor` (string dot-path or function), object-arg `formatter` ctx, `isRowHeader` → `<th scope="row">` per row, `cellAttrs` / `headerAttrs` (static or function), `headerTitle` / `headerAbbr`, `stickyColumn`, `initialSortDirection`.
- **Row-meta convention** — `_rowVariant` / `_cellVariants` underscore-prefixed fields on the row payload tint rows / cells declaratively. `WithRowMeta<T>` helper.
- **Single-column controlled sort** — `useSortMachine` cycles `null → asc → desc → null` (or `→ asc` when `:must-sort`), honors per-column `initialSortDirection`. Click + Enter + Space activate.
- **Opt-in row click + keyboard nav** — `:row-clickable` adds `tabindex=0` + cursor-pointer per row, wires `↓` / `↑` / `Home` / `End` + Shift + Enter / Space. `filterRowClickEvent()` (ported from bvnext) suppresses clicks originating in interactive descendants.
- **D3 reversal** — `colspan` auto-counts from `<VCTableHeadCell>` siblings (Shape B) or `columns.length` (Shape A); per-instance `:colspan` wins. No sentinel.
- **D4 reversal** — sortable `<th tabindex="0" role="columnheader" aria-sort="…">` without inner `<button>` — matches BTable DOM, stronger AT semantics.
- **Free-win a11y** — `aria-busy` on `<table>` while `:busy`, smart `<th scope>` default (`colspan>1` → `'colgroup'`, etc.), `data-label` on every `<td>`, `role=alert/status` + `aria-live=polite` on Empty/Loading.
- **Empty-after-filter** distinct from empty-no-data via `tableEmpty.filtered` variant + `filteredContent` behavioral default. Loading has default + `:overlay` modes.
- **Theme entries** in all three shipping themes — Bootstrap composes native `.table` family; Bulma composes its `.table` family; Tailwind emits design-token utilities. Sort indicators + sticky-header + sticky-column + row-focused / row-disabled live in `vc-table-*` helpers in the BS + Bulma bridge CSS (theme strings can't carry attribute selectors).
- **Tests** — 30 vitest specs cover sort cycle, column normalization, dot-path accessor, `filterRowClickEvent`, `defineTable` factory.
- **Demo** at `examples/_shared/src/views/Table.vue` + iframe at `docs/demos/src/table.{html,ts}` + Nuxt example page + nav entry + docs sidebar + components index row + `.agents/architecture.md` Table compound section + variant catalog + `.agents/structure.md` + `AGENTS.md` all updated.

Unblocks the #1 highest-frequency gap in the authup migration inventory (9 entity index pages using `<BTable :fields :items>`).

## Test plan

- [ ] `npm run build` — all 26 projects build green (verified locally)
- [ ] `npm run test` — all 12 test workspaces pass, including the new `@vuecs/table` suite (30 tests) and three per-theme audit specs covering the nine new component keys (verified locally)
- [ ] `npm run lint` — zero errors (verified locally)
- [ ] Visual check in `examples/tailwind` / `examples/bootstrap` / `examples/bulma` — `/table` route renders driver + sort + row meta correctly in each theme
- [ ] Nuxt example: `/table` route renders, in-sidebar nav entry works
- [ ] Docs Playground at `docs/src/components/table.md` exercises variant axes via the toolbar
- [ ] Verify `aria-busy` toggles on `<table>` when `:busy` flips
- [ ] Verify Enter / Space on a focused `:sortable` `<th>` cycles sort state
- [ ] Verify `↓` / `↑` / `Home` / `End` + Shift navigate rows when `:row-clickable`
- [ ] Verify row-click suppression: clicking a `<VCButton>` inside a row should NOT fire `@row-click`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new compound table component with support for columns/data binding, controlled sorting, row click handling, and keyboard navigation.
  * Included customizable empty and loading states with flexible theming.
  * Added comprehensive theme support across Bootstrap, Bulma, and Tailwind.

* **Documentation**
  * Added component documentation with usage examples and API reference.
  * Added demo pages and integration examples.

* **Tests**
  * Added unit tests for core table utilities and composables.

* **Chores**
  * Updated package configuration and dependency manifests.
  * Updated theme audits for all supported themes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->