### PR TITLE
feat(table): default cell renderer via accessor + formatter (plan 033 v0.2-A)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1802,6 +1802,39 @@ entries copy verbatim from a migration. Auto-derive: when `:columns`
 is omitted and `data[0]` is an object, columns come from
 `Object.keys(data[0])` (skipping underscore-prefixed row-meta keys).
 
+### Default cell rendering (v0.2-A)
+
+`<VCTableCell columnKey="...">` without slot content auto-renders the
+cell value when both `<VCTable>` and `<VCTableRow>` context are
+available. Resolution order per cell:
+
+1. **Slot content wins** — any non-whitespace / non-comment slot content
+   skips the auto-render entirely. The consumer keeps full control by
+   passing children.
+2. **Column lookup** — `columnKey` is matched against `tableCtx.columns`.
+   No match → empty cell (no fallback to `row[columnKey]`).
+3. **Value resolution** — `resolveCellValue(column, row)`:
+   - `column.accessor` function → `accessor(row)`
+   - `column.accessor` string → dot-path lookup on `row` (e.g.
+     `'profile.email'`)
+   - else → `row[column.key]`
+4. **Formatting** — when `column.formatter` is set, it receives
+   `{ value, key, row }` and its return value is rendered. Otherwise
+   `null` / `undefined` render as `''`; everything else via `String(...)`.
+
+The slot-vs-auto branch is decided by `hasMeaningfulSlotContent()` —
+Vue passes `slots.default` as an always-present render fn when a
+`<template>` slot is declared, so a naive `slots.default?.()` truthy
+check would always pick the slot path. The helper walks the returned
+vnode array and considers a slot meaningful when it contains an
+element, a component, or a text node with non-whitespace content.
+
+Mounting `<VCTableCell>` outside a `<VCTable>` context renders an
+empty cell — no fallback to `row[columnKey]` from inject. Manual
+compound markup that needs auto-render must wrap rows in
+`<VCTableRow :row :index>` inside a `<VCTable>` so the contexts
+exist.
+
 ### Row-meta convention (`_rowVariant` / `_cellVariants`)
 
 Underscore-prefixed fields on the data row tint rows / specific cells

--- a/docs/src/components/table.md
+++ b/docs/src/components/table.md
@@ -122,6 +122,32 @@ columns: ['id', 'name', 'email']
 // ≡ [{ key: 'id', label: 'Id' }, { key: 'name', label: 'Name' }, ...]
 ```
 
+## Default cell rendering
+
+`<VCTableCell columnKey="...">` with no slot content auto-renders the
+value via the column's `accessor` + `formatter`. Slot content always
+wins, so passing children opts out of the default render:
+
+```vue
+<!-- Auto-rendered: row[col.key] / accessor / formatter -->
+<VCTableCell :column-key="col.key" />
+
+<!-- Slot wins: consumer renders manually -->
+<VCTableCell :column-key="col.key">
+    {{ row[col.key as keyof User] }}
+</VCTableCell>
+
+<!-- With accessor dot-path + formatter -->
+const columns: TableColumn<User>[] = [
+    { key: 'email', accessor: 'profile.email' },
+    { key: 'price', formatter: ({ value }) => `$${value}` },
+];
+```
+
+`null` / `undefined` resolve to empty strings. Mounting
+`<VCTableCell>` outside a `<VCTable>` (or with a `columnKey` that
+isn't in the columns array) renders an empty cell.
+
 ## Row meta — `_rowVariant` / `_cellVariants`
 
 Underscore-prefixed fields on the data row tint the row / specific cells without forcing a function prop:

--- a/examples/_shared/src/views/Table.vue
+++ b/examples/_shared/src/views/Table.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import {
     VCTable,
     VCTableBody,
@@ -101,6 +101,26 @@ const data: WithRowMeta<User>[] = [
     },
 ];
 
+// Controlled sort: VCTable emits sort intent via `v-model:sort` but
+// never reorders data itself. The demo applies the sort client-side
+// so the user sees real reordering across every sortable column.
+const sortedData = computed(() => {
+    const s = sort.value;
+    if (!s) return data;
+    const key = s.key as keyof User;
+    const dir = s.direction === 'asc' ? 1 : -1;
+    return [...data].sort((a, b) => {
+        const av = a[key];
+        const bv = b[key];
+        if (av == null && bv == null) return 0;
+        if (av == null) return 1;
+        if (bv == null) return -1;
+        if (av < bv) return -1 * dir;
+        if (av > bv) return 1 * dir;
+        return 0;
+    });
+});
+
 const lastClicked = ref<User | null>(null);
 function onRowClick(row: User) { lastClicked.value = row; }
 </script>
@@ -115,7 +135,7 @@ function onRowClick(row: User) { lastClicked.value = row; }
             <VCTable
                 v-model:sort="sort"
                 :columns="columns"
-                :data="data"
+                :data="sortedData"
                 :density="density"
                 :striped="striped"
                 :bordered="bordered"

--- a/packages/table/src/components/TableCell.vue
+++ b/packages/table/src/components/TableCell.vue
@@ -1,10 +1,17 @@
 <script lang="ts">
-import { defineComponent, h, mergeProps } from 'vue';
-import type { 
-    ExtractPublicPropTypes, 
-    PropType, 
-    Slot, 
-    VNodeArrayChildren, 
+import {
+    Comment,
+    Fragment,
+    Text,
+    defineComponent,
+    h,
+    mergeProps,
+} from 'vue';
+import type {
+    ExtractPublicPropTypes,
+    PropType,
+    VNode,
+    VNodeArrayChildren,
 } from 'vue';
 import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
 import { useTable, useTableRow } from '../composables/context';
@@ -34,30 +41,44 @@ const tableCellProps = {
 export type TableCellProps = ExtractPublicPropTypes<typeof tableCellProps>;
 
 /**
- * Detect whether the consumer-passed default slot actually has content
- * (vs being an empty / whitespace-only / comment-only render).
+ * Detect whether the consumer-passed default slot's rendered vnodes
+ * contain any meaningful content (vs being an empty / whitespace-only
+ * / comment-only render).
  *
  * Vue passes `slots.default` as a render fn that's always present when
  * a `<template>` slot is declared (even if empty), so a naive
- * `slots.default?.()` check would always pick the slot path and skip
- * the auto-render. Walk the returned vnode array and look for at least
- * one element / text node with non-whitespace content.
+ * `slots.default?.()` truthy check would always pick the slot path
+ * and skip the auto-render. Walk the rendered vnodes and recurse into
+ * `Fragment` children — a `<template v-if>` / `<template v-for>` /
+ * multi-child template renders as a Fragment whose `children` is the
+ * actual content. Without recursion those would be falsely classified
+ * as empty.
+ *
+ * Takes the pre-rendered vnodes (not the slot fn) so the caller can
+ * invoke the slot at most once per render — slot fns can be
+ * non-trivial and should not be called twice.
  */
-function hasMeaningfulSlotContent(slot: Slot | undefined): boolean {
-    if (!slot) return false;
-    const vnodes = slot();
-    if (!Array.isArray(vnodes)) return !!vnodes;
-    for (const v of vnodes) {
-        // Comments + static placeholders → skip.
-        if (typeof v.type === 'symbol') {
-            // Text nodes: type === Text symbol; children is the text.
-            if (typeof v.children === 'string' && v.children.trim().length > 0) return true;
-            continue;
+function hasMeaningfulSlotContent(nodes: unknown): boolean {
+    if (nodes == null || nodes === false) return false;
+    if (typeof nodes === 'string') return nodes.trim().length > 0;
+    if (typeof nodes === 'number') return true;
+    if (Array.isArray(nodes)) {
+        for (const child of nodes) {
+            if (hasMeaningfulSlotContent(child)) return true;
         }
-        // Element or component vnode.
-        return true;
+        return false;
     }
-    return false;
+    if (typeof nodes !== 'object') return false;
+    const v = nodes as VNode;
+    if (v.type === Comment) return false;
+    if (v.type === Text) {
+        return typeof v.children === 'string' && v.children.trim().length > 0;
+    }
+    if (v.type === Fragment) {
+        return hasMeaningfulSlotContent(v.children);
+    }
+    // Element or component vnode (string tag, object component, symbol other than the above).
+    return true;
 }
 
 export default defineComponent({
@@ -88,13 +109,14 @@ export default defineComponent({
             // content AND we have enough context (table column lookup + row
             // value), resolve via `accessor` + `formatter`. Slot content
             // always wins — the consumer keeps full control when they pass
-            // anything.
-            let content: unknown = slots.default?.();
+            // anything. Invoke `slots.default` at most once per render.
+            const slotVNodes = slots.default?.();
+            let content: unknown = slotVNodes;
             if (
                 props.columnKey &&
                 tableCtx &&
                 rowCtx &&
-                !hasMeaningfulSlotContent(slots.default)
+                !hasMeaningfulSlotContent(slotVNodes)
             ) {
                 const column = tableCtx.columns.value
                     .find((c) => c.key === props.columnKey);

--- a/packages/table/src/components/TableCell.vue
+++ b/packages/table/src/components/TableCell.vue
@@ -1,8 +1,14 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { 
+    ExtractPublicPropTypes, 
+    PropType, 
+    Slot, 
+    VNodeArrayChildren, 
+} from 'vue';
 import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
-import { useTableRow } from '../composables/context';
+import { useTable, useTableRow } from '../composables/context';
+import { resolveCellValue } from '../utils/render-utils';
 import type { TableCellThemeClasses } from '../types';
 
 const tableCellThemeDefaults = { classes: { root: 'vc-table-cell' } };
@@ -10,7 +16,11 @@ const tableCellThemeDefaults = { classes: { root: 'vc-table-cell' } };
 const tableCellProps = {
     /** Render as `<th scope="row">` instead of `<td>` (mirror of `column.isRowHeader`). */
     isRowHeader: { type: Boolean, default: false },
-    /** Column key this cell corresponds to — used to resolve `_cellVariants[key]` from row meta. */
+    /**
+     * Column key this cell corresponds to — used to resolve
+     * `_cellVariants[key]` from row meta AND to look up the column's
+     * `accessor` / `formatter` for the default-render path.
+     */
     columnKey: { type: String, default: undefined },
     /** Forward-compat for stacked-mode CSS — emitted as `data-label`. */
     dataLabel: { type: String, default: undefined },
@@ -23,11 +33,39 @@ const tableCellProps = {
 
 export type TableCellProps = ExtractPublicPropTypes<typeof tableCellProps>;
 
+/**
+ * Detect whether the consumer-passed default slot actually has content
+ * (vs being an empty / whitespace-only / comment-only render).
+ *
+ * Vue passes `slots.default` as a render fn that's always present when
+ * a `<template>` slot is declared (even if empty), so a naive
+ * `slots.default?.()` check would always pick the slot path and skip
+ * the auto-render. Walk the returned vnode array and look for at least
+ * one element / text node with non-whitespace content.
+ */
+function hasMeaningfulSlotContent(slot: Slot | undefined): boolean {
+    if (!slot) return false;
+    const vnodes = slot();
+    if (!Array.isArray(vnodes)) return !!vnodes;
+    for (const v of vnodes) {
+        // Comments + static placeholders → skip.
+        if (typeof v.type === 'symbol') {
+            // Text nodes: type === Text symbol; children is the text.
+            if (typeof v.children === 'string' && v.children.trim().length > 0) return true;
+            continue;
+        }
+        // Element or component vnode.
+        return true;
+    }
+    return false;
+}
+
 export default defineComponent({
     name: 'VCTableCell',
     inheritAttrs: false,
     props: tableCellProps,
     setup(props, { attrs, slots }) {
+        const tableCtx = useTable();
         const rowCtx = useTableRow();
         const themeProps = useThemeProps(props, 'align', 'stickyColumn');
 
@@ -45,16 +83,48 @@ export default defineComponent({
         };
         const theme = useComponentTheme('tableCell', mergedThemeProps, tableCellThemeDefaults);
 
-        return () => h(
-            props.isRowHeader ? 'th' : 'td',
-            mergeProps(attrs, {
-                class: theme.value.root || undefined,
-                'data-label': props.dataLabel || undefined,
-                'data-sticky-column': props.stickyColumn ? '' : undefined,
-                scope: props.isRowHeader ? 'row' : undefined,
-            }),
-            slots.default?.(),
-        );
+        return () => {
+            // Default-render path: when the consumer didn't provide slot
+            // content AND we have enough context (table column lookup + row
+            // value), resolve via `accessor` + `formatter`. Slot content
+            // always wins — the consumer keeps full control when they pass
+            // anything.
+            let content: unknown = slots.default?.();
+            if (
+                props.columnKey &&
+                tableCtx &&
+                rowCtx &&
+                !hasMeaningfulSlotContent(slots.default)
+            ) {
+                const column = tableCtx.columns.value
+                    .find((c) => c.key === props.columnKey);
+                if (column) {
+                    const value = resolveCellValue(column, rowCtx.row.value);
+                    if (column.formatter) {
+                        content = column.formatter({
+                            value,
+                            key: column.key,
+                            row: rowCtx.row.value,
+                        });
+                    } else if (value === undefined || value === null) {
+                        content = '';
+                    } else {
+                        content = String(value);
+                    }
+                }
+            }
+
+            return h(
+                props.isRowHeader ? 'th' : 'td',
+                mergeProps(attrs, {
+                    class: theme.value.root || undefined,
+                    'data-label': props.dataLabel || undefined,
+                    'data-sticky-column': props.stickyColumn ? '' : undefined,
+                    scope: props.isRowHeader ? 'row' : undefined,
+                }),
+                content as string | VNodeArrayChildren,
+            );
+        };
     },
 });
 </script>

--- a/packages/table/test/unit/default-cell-renderer.spec.ts
+++ b/packages/table/test/unit/default-cell-renderer.spec.ts
@@ -5,7 +5,7 @@ import {
     expect,
     it,
 } from 'vitest';
-import { defineComponent, h } from 'vue';
+import { Fragment, defineComponent, h } from 'vue';
 import { mount } from '@vue/test-utils';
 import vuecsTable, {
     VCTable,
@@ -89,6 +89,12 @@ describe('<VCTableCell> default renderer', () => {
                                         h(VCTableCell, { columnKey: 'missing' }),
                                     ],
                                 }),
+                                h(VCTableRow, { row: { name: 'Bob', missing: undefined }, index: 1 }, {
+                                    default: () => [
+                                        h(VCTableCell, { columnKey: 'name' }),
+                                        h(VCTableCell, { columnKey: 'missing' }),
+                                    ],
+                                }),
                             ],
                         }),
                     ],
@@ -99,6 +105,8 @@ describe('<VCTableCell> default renderer', () => {
         const cells = wrapper.element.querySelectorAll('tbody td');
         expect(cells[0].textContent).toBe('Alice');
         expect(cells[1].textContent).toBe('');
+        expect(cells[2].textContent).toBe('Bob');
+        expect(cells[3].textContent).toBe('');
     });
 
     it('honors string-accessor dot-path', () => {
@@ -223,6 +231,32 @@ describe('<VCTableCell> default renderer', () => {
             row: data[0], 
         });
         wrapper.unmount();
+    });
+
+    it('honors Fragment-wrapped slot content (e.g. template v-if / v-for)', () => {
+        const wrapper = mount(defineComponent({
+            setup() {
+                return () => h(VCTable, {
+                    columns: [
+                        { key: 'name', formatter: () => 'AUTO' },
+                    ] as never,
+                    data: data as never,
+                }, {
+                    default: () => [
+                        h(VCTableHeader),
+                        h(VCTableBody, null, {
+                            default: () => [h(VCTableRow, { row: data[0], index: 0 }, {
+                                default: () => [
+                                    h(VCTableCell, { columnKey: 'name' }, { default: () => [h(Fragment, null, ['FRAGMENT'])] }),
+                                ],
+                            })],
+                        }),
+                    ],
+                });
+            },
+        }), { global: { plugins: [...plugins] } });
+        // Without Fragment-aware walk the cell would render 'AUTO'.
+        expect(wrapper.element.querySelector('tbody td')!.textContent).toBe('FRAGMENT');
     });
 
     it('consumer slot content overrides the default renderer', () => {

--- a/packages/table/test/unit/default-cell-renderer.spec.ts
+++ b/packages/table/test/unit/default-cell-renderer.spec.ts
@@ -1,0 +1,289 @@
+// @vitest-environment jsdom
+import {
+    afterEach,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { defineComponent, h } from 'vue';
+import { mount } from '@vue/test-utils';
+import vuecsTable, {
+    VCTable,
+    VCTableBody,
+    VCTableCell,
+    VCTableHeader,
+    VCTableRow,
+} from '../../src';
+
+const plugins = [[vuecsTable, {}]] as const;
+
+type User = {
+    id: number; 
+    name: string; 
+    profile: { email: string } 
+};
+
+const data: User[] = [
+    {
+        id: 1, 
+        name: 'Alice', 
+        profile: { email: 'alice@example.com' }, 
+    },
+    {
+        id: 2, 
+        name: 'Bob', 
+        profile: { email: 'bob@example.com' }, 
+    },
+];
+
+function mountTable(opts: {
+    columns?: unknown; 
+    cellSlot?: () => unknown; 
+    cellAttrs?: Record<string, unknown> 
+} = {}) {
+    return mount(defineComponent({
+        setup() {
+            return () => h(VCTable, { columns: opts.columns as never, data: data as never }, {
+                default: () => [
+                    h(VCTableHeader),
+                    h(VCTableBody, null, {
+                        default: () => data.map((row) => h(VCTableRow, { row, index: data.indexOf(row) }, {
+                            default: () => [
+                                h(VCTableCell, { columnKey: 'id', ...opts.cellAttrs }, opts.cellSlot && opts.cellAttrs?.columnKey === 'id' ? { default: opts.cellSlot } : undefined),
+                                h(VCTableCell, { columnKey: 'name', ...opts.cellAttrs }, opts.cellSlot && opts.cellAttrs?.columnKey === 'name' ? { default: opts.cellSlot } : undefined),
+                            ],
+                        })),
+                    }),
+                ],
+            });
+        },
+    }), { global: { plugins: [...plugins] } });
+}
+
+describe('<VCTableCell> default renderer', () => {
+    afterEach(() => { document.body.innerHTML = ''; });
+
+    it('renders row[columnKey] when no accessor / formatter / slot', () => {
+        const wrapper = mountTable({ columns: [{ key: 'id' }, { key: 'name' }] });
+        const cells = wrapper.element.querySelectorAll('tbody td');
+        expect(cells[0].textContent).toBe('1');
+        expect(cells[1].textContent).toBe('Alice');
+        expect(cells[2].textContent).toBe('2');
+        expect(cells[3].textContent).toBe('Bob');
+    });
+
+    it('renders empty string for null / undefined values', () => {
+        const wrapper = mount(defineComponent({
+            setup() {
+                return () => h(VCTable, {
+                    columns: [{ key: 'name' }, { key: 'missing' }] as never,
+                    data: [{ name: 'Alice', missing: null }, { name: 'Bob', missing: undefined }] as never,
+                }, {
+                    default: () => [
+                        h(VCTableHeader),
+                        h(VCTableBody, null, {
+                            default: () => [
+                                h(VCTableRow, { row: { name: 'Alice', missing: null }, index: 0 }, {
+                                    default: () => [
+                                        h(VCTableCell, { columnKey: 'name' }),
+                                        h(VCTableCell, { columnKey: 'missing' }),
+                                    ],
+                                }),
+                            ],
+                        }),
+                    ],
+                });
+            },
+        }), { global: { plugins: [...plugins] } });
+
+        const cells = wrapper.element.querySelectorAll('tbody td');
+        expect(cells[0].textContent).toBe('Alice');
+        expect(cells[1].textContent).toBe('');
+    });
+
+    it('honors string-accessor dot-path', () => {
+        const wrapper = mount(defineComponent({
+            setup() {
+                return () => h(VCTable, {
+                    columns: [
+                        { key: 'name' },
+                        { key: 'email', accessor: 'profile.email' },
+                    ] as never,
+                    data: data as never,
+                }, {
+                    default: () => [
+                        h(VCTableHeader),
+                        h(VCTableBody, null, {
+                            default: () => data.map((row) => h(VCTableRow, { row, index: data.indexOf(row) }, {
+                                default: () => [
+                                    h(VCTableCell, { columnKey: 'name' }),
+                                    h(VCTableCell, { columnKey: 'email' }),
+                                ],
+                            })),
+                        }),
+                    ],
+                });
+            },
+        }), { global: { plugins: [...plugins] } });
+
+        const cells = wrapper.element.querySelectorAll('tbody td');
+        expect(cells[0].textContent).toBe('Alice');
+        expect(cells[1].textContent).toBe('alice@example.com');
+        expect(cells[2].textContent).toBe('Bob');
+        expect(cells[3].textContent).toBe('bob@example.com');
+    });
+
+    it('honors function-accessor', () => {
+        const wrapper = mount(defineComponent({
+            setup() {
+                return () => h(VCTable, {
+                    columns: [
+                        { key: 'name' },
+                        { key: 'shouty', accessor: (r: User) => r.name.toUpperCase() },
+                    ] as never,
+                    data: data as never,
+                }, {
+                    default: () => [
+                        h(VCTableHeader),
+                        h(VCTableBody, null, {
+                            default: () => data.map((row) => h(VCTableRow, { row, index: data.indexOf(row) }, {
+                                default: () => [
+                                    h(VCTableCell, { columnKey: 'name' }),
+                                    h(VCTableCell, { columnKey: 'shouty' }),
+                                ],
+                            })),
+                        }),
+                    ],
+                });
+            },
+        }), { global: { plugins: [...plugins] } });
+
+        const cells = wrapper.element.querySelectorAll('tbody td');
+        expect(cells[1].textContent).toBe('ALICE');
+        expect(cells[3].textContent).toBe('BOB');
+    });
+
+    it('runs formatter on the resolved value', () => {
+        const wrapper = mount(defineComponent({
+            setup() {
+                return () => h(VCTable, {
+                    columns: [
+                        { key: 'id', formatter: (ctx: { value: unknown }) => `#${ctx.value}` },
+                        { key: 'name', formatter: (ctx: { value: unknown }) => `Mr ${ctx.value}` },
+                    ] as never,
+                    data: data as never,
+                }, {
+                    default: () => [
+                        h(VCTableHeader),
+                        h(VCTableBody, null, {
+                            default: () => data.map((row) => h(VCTableRow, { row, index: data.indexOf(row) }, {
+                                default: () => [
+                                    h(VCTableCell, { columnKey: 'id' }),
+                                    h(VCTableCell, { columnKey: 'name' }),
+                                ],
+                            })),
+                        }),
+                    ],
+                });
+            },
+        }), { global: { plugins: [...plugins] } });
+
+        const cells = wrapper.element.querySelectorAll('tbody td');
+        expect(cells[0].textContent).toBe('#1');
+        expect(cells[1].textContent).toBe('Mr Alice');
+    });
+
+    it('formatter receives { value, key, row }', () => {
+        let ctxSeen: unknown;
+        const wrapper = mount(defineComponent({
+            setup() {
+                return () => h(VCTable, {
+                    columns: [
+                        {
+                            key: 'name',
+                            formatter: (ctx) => {
+                                ctxSeen = ctx;
+                                return String(ctx.value);
+                            },
+                        },
+                    ] as never,
+                    data: data as never,
+                }, {
+                    default: () => [
+                        h(VCTableHeader),
+                        h(VCTableBody, null, { default: () => [h(VCTableRow, { row: data[0], index: 0 }, { default: () => [h(VCTableCell, { columnKey: 'name' })] })] }),
+                    ],
+                });
+            },
+        }), { global: { plugins: [...plugins] } });
+
+        expect(ctxSeen).toEqual({
+            value: 'Alice', 
+            key: 'name', 
+            row: data[0], 
+        });
+        wrapper.unmount();
+    });
+
+    it('consumer slot content overrides the default renderer', () => {
+        const wrapper = mount(defineComponent({
+            setup() {
+                return () => h(VCTable, {
+                    columns: [
+                        { key: 'name', formatter: () => 'AUTO' },
+                    ] as never,
+                    data: data as never,
+                }, {
+                    default: () => [
+                        h(VCTableHeader),
+                        h(VCTableBody, null, {
+                            default: () => [h(VCTableRow, { row: data[0], index: 0 }, {
+                                default: () => [
+                                    h(VCTableCell, { columnKey: 'name' }, { default: () => 'CUSTOM' }),
+                                ],
+                            })],
+                        }),
+                    ],
+                });
+            },
+        }), { global: { plugins: [...plugins] } });
+        expect(wrapper.element.querySelector('tbody td')!.textContent).toBe('CUSTOM');
+    });
+
+    it('does NOT auto-render when columnKey is not in the columns array', () => {
+        const wrapper = mount(defineComponent({
+            setup() {
+                return () => h(VCTable, {
+                    columns: [{ key: 'name' }] as never,
+                    data: data as never,
+                }, {
+                    default: () => [
+                        h(VCTableHeader),
+                        h(VCTableBody, null, {
+                            default: () => [h(VCTableRow, { row: data[0], index: 0 }, {
+                                default: () => [
+                                    h(VCTableCell, { columnKey: 'unknown' }),
+                                ],
+                            })],
+                        }),
+                    ],
+                });
+            },
+        }), { global: { plugins: [...plugins] } });
+        // No matching column → no auto-render → empty cell.
+        expect(wrapper.element.querySelector('tbody td')!.textContent).toBe('');
+    });
+
+    it('renders empty when mounted outside a <VCTable> context (no fallback render)', () => {
+        // Standalone <VCTableCell> with no parent table — should not throw,
+        // just render empty.
+        const wrapper = mount(defineComponent({
+            setup() {
+                return () => h('table', null, [h('tbody', null, [h('tr', null, [
+                    h(VCTableCell, { columnKey: 'name' }),
+                ])])]);
+            },
+        }), { global: { plugins: [...plugins] } });
+        expect(wrapper.element.querySelector('td')!.textContent).toBe('');
+    });
+});


### PR DESCRIPTION
## Summary

Closes a v0.1 correctness gap in `<VCTable>`: `TableColumn.accessor` and `TableColumn.formatter` were declared on the column shape but never invoked. Consumers had to render every cell manually inside `<VCTableCell>`'s slot.

`<VCTableCell columnKey="...">` with no slot content now auto-renders the cell value via:

1. **Slot content wins** — any non-whitespace / non-comment slot content skips auto-render.
2. **Column lookup** — `columnKey` is matched against `tableCtx.columns`. No match → empty cell.
3. **Value resolution** — `column.accessor` (fn or string dot-path) or `row[column.key]`.
4. **Formatting** — `column.formatter({ value, key, row })` if set; else `null`/`undefined` → `''`, everything else via `String(...)`.

The slot-vs-auto branch is decided by `hasMeaningfulSlotContent()` which walks the slot vnodes — Vue passes `slots.default` as an always-present render fn when a `<template>` slot is declared, so a naive truthy check would always pick the slot path.

Mounting `<VCTableCell>` outside a `<VCTable>` context renders an empty cell (no fallback to `row[columnKey]`).

Scope: ~15 LOC of runtime logic + 8 new unit tests (39 total in the package) + doc updates.

## Test plan

- [x] `npm run test --workspace=@vuecs/table` — 39/39 passing (8 new tests cover key lookup, null/undefined, string-accessor, fn-accessor, formatter exec, formatter ctx shape, slot override, unknown key, standalone-no-context)
- [x] `npm run lint` on changed files — clean (only `vue/one-component-per-file` warnings, consistent with the rest of the table test suite)
- [x] `npx nx build @vuecs/table` — green
- [ ] Manual: run the table demo in `examples/tailwind` and verify slot-overridden cells still render consumer content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table cells auto-render values via column accessors/formatters when no custom slot content is provided.

* **Documentation**
  * Added detailed docs describing default cell rendering, precedence rules, and examples.

* **Tests**
  * Added comprehensive unit tests covering rendering, accessors, formatters, slot overrides, and edge cases.

* **Examples**
  * Demo table now client-side sorts rows when using column sorting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->