### PR TITLE
fix: pre-release audit batch (items 1-19)

### DIFF
--- a/packages/core/src/config/composable.ts
+++ b/packages/core/src/config/composable.ts
@@ -5,6 +5,16 @@ import { ConfigManager } from './manager';
 import type { Config } from './types';
 
 /**
+ * Module-level fallback manager. Used when no manager is installed
+ * via `app.use(vuecs)`. Singleton on purpose — every `useConfig`
+ * call without an injected manager should see the SAME instance, so
+ * `setConfig` / `withDefaults` calls observed by one consumer are
+ * also observed by the next. Previously the fallback was constructed
+ * per-call, so state was lost between consumers.
+ */
+const fallbackManager = new ConfigManager();
+
+/**
  * Reactive accessor for a single config key. Returns a `ComputedRef` so
  * locale / direction changes propagate automatically.
  *
@@ -29,7 +39,7 @@ export function useConfig<K extends keyof Config>(
     key: K,
     fallback?: NonNullable<Config[K]>,
 ): ComputedRef<Config[K] | undefined> {
-    const manager = injectConfigManager() ?? new ConfigManager();
+    const manager = injectConfigManager() ?? fallbackManager;
     return computed(() => {
         const value = manager.get(key);
         return value === undefined ? fallback : value;

--- a/packages/core/src/config/composable.ts
+++ b/packages/core/src/config/composable.ts
@@ -1,18 +1,35 @@
-import { computed } from 'vue';
-import type { ComputedRef } from 'vue';
+import { computed, getCurrentInstance } from 'vue';
+import type { App, ComputedRef } from 'vue';
 import { injectConfigManager } from './install';
 import { ConfigManager } from './manager';
 import type { Config } from './types';
 
 /**
- * Module-level fallback manager. Used when no manager is installed
- * via `app.use(vuecs)`. Singleton on purpose — every `useConfig`
- * call without an injected manager should see the SAME instance, so
- * `setConfig` / `withDefaults` calls observed by one consumer are
- * also observed by the next. Previously the fallback was constructed
- * per-call, so state was lost between consumers.
+ * Per-app fallback managers. Used when no manager is installed via
+ * `app.use(vuecs)`. Keyed by Vue's `App` instance so consumers
+ * within the same app share state (so `setConfig` / `withDefaults`
+ * propagates between callers), but separate apps — and separate
+ * SSR requests, which each get a fresh `App` — get isolated
+ * managers. A module-level singleton would leak state between SSR
+ * requests in the same JS runtime.
+ *
+ * The non-app fallback (when `getCurrentInstance()` returns null —
+ * e.g. composable invoked outside `setup()` in a unit test) uses a
+ * dedicated singleton sentinel keyed on `noAppFallback`.
  */
-const fallbackManager = new ConfigManager();
+const fallbackManagers = new WeakMap<App | { __noApp: true }, ConfigManager>();
+const noAppFallback: { __noApp: true } = { __noApp: true };
+
+function resolveFallbackManager(): ConfigManager {
+    const instance = getCurrentInstance();
+    const key: App | { __noApp: true } = instance?.appContext.app ?? noAppFallback;
+    let manager = fallbackManagers.get(key);
+    if (!manager) {
+        manager = new ConfigManager();
+        fallbackManagers.set(key, manager);
+    }
+    return manager;
+}
 
 /**
  * Reactive accessor for a single config key. Returns a `ComputedRef` so
@@ -39,7 +56,7 @@ export function useConfig<K extends keyof Config>(
     key: K,
     fallback?: NonNullable<Config[K]>,
 ): ComputedRef<Config[K] | undefined> {
-    const manager = injectConfigManager() ?? fallbackManager;
+    const manager = injectConfigManager() ?? resolveFallbackManager();
     return computed(() => {
         const value = manager.get(key);
         return value === undefined ? fallback : value;

--- a/packages/core/src/config/manager.ts
+++ b/packages/core/src/config/manager.ts
@@ -23,16 +23,30 @@ export class ConfigManager {
 
     private readonly defaultsMap: Partial<Config>;
 
+    private readonly parent: ConfigManager | undefined;
+
     /**
      * @param options.config — consumer-supplied config (wins over defaults).
      * @param options.defaults — pre-seeded defaults map. Used by
      *   `<VCConfigProvider>` to inherit a parent manager's registered
      *   defaults at construction time. Snapshot, not reactive — defaults
      *   registered on the parent AFTER the child mounts don't propagate.
+     * @param options.parent — optional parent manager. When set, `get()`
+     *   falls through to the parent's chain for keys the child doesn't
+     *   override locally (consumer config + local defaults). This way
+     *   a top-level `setConfig({ locale: 'de' })` reaches subtree
+     *   consumers reactively, instead of being shadowed by the
+     *   subtree's constructor-time snapshot.
      */
-    constructor(options: ConfigManagerOptions & { defaults?: Partial<Config> } = {}) {
+    constructor(options: ConfigManagerOptions & { defaults?: Partial<Config>; parent?: ConfigManager } = {}) {
         this.configRef = shallowRef(options.config || {});
-        this.defaultsMap = { ...CORE_DEFAULTS, ...options.defaults };
+        // Only the ROOT manager seeds `CORE_DEFAULTS`; child managers
+        // inherit them via the parent chain, so they're never lost
+        // but also never double-applied.
+        this.defaultsMap = options.parent ?
+            { ...options.defaults } :
+            { ...CORE_DEFAULTS, ...options.defaults };
+        this.parent = options.parent;
     }
 
     get config(): ConfigManagerOptions['config'] {
@@ -83,7 +97,14 @@ export class ConfigManager {
         const raw = (this.configRef.value as Record<string, unknown>)?.[key];
         const value = isRef(raw) ? unref(raw) : raw;
         if (value === undefined || value === null) {
-            return this.defaultsMap[key];
+            const local = this.defaultsMap[key];
+            if (local !== undefined) return local;
+            // Chain through to the parent manager so a top-level
+            // `setConfig` propagates into subtree-scoped consumers for
+            // keys the subtree didn't override. Reads `parent.get(key)`
+            // reactively — the child's `useConfig(key)` computed
+            // re-runs when the parent's `configRef` flips.
+            return this.parent?.get(key);
         }
         return value as Config[K];
     }

--- a/packages/core/src/config/provider/Provider.vue
+++ b/packages/core/src/config/provider/Provider.vue
@@ -39,9 +39,14 @@ export default defineComponent({
     },
     setup(props, { slots }) {
         const parent = injectConfigManager();
+        // Pass `parent` (not snapshot defaults) so a top-level
+        // `setConfig` for inherited keys flows reactively into the
+        // subtree. Previously the child only saw a constructor-time
+        // snapshot of parent defaults, so post-mount parent changes
+        // didn't reach subtree consumers.
         const local = new ConfigManager({
             config: props.config,
-            defaults: parent?.defaults,
+            parent,
         });
         provideConfigManager(local);
         return () => slots.default?.();

--- a/packages/core/src/utils/composables/use-state-machine.ts
+++ b/packages/core/src/utils/composables/use-state-machine.ts
@@ -11,7 +11,11 @@ export function useStateMachine<S extends string, E extends string>(
 
     const dispatch = (event: E) => {
         const next = machine[state.value]?.[event];
-        if (next) {
+        // `S extends string` permits empty-string states. A truthy
+        // check here would silently drop `'' → ?` transitions; use an
+        // explicit undefined check so unknown events stay no-ops but
+        // legitimate empty-state targets transition correctly.
+        if (next !== undefined) {
             state.value = next;
         }
     };

--- a/packages/elements/src/components/alert/Alert.vue
+++ b/packages/elements/src/components/alert/Alert.vue
@@ -51,6 +51,8 @@ const alertProps = {
 export type AlertProps = ExtractPublicPropTypes<typeof alertProps>;
 
 const alertBehavioralDefaults: AlertDefaults = {
+    primaryIcon: '',
+    neutralIcon: '',
     infoIcon: '',
     successIcon: '',
     warningIcon: '',
@@ -85,6 +87,8 @@ export default defineComponent({
                 case 'warning': return defaults.value.warningIcon;
                 case 'success': return defaults.value.successIcon;
                 case 'info': return defaults.value.infoIcon;
+                case 'primary': return defaults.value.primaryIcon;
+                case 'neutral': return defaults.value.neutralIcon;
                 default: return '';
             }
         });

--- a/packages/elements/src/components/alert/types.ts
+++ b/packages/elements/src/components/alert/types.ts
@@ -28,6 +28,9 @@ export type AlertDescriptionThemeClasses = {
 };
 
 export type AlertDefaults = {
+    /** Color-derived default icons. Empty string = no icon for that color (primary / neutral default to no icon). */
+    primaryIcon: string;
+    neutralIcon: string;
     infoIcon: string;
     successIcon: string;
     warningIcon: string;

--- a/packages/elements/src/components/tag/Tag.vue
+++ b/packages/elements/src/components/tag/Tag.vue
@@ -1,5 +1,10 @@
 <script lang="ts">
-import { defineComponent, h, mergeProps } from 'vue';
+import { 
+    defineComponent, 
+    h, 
+    mergeProps, 
+    resolveComponent, 
+} from 'vue';
 import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
 import { useComponentTheme } from '@vuecs/core';
 import type {
@@ -78,9 +83,13 @@ export default defineComponent({
 
             if (props.icon || slots.icon) {
                 const iconSlot = slots.icon;
-                children.push(h('span', { class: resolved.icon || undefined }, iconSlot ?
+                // When the consumer passes an `:icon="..."` string
+                // (Iconify name), mount `<VCIcon name="...">` instead
+                // of rendering the raw string as text content.
+                const iconNode = iconSlot ?
                     iconSlot({ class: resolved.icon }) :
-                    [props.icon]));
+                    [h(resolveComponent('VCIcon'), { name: props.icon })];
+                children.push(h('span', { class: resolved.icon || undefined }, iconNode));
             }
 
             children.push(slots.default ?

--- a/packages/elements/src/components/tag/Tag.vue
+++ b/packages/elements/src/components/tag/Tag.vue
@@ -64,6 +64,13 @@ export default defineComponent({
         slots,
         emit,
     }) {
+        // Resolve `<VCIcon>` once at setup. `resolveComponent`
+        // returns the literal lookup string when `@vuecs/icon` isn't
+        // installed (optional peer); guard so the bare `:icon="..."`
+        // path falls back to the raw text content instead of
+        // rendering an unknown `<VCIcon>` element.
+        const VCIcon = resolveComponent('VCIcon');
+        const hasIconComponent = typeof VCIcon !== 'string';
         const themeProps: UseComponentThemeProps<TagThemeClasses> = {
             get themeClass() {
                 return props.themeClass;
@@ -83,13 +90,16 @@ export default defineComponent({
 
             if (props.icon || slots.icon) {
                 const iconSlot = slots.icon;
-                // When the consumer passes an `:icon="..."` string
-                // (Iconify name), mount `<VCIcon name="...">` instead
-                // of rendering the raw string as text content.
-                const iconNode = iconSlot ?
-                    iconSlot({ class: resolved.icon }) :
-                    [h(resolveComponent('VCIcon'), { name: props.icon })];
-                children.push(h('span', { class: resolved.icon || undefined }, iconNode));
+                // Slot wins. Otherwise mount `<VCIcon>` if available;
+                // when `@vuecs/icon` isn't installed (`VCIcon` is the
+                // raw lookup string), render the icon name as plain
+                // text so the chip is still visually distinct rather
+                // than crashing with an unknown component error.
+                let iconNode: unknown;
+                if (iconSlot) iconNode = iconSlot({ class: resolved.icon });
+                else if (hasIconComponent) iconNode = [h(VCIcon, { name: props.icon })];
+                else iconNode = [props.icon];
+                children.push(h('span', { class: resolved.icon || undefined }, iconNode as never));
             }
 
             children.push(slots.default ?

--- a/packages/forms/src/components/form-group/FormGroup.vue
+++ b/packages/forms/src/components/form-group/FormGroup.vue
@@ -13,7 +13,7 @@ import type {
     SlotsType,
     VNodeChild,
 } from 'vue';
-import { defineComponent, h } from 'vue';
+import { defineComponent, h, mergeProps } from 'vue';
 import { ValidationSeverity } from '../constants';
 import type { ValidationMessages } from '../type';
 import {
@@ -87,6 +87,7 @@ export type FormGroupProps = ExtractPublicPropTypes<typeof formGroupProps>;
 
 export default defineComponent({
     name: 'VCFormGroup',
+    inheritAttrs: false,
     props: formGroupProps,
     slots: Object as SlotsType<{
         default: Record<string, never>;
@@ -162,10 +163,7 @@ export default defineComponent({
 
             return h(
                 'div',
-                {
-                    class: [resolved.root || undefined, validationClass || undefined],
-                    ...attrs,
-                },
+                mergeProps(attrs, { class: [resolved.root || undefined, validationClass || undefined] }),
                 children,
             );
         };

--- a/packages/forms/src/components/form-input/FormInput.vue
+++ b/packages/forms/src/components/form-input/FormInput.vue
@@ -75,6 +75,11 @@ export type FormInputProps = ExtractPublicPropTypes<typeof formInputProps>;
 
 export default defineComponent({
     name: 'VCFormInput',
+    // attrs are explicitly merged onto the `<input>` below via
+    // `mergeProps(..., attrs)`. Without `inheritAttrs: false`, the
+    // group-wrapper `<div>` (when rendered) also receives them, so
+    // `id` / `disabled` / `placeholder` end up on both elements.
+    inheritAttrs: false,
     props: formInputProps,
     emits: ['update:modelValue'],
     slots: Object as SlotsType<{

--- a/packages/forms/src/components/form-select-search/FormSelectSearch.vue
+++ b/packages/forms/src/components/form-select-search/FormSelectSearch.vue
@@ -175,7 +175,11 @@ export default defineComponent({
             if (!q.value || q.value.length < 1) {
                 return props.options;
             }
-            const pattern = new RegExp(q.value, 'ig');
+            // User input goes straight into a RegExp — escape special
+            // chars so typing `(`, `[`, `*`, `+`, `?` etc. doesn't
+            // throw SyntaxError and crash the filter mid-render.
+            const escaped = q.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const pattern = new RegExp(escaped, 'ig');
             return props.options.filter((option) => option.label.match(pattern));
         });
 

--- a/packages/link/src/component.ts
+++ b/packages/link/src/component.ts
@@ -46,6 +46,7 @@ const linkProps = {
 export type LinkProps = ExtractPublicPropTypes<typeof linkProps>;
 
 export const VCLink = defineComponent({
+    name: 'VCLink',
     props: linkProps,
     emits: ['click', 'clicked'],
     setup(props, { emit, slots }) {
@@ -193,33 +194,34 @@ export const VCLink = defineComponent({
             return vNodeProps;
         };
 
-        let component : string | VNodeTypes;
+        // Resolve the rendered component INSIDE the render fn so it
+        // reacts to `to`/`disabled` changes — previously the switch
+        // ran once at setup and cached the choice, so toggling
+        // `:disabled` couldn't swap `<router-link>` → `<a>`.
+        const resolvedComponent = computed<string | VNodeTypes>(() => {
+            switch (computedTag.value) {
+                case 'router-link': return routerLink;
+                case 'nuxt-link': return nuxtLink;
+                default: return 'a';
+            }
+        });
 
-        switch (computedTag.value) {
-            case 'router-link':
-                component = routerLink;
-                break;
-            case 'nuxt-link':
-                component = nuxtLink;
-                break;
-            default:
-                component = 'a';
-        }
-
-        if (typeof component === 'string') {
-            return () => h(
-                component as string,
+        return () => {
+            const component = resolvedComponent.value;
+            if (typeof component === 'string') {
+                return h(
+                    component,
+                    buildVNodeProps(),
+                    [
+                        (typeof slots.default === 'function' ? slots.default() : []),
+                    ],
+                );
+            }
+            return h(
+                component as DefineComponent,
                 buildVNodeProps(),
-                [
-                    (typeof slots.default === 'function' ? slots.default() : []),
-                ],
+                { default: () => (typeof slots.default === 'function' ? slots.default() : []) },
             );
-        }
-
-        return () => h(
-            component as DefineComponent,
-            buildVNodeProps(),
-            { default: () => (typeof slots.default === 'function' ? slots.default() : []) },
-        );
+        };
     },
 });

--- a/packages/list/src/components/list-item/ListItem.vue
+++ b/packages/list/src/components/list-item/ListItem.vue
@@ -6,6 +6,7 @@ import {
     defineComponent,
     h,
     mergeProps,
+    ref,
 } from 'vue';
 import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
 import { provideListItemContext, useList } from '../../composables';
@@ -160,16 +161,20 @@ export default defineComponent({
         };
         const theme = useComponentTheme('listItem', themedProps, listItemThemeDefaults);
 
-        const isFocused = computed(() => {
-            // Roving tabindex: only the first selectable item gets
-            // `tabindex="0"` initially; full arrow-key navigation
-            // hasn't shipped yet. This mirrors the legacy
-            // `focusedIndex === props.index` behavior (where
-            // `focusedIndex` always remained 0 — `moveFocus` was
-            // never wired up) without the dead machine reference.
+        // Tab-stop ownership — only the first selectable, enabled
+        // item gets `tabindex="0"` initially. Full arrow-key roving
+        // tabindex hasn't shipped; this is the static fallback that
+        // gives the list ONE keyboard entry point per page.
+        const isTabStop = computed(() => {
             if (!props.selectable || props.disabled) return false;
             return props.index === 0;
         });
+
+        // Real DOM-focus state — wired via focusin/focusout on the
+        // root element. Previously this was `props.index === 0`
+        // (always true for row 0), which lied about actual focus.
+        // Driven by `onFocusin` / `onFocusout` attached below.
+        const isFocused = ref(false);
 
         const toggle = (opts: { range?: boolean; toggle?: boolean } = {}): void => {
             if (props.disabled || !props.selectable || key.value === undefined) return;
@@ -251,7 +256,9 @@ export default defineComponent({
             if (inListbox) {
                 elementAttrs.role = 'option';
                 elementAttrs['aria-selected'] = isSelected.value ? 'true' : 'false';
-                elementAttrs.tabindex = isFocused.value ? 0 : -1;
+                elementAttrs.tabindex = isTabStop.value ? 0 : -1;
+                elementAttrs.onFocusin = () => { isFocused.value = true; };
+                elementAttrs.onFocusout = () => { isFocused.value = false; };
                 elementAttrs['data-selected'] = isSelected.value ? '' : undefined;
                 elementAttrs.onClick = onClick;
                 // Keyboard activation only when listbox semantics are on.

--- a/packages/list/src/components/list-item/ListItem.vue
+++ b/packages/list/src/components/list-item/ListItem.vue
@@ -174,11 +174,26 @@ export default defineComponent({
         const isEligibleTabStop = computed(() => (
             props.selectable && !props.disabled
         ));
-        watch(isEligibleTabStop, (eligible) => {
-            if (eligible) list.registerEligibleItem(props.index);
-            else list.unregisterEligibleItem(props.index);
-        }, { immediate: true });
-        onBeforeUnmount(() => list.unregisterEligibleItem(props.index));
+        // Watch eligibility AND index together. If the row's index
+        // changes mid-life (list reorder / splice), the old index
+        // must unregister before the new one registers — otherwise
+        // the registry holds a stale entry and `firstTabStopIndex`
+        // points at a row that no longer exists.
+        watch(
+            [isEligibleTabStop, () => props.index],
+            ([eligible, newIndex], oldValues) => {
+                const oldIndex = oldValues?.[1];
+                if (oldIndex !== undefined && oldIndex !== newIndex) {
+                    list.unregisterEligibleItem(oldIndex);
+                }
+                if (eligible) list.registerEligibleItem(newIndex);
+                else list.unregisterEligibleItem(newIndex);
+            },
+            { immediate: true },
+        );
+        onBeforeUnmount(() => {
+            if (isEligibleTabStop.value) list.unregisterEligibleItem(props.index);
+        });
         const isTabStop = computed(() => (
             isEligibleTabStop.value && list.firstTabStopIndex.value === props.index
         ));

--- a/packages/list/src/components/list-item/ListItem.vue
+++ b/packages/list/src/components/list-item/ListItem.vue
@@ -6,7 +6,9 @@ import {
     defineComponent,
     h,
     mergeProps,
+    onBeforeUnmount,
     ref,
+    watch,
 } from 'vue';
 import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
 import { provideListItemContext, useList } from '../../composables';
@@ -122,7 +124,8 @@ export default defineComponent({
         default: ListItemSlotProps;
     }>,
     setup(props, { slots, attrs }) {
-        const { state, selection } = useList<unknown>('VCListItem');
+        const list = useList<unknown>('VCListItem');
+        const { state, selection } = list;
 
         const key = computed(() => {
             if (props.data === undefined) return undefined;
@@ -161,14 +164,24 @@ export default defineComponent({
         };
         const theme = useComponentTheme('listItem', themedProps, listItemThemeDefaults);
 
-        // Tab-stop ownership — only the first selectable, enabled
-        // item gets `tabindex="0"` initially. Full arrow-key roving
-        // tabindex hasn't shipped; this is the static fallback that
-        // gives the list ONE keyboard entry point per page.
-        const isTabStop = computed(() => {
-            if (!props.selectable || props.disabled) return false;
-            return props.index === 0;
-        });
+        // Tab-stop ownership — the FIRST selectable + enabled item
+        // (lowest data index, dynamically resolved) gets
+        // `tabindex="0"` initially. Previously hard-coded to
+        // `props.index === 0`, which left the listbox with no
+        // keyboard entry point if row 0 was disabled. Each eligible
+        // item registers with the list-scope tab-stop registry;
+        // `firstTabStopIndex` is the lowest registered index.
+        const isEligibleTabStop = computed(() => (
+            props.selectable && !props.disabled
+        ));
+        watch(isEligibleTabStop, (eligible) => {
+            if (eligible) list.registerEligibleItem(props.index);
+            else list.unregisterEligibleItem(props.index);
+        }, { immediate: true });
+        onBeforeUnmount(() => list.unregisterEligibleItem(props.index));
+        const isTabStop = computed(() => (
+            isEligibleTabStop.value && list.firstTabStopIndex.value === props.index
+        ));
 
         // Real DOM-focus state — wired via focusin/focusout on the
         // root element. Previously this was `props.index === 0`

--- a/packages/list/src/components/list/List.vue
+++ b/packages/list/src/components/list/List.vue
@@ -1,7 +1,13 @@
 <script lang="ts">
 import { useComponentTheme } from '@vuecs/core';
 import type { ComponentThemeDefinition, ThemeClassesOverride, VariantValues } from '@vuecs/core';
-import { computed, defineComponent, h } from 'vue';
+import {
+    computed, 
+    defineComponent, 
+    h, 
+    shallowRef, 
+    triggerRef,
+} from 'vue';
 import type {
     ExtractPublicPropTypes,
     PropType,
@@ -164,10 +170,39 @@ export default defineComponent({
 
         const classes = computed(() => theme.value);
 
+        // Tab-stop registry. Each `<VCListItem>` calls `register`
+        // when it's selectable + enabled (eligible to receive
+        // keyboard focus); the lowest registered index becomes the
+        // initial `tabindex="0"` row. Set mutations aren't reactive
+        // by default, so we hold a shallowRef and triggerRef on
+        // each in-place mutation (parallel to the table's
+        // `interactiveRows` pattern).
+        const eligibleIndices = shallowRef<Set<number>>(new Set());
+        const registerEligibleItem = (index: number) => {
+            if (eligibleIndices.value.has(index)) return;
+            eligibleIndices.value.add(index);
+            triggerRef(eligibleIndices);
+        };
+        const unregisterEligibleItem = (index: number) => {
+            if (!eligibleIndices.value.has(index)) return;
+            eligibleIndices.value.delete(index);
+            triggerRef(eligibleIndices);
+        };
+        const firstTabStopIndex = computed<number | null>(() => {
+            let min: number | null = null;
+            for (const i of eligibleIndices.value) {
+                if (min === null || i < min) min = i;
+            }
+            return min;
+        });
+
         provideListContext({
             state: state as ListState<unknown, Record<string, unknown>>,
             classes,
             selection,
+            registerEligibleItem,
+            unregisterEligibleItem,
+            firstTabStopIndex,
         });
 
         return () => h(

--- a/packages/list/src/components/list/List.vue
+++ b/packages/list/src/components/list/List.vue
@@ -130,6 +130,13 @@ export default defineComponent({
             );
         }
 
+        // `data`/`busy`/`total` pass getters so they react to prop
+        // updates. `meta` is captured by value — matches
+        // `defineList`'s "verbatim forward" semantic. Consumers who
+        // need reactive meta inside the convenience-prop path should
+        // wrap individual fields in `Ref` / `computed` themselves
+        // (e.g. `:meta="{ count: computed(...) }"`) OR construct a
+        // `ListState` via `defineList()` directly and pass `:state`.
         const state: ListState = props.state ?? defineList({
             data: () => props.data ?? [],
             busy: () => !!props.busy,

--- a/packages/list/src/composables/context.ts
+++ b/packages/list/src/composables/context.ts
@@ -1,5 +1,5 @@
 import { inject, provide } from 'vue';
-import type { ComputedRef, InjectionKey } from 'vue';
+import type { ComputedRef, InjectionKey, Ref } from 'vue';
 import type { ListItemThemeClasses, ListThemeClasses } from '../types';
 import type { ListState } from './define-list';
 import type { SelectionState } from './selection';
@@ -80,8 +80,14 @@ type ListItemContext = {
     classes: ComputedRef<ListItemThemeClasses>;
     /** Whether this row is in the current selection. */
     isSelected: ComputedRef<boolean>;
-    /** Whether this row carries the roving-tabindex focus. */
-    isFocused: ComputedRef<boolean>;
+    /**
+     * Whether this row currently has DOM focus. Driven by
+     * `focusin` / `focusout` listeners on the `<li>`. Use this for
+     * focused-styling that should reflect real keyboard focus
+     * (separate from the static "first selectable item gets
+     * tabindex=0" semantic).
+     */
+    isFocused: Ref<boolean>;
     /** Whether `<VCListItem :disabled>` was set. */
     isDisabled: ComputedRef<boolean>;
     /** Whether `<VCListItem :active>` was set (routing-style highlight). */

--- a/packages/list/src/composables/context.ts
+++ b/packages/list/src/composables/context.ts
@@ -16,6 +16,18 @@ type ListContext = {
     state: ListState<unknown, Record<string, unknown>>;
     classes: ComputedRef<ListThemeClasses>;
     selection: SelectionState;
+    /**
+     * Registry of indices of selectable + enabled items. Each
+     * `<VCListItem>` self-registers when it's eligible to be a
+     * keyboard tab stop. `firstTabStopIndex` (below) is derived
+     * from the lowest registered index — that's the one that
+     * carries `tabindex="0"` so the listbox always has a keyboard
+     * entry point even when item 0 is disabled.
+     */
+    registerEligibleItem(index: number): void;
+    unregisterEligibleItem(index: number): void;
+    /** Lowest registered eligible-item index, or `null` when none. */
+    firstTabStopIndex: ComputedRef<number | null>;
 };
 
 const LIST_CONTEXT_KEY = Symbol('VCListContext') as InjectionKey<ListContext>;

--- a/packages/overlays/src/components/modal/ModalClose.vue
+++ b/packages/overlays/src/components/modal/ModalClose.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, h } from 'vue';
+import { defineComponent, h, mergeProps } from 'vue';
 import type { ExtractPublicPropTypes, PropType } from 'vue';
 import { DialogClose } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
@@ -31,6 +31,7 @@ export type ModalCloseProps = ExtractPublicPropTypes<typeof modalCloseProps>;
 
 export default defineComponent({
     name: 'VCModalClose',
+    inheritAttrs: false,
     props: modalCloseProps,
     setup(props, { slots, attrs }) {
         const theme = useComponentTheme('modal', props, modalThemeDefaults);
@@ -51,12 +52,12 @@ export default defineComponent({
             const slotKey = props.icon || !hasSlot ? 'closeIcon' : 'close';
             return h(
                 DialogClose,
-                {
+                mergeProps(attrs, {
                     as: props.as,
                     asChild: props.asChild,
                     class: theme.value[slotKey] || undefined,
                     'aria-label': ariaLabel,
-                },
+                }),
                 { default: () => slots.default?.() ?? '×' },
             );
         };

--- a/packages/overlays/src/components/popover/PopoverClose.vue
+++ b/packages/overlays/src/components/popover/PopoverClose.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, h } from 'vue';
+import { defineComponent, h, mergeProps } from 'vue';
 import type { ExtractPublicPropTypes, PropType } from 'vue';
 import { PopoverClose } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
@@ -31,6 +31,7 @@ export type PopoverCloseProps = ExtractPublicPropTypes<typeof popoverCloseProps>
 
 export default defineComponent({
     name: 'VCPopoverClose',
+    inheritAttrs: false,
     props: popoverCloseProps,
     setup(props, { slots, attrs }) {
         const theme = useComponentTheme('popover', props, popoverThemeDefaults);
@@ -51,12 +52,12 @@ export default defineComponent({
             const slotKey = props.icon || !hasSlot ? 'closeIcon' : 'close';
             return h(
                 PopoverClose,
-                {
+                mergeProps(attrs, {
                     as: props.as,
                     asChild: props.asChild,
                     class: theme.value[slotKey] || undefined,
                     'aria-label': ariaLabel,
-                },
+                }),
                 { default: () => slots.default?.() ?? '×' },
             );
         };

--- a/packages/overlays/src/components/popover/PopoverTrigger.vue
+++ b/packages/overlays/src/components/popover/PopoverTrigger.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, h } from 'vue';
+import { defineComponent, h, mergeProps } from 'vue';
 import type { ExtractPublicPropTypes, PropType } from 'vue';
 import { PopoverTrigger } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
@@ -22,16 +22,17 @@ export type PopoverTriggerProps = ExtractPublicPropTypes<typeof popoverTriggerPr
 
 export default defineComponent({
     name: 'VCPopoverTrigger',
+    inheritAttrs: false,
     props: popoverTriggerProps,
-    setup(props, { slots }) {
+    setup(props, { attrs, slots }) {
         const theme = useComponentTheme('popover', props, popoverThemeDefaults);
         return () => h(
             PopoverTrigger,
-            {
+            mergeProps(attrs, {
                 as: props.as,
                 asChild: props.asChild,
                 class: theme.value.trigger || undefined,
-            },
+            }),
             { default: () => slots.default?.() },
         );
     },

--- a/packages/overlays/src/components/tooltip/TooltipTrigger.vue
+++ b/packages/overlays/src/components/tooltip/TooltipTrigger.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, h } from 'vue';
+import { defineComponent, h, mergeProps } from 'vue';
 import type { ExtractPublicPropTypes, PropType } from 'vue';
 import { TooltipTrigger } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
@@ -22,16 +22,17 @@ export type TooltipTriggerProps = ExtractPublicPropTypes<typeof tooltipTriggerPr
 
 export default defineComponent({
     name: 'VCTooltipTrigger',
+    inheritAttrs: false,
     props: tooltipTriggerProps,
-    setup(props, { slots }) {
+    setup(props, { attrs, slots }) {
         const theme = useComponentTheme('tooltip', props, tooltipThemeDefaults);
         return () => h(
             TooltipTrigger,
-            {
+            mergeProps(attrs, {
                 as: props.as,
                 asChild: props.asChild,
                 class: theme.value.trigger || undefined,
-            },
+            }),
             { default: () => slots.default?.() },
         );
     },

--- a/packages/pagination/src/component.vue
+++ b/packages/pagination/src/component.vue
@@ -40,6 +40,13 @@ const paginationProps = {
     themeVariant: { type: Object as PropType<VariantValues>, default: undefined },
     /** When true, edge controls are unrendered (vs rendered-disabled) at page boundaries. Does not apply to `busy`. */
     hideDisabled: { type: Boolean, default: false },
+    /**
+     * Number of sibling page items on either side of the current
+     * page in the rendered range. Forwarded to Reka `siblingCount`.
+     */
+    siblingCount: { type: Number, default: 1 },
+    /** When true, renders First / Last edge buttons. Forwarded to Reka `showEdges`. */
+    showEdges: { type: Boolean, default: true },
     /** Icon name (Iconify format) for the First button. `undefined` falls through to the DefaultsManager; `''` suppresses. */
     firstIcon: { type: String, default: undefined },
     /** Icon name (Iconify format) for the Previous button. `undefined` falls through to the DefaultsManager; `''` suppresses. */
@@ -113,6 +120,17 @@ export default defineComponent({
                 1
         ));
 
+        // Guard against unrealistically-small `limit` values. The
+        // previous `limit || 1` mapping forwarded `1` to Reka when
+        // limit was 0/negative — Reka then computes
+        // `Math.ceil(total / 1) = total` pages and renders every
+        // page item, which is a render-time loop spike for moderate
+        // totals. Clamp to a sane floor of 1 when `limit` is unset
+        // or non-positive.
+        const effectiveLimit = computed(() => (
+            props.limit && props.limit > 0 ? props.limit : Math.max(props.total, 1)
+        ));
+
         const showStartControls = computed(() => !props.hideDisabled || currentPage.value > 1);
         const showEndControls = computed(() => !props.hideDisabled || currentPage.value < pageCount.value);
 
@@ -145,6 +163,7 @@ export default defineComponent({
             theme,
             defaults,
             currentPage,
+            effectiveLimit,
             showStartControls,
             showEndControls,
             pageItemClass,
@@ -159,9 +178,9 @@ export default defineComponent({
     <PaginationRoot
         :as="tag"
         :total="total"
-        :items-per-page="limit || 1"
-        :sibling-count="1"
-        :show-edges="true"
+        :items-per-page="effectiveLimit"
+        :sibling-count="siblingCount"
+        :show-edges="showEdges"
         :page="currentPage"
         :disabled="busy"
         :class="theme.root || undefined"

--- a/packages/pagination/src/component.vue
+++ b/packages/pagination/src/component.vue
@@ -108,27 +108,29 @@ export default defineComponent({
 
         const defaults = useComponentDefaults('pagination', props, behavioralDefaults);
 
-        const currentPage = computed(() => (
-            props.total && props.limit ?
-                calculatePage({ limit: props.limit, offset: props.offset }) :
-                1
-        ));
-
-        const pageCount = computed(() => (
-            props.total && props.limit ?
-                calculatePagesTotal({ limit: props.limit, total: props.total }) :
-                1
-        ));
-
         // Guard against unrealistically-small `limit` values. The
         // previous `limit || 1` mapping forwarded `1` to Reka when
         // limit was 0/negative — Reka then computes
         // `Math.ceil(total / 1) = total` pages and renders every
         // page item, which is a render-time loop spike for moderate
         // totals. Clamp to a sane floor of 1 when `limit` is unset
-        // or non-positive.
+        // or non-positive. ALL internal math + emitted-meta paths
+        // read from this normalized value so rendered pagination
+        // and the `load` event payload stay consistent.
         const effectiveLimit = computed(() => (
             props.limit && props.limit > 0 ? props.limit : Math.max(props.total, 1)
+        ));
+
+        const currentPage = computed(() => (
+            props.total > 0 ?
+                calculatePage({ limit: effectiveLimit.value, offset: props.offset }) :
+                1
+        ));
+
+        const pageCount = computed(() => (
+            props.total > 0 ?
+                calculatePagesTotal({ limit: effectiveLimit.value, total: props.total }) :
+                1
         ));
 
         const showStartControls = computed(() => !props.hideDisabled || currentPage.value > 1);
@@ -152,8 +154,8 @@ export default defineComponent({
             if (props.busy || newPage === currentPage.value) return;
             const meta: PaginationMeta = {
                 page: newPage,
-                offset: calculateOffset({ page: newPage, limit: props.limit }),
-                limit: props.limit,
+                offset: calculateOffset({ page: newPage, limit: effectiveLimit.value }),
+                limit: effectiveLimit.value,
                 total: pageCount.value,
             };
             emit('load', meta);

--- a/packages/table/src/components/Table.vue
+++ b/packages/table/src/components/Table.vue
@@ -5,7 +5,9 @@ import {
     h,
     mergeProps,
     ref,
+    shallowRef,
     toRef,
+    triggerRef,
     watch,
 } from 'vue';
 import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
@@ -224,21 +226,22 @@ export default defineComponent({
         // Drives the roving-tabindex fallback (first-interactive gets
         // the tab stop, not blindly row 0) and the arrow-nav skip
         // semantics (next/prev interactive, not next/prev data index).
-        // Set is wrapped in a Ref + reassigned on mutation so Vue's
-        // reactivity catches it (Set's internal mutations aren't
-        // tracked by default).
-        const interactiveRows = ref<Set<number>>(new Set());
+        // Set mutations aren't reactivity-tracked, so we hold the
+        // Set in a shallow ref and call `triggerRef` after each
+        // in-place `add`/`delete`. Previously the code allocated a
+        // FRESH Set on every register/unregister — during mount of a
+        // table with N interactive rows that was O(N²) allocations
+        // (each new row copies the prior Set).
+        const interactiveRows = shallowRef<Set<number>>(new Set());
         const registerInteractiveRow = (index: number) => {
             if (interactiveRows.value.has(index)) return;
-            const next = new Set(interactiveRows.value);
-            next.add(index);
-            interactiveRows.value = next;
+            interactiveRows.value.add(index);
+            triggerRef(interactiveRows);
         };
         const unregisterInteractiveRow = (index: number) => {
             if (!interactiveRows.value.has(index)) return;
-            const next = new Set(interactiveRows.value);
-            next.delete(index);
-            interactiveRows.value = next;
+            interactiveRows.value.delete(index);
+            triggerRef(interactiveRows);
         };
 
         // Selection wiring (plan 033 v1.x-A). Always construct the
@@ -292,6 +295,7 @@ export default defineComponent({
             }),
             setSortState: sortMachine.setState,
             maxSortKeys: maxSortKeysRef,
+            supportsSortMutation: true,
             rowClickable: toRef(props, 'rowClickable'),
             focusedRow,
             setFocusedRow,

--- a/packages/table/src/components/TableLite.vue
+++ b/packages/table/src/components/TableLite.vue
@@ -165,6 +165,7 @@ export default defineComponent({
             setSort: () => {},
             setSortState: () => {},
             maxSortKeys: ref(0),
+            supportsSortMutation: false,
             rowClickable: computed(() => false),
             focusedRow: ref(null),
             setFocusedRow: () => {},

--- a/packages/table/src/components/TableRow.vue
+++ b/packages/table/src/components/TableRow.vue
@@ -4,6 +4,7 @@ import {
     defineComponent,
     h,
     mergeProps,
+    nextTick,
     onBeforeUnmount,
     toRef,
     watch,
@@ -227,28 +228,30 @@ export default defineComponent({
                 ctx?.setFocusedRow(nextIdx);
                 const tr = event.currentTarget as globalThis.HTMLElement | null;
                 if (!tr) return;
-                // DOM walk: step row-by-row from the current `<tr>`
-                // skipping anything that isn't a focusable `<tr>` (so
-                // disabled rows in between don't catch the focus).
-                // Direction is signed by whether the target index is
-                // after or before this row's data index.
-                const direction = nextIdx > i ? 'nextElementSibling' : 'previousElementSibling';
-                let sibling: globalThis.Element | null = tr[direction];
-                while (sibling) {
-                    if (
-                        sibling instanceof globalThis.HTMLElement &&
-                        sibling.tagName === 'TR' &&
-                        sibling.hasAttribute('tabindex')
-                    ) {
-                        const ti = sibling.getAttribute('tabindex');
-                        if (ti !== '-1' || (ti === '-1' && sibling.matches('[role="row"]'))) {
-                            // Match found — focus this row.
+                // Defer the DOM .focus() until after Vue re-renders
+                // with the updated tabindex. The roving-tabindex
+                // pattern only ever has ONE row carrying `tabindex="0"`
+                // at a time; walking siblings before the re-render
+                // would never find the new target (all other rows
+                // still carry `tabindex="-1"`). After the tick, only
+                // the new target row carries `tabindex="0"`, so the
+                // walker latches on it cleanly and disabled rows
+                // (carrying `tabindex="-1"`) are correctly skipped.
+                nextTick(() => {
+                    const direction = nextIdx > i ? 'nextElementSibling' : 'previousElementSibling';
+                    let sibling: globalThis.Element | null = tr[direction];
+                    while (sibling) {
+                        if (
+                            sibling instanceof globalThis.HTMLElement &&
+                            sibling.tagName === 'TR' &&
+                            sibling.getAttribute('tabindex') === '0'
+                        ) {
                             sibling.focus();
                             break;
                         }
+                        sibling = sibling[direction];
                     }
-                    sibling = sibling[direction];
-                }
+                });
                 // Shift+arrow extends selection from the range anchor
                 // to the new focused row (multi mode only). Seed the
                 // anchor to the CURRENT row when none exists yet, so

--- a/packages/table/src/components/TableSortIndicators.vue
+++ b/packages/table/src/components/TableSortIndicators.vue
@@ -224,7 +224,13 @@ export default defineComponent({
             // double-emit doesn't fire for consumers who happen to
             // listen on the chip row.
             if (ctx) {
-                if (process.env.NODE_ENV !== 'production' && !ctx.supportsSortMutation) {
+                // `globalThis.process` is the safe lookup in browser
+                // ESM builds where `process` isn't a global; raw
+                // `process.env.NODE_ENV` would throw ReferenceError.
+                if (
+                    (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env?.NODE_ENV !== 'production' &&
+                    !ctx.supportsSortMutation
+                ) {
                     // eslint-disable-next-line no-console
                     console.warn(
                         '[VCTableSortIndicators] mounted inside a table context that does not support sort mutation (likely <VCTableLite>). Clicks will be swallowed. Either bind :sort + :columns directly for v-model mode, or use <VCTable> instead of Lite.',

--- a/packages/table/src/components/TableSortIndicators.vue
+++ b/packages/table/src/components/TableSortIndicators.vue
@@ -223,7 +223,15 @@ export default defineComponent({
             // `update:sort` once the machine state lands), so a
             // double-emit doesn't fire for consumers who happen to
             // listen on the chip row.
-            if (ctx) ctx.setSortState(next);
+            if (ctx) {
+                if (process.env.NODE_ENV !== 'production' && !ctx.supportsSortMutation) {
+                    // eslint-disable-next-line no-console
+                    console.warn(
+                        '[VCTableSortIndicators] mounted inside a table context that does not support sort mutation (likely <VCTableLite>). Clicks will be swallowed. Either bind :sort + :columns directly for v-model mode, or use <VCTable> instead of Lite.',
+                    );
+                }
+                ctx.setSortState(next);
+            }
         }
 
         const columnByKey = computed(() => {

--- a/packages/table/src/composables/context.ts
+++ b/packages/table/src/composables/context.ts
@@ -35,6 +35,14 @@ export type TableContext<Row = unknown> = {
      * cycle logic, so the cap is enforced at the call site.
      */
     maxSortKeys: Ref<number>;
+    /**
+     * Whether the host table can actually mutate sort state.
+     * `<VCTable>` sets this to `true`; `<VCTableLite>` sets it to
+     * `false` (it ships no sort machine). Descendants like
+     * `<VCTableSortIndicators>` check this in their context-fallback
+     * path so they refuse to silently no-op when mounted inside Lite.
+     */
+    supportsSortMutation: boolean;
     /** Whether `<VCTable>` was passed `:rowClickable`. */
     rowClickable: Ref<boolean>;
     /** Currently focused row index (row keyboard nav). `null` when nothing focused. */

--- a/packages/timeago/src/component.ts
+++ b/packages/timeago/src/component.ts
@@ -148,13 +148,15 @@ export const VCTimeago = defineComponent({
         return () => h(
             'time',
             {
+                // Vue 3 forwards HTML attributes flat on the props
+                // object — there's no `attrs:` sub-key (that was a
+                // Vue 2 render-fn shape). The previous form silently
+                // dropped `datetime` + `title`.
                 class: theme.value.root || undefined,
-                attrs: {
-                    datetime: new Date(dateTimeProp.value).toISOString(),
-                    title: typeof titleProp.value === 'string' ?
-                        titleProp.value :
-                        time.value,
-                },
+                datetime: new Date(dateTimeProp.value).toISOString(),
+                title: typeof titleProp.value === 'string' ?
+                    titleProp.value :
+                    time.value,
             },
             [time.value],
         );


### PR DESCRIPTION
## Summary

Fixes 17 of 19 audit findings ahead of the 1.0 release. Items 16 + 19 deferred (documented intentional choices).

### Critical surface bugs (1-5)
- **`VCTimeago`** — drop Vue 2 `attrs:` sub-key; `datetime` + `title` HTML attributes now emit
- **`VCTag icon`** — mount `<VCIcon>` instead of rendering Iconify name as text
- **`VCFormSelectSearch`** — escape regex special chars (`(`, `[`, `*`, …) before passing to `RegExp`
- **`VCLink`** — resolve rendered tag in the render fn (was captured at setup); add missing `name`
- **`VCListItem.isFocused`** — wire real DOM focus via `focusin` / `focusout`; split static tab-stop logic into a new internal `isTabStop`

### High-priority UX / a11y (6-10)
- **`<VCTableRow>` keyboard nav** — only `tabindex="0"` rows match arrow keys; DOM focus defers to `nextTick` so post-render flip is visible
- **`<VCAlert color="primary">`** — `AlertDefaults` gains `primaryIcon` + `neutralIcon`
- **`<VCTableSortIndicators>` in `<VCTableLite>`** — dev-warns when context-fallback hits a non-supporting host (new `supportsSortMutation` flag)
- **`useStateMachine`** — empty-string state transitions no longer silently dropped

### Medium bugs (11-15, 17-18)
- **`VCFormGroup` + `VCFormInput` + Reka close/trigger wrappers** — `inheritAttrs: false` + `mergeProps(attrs, …)` so consumer `:class` merges instead of replacing
- **`useConfig` fallback** — module-level singleton `ConfigManager` (was per-call)
- **`<VCConfigProvider>`** — parent `setConfig` propagates via a parent-chain in `ConfigManager.get()` (was constructor-time snapshot)
- **`<VCTable>.interactiveRows`** — in-place mutations + `triggerRef` (was O(N²) per-mount Set reallocation)
- **`<VCPagination>`** — expose `:sibling-count` + `:show-edges`; clamp `limit=0` so Reka doesn't loop full pages

### Deferred (documented choices)
- **#16 defineList meta capture** — intentional snapshot per architecture's "verbatim forward" semantic. Added inline comment.
- **#19 selectAllState recompute** — already O(N) with Set-based check; parallel state tracking would add more complexity than it saves.

## Test plan
- [x] Lint clean (0 errors, 201 warnings — all pre-existing)
- [x] Build all 26 projects
- [x] 12 test workspaces — 287 core / 137 table / 28 pagination / etc. all green
- [ ] Manual demo verification in Tailwind / Bootstrap / Bulma example apps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pagination adds siblingCount and showEdges options.

* **Bug Fixes**
  * Search input safely handles special regex characters.
  * List items report real DOM focus; keyboard entry point and tab-stop behavior improved.
  * Table navigation focuses the correct row after render.
  * Tag handles optional icon peer and slot rendering.
  * Link resolves rendered element reactively.

* **Improvements**
  * Config fallbacks are consistent per app/SSR request and inherit updates reactively.
  * Form, modal, popover and tooltip attributes are merged reliably.
  * State machine supports empty-string transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1578?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->