### PR TITLE
fix: widen as: prop to accept components across themable components

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -83,6 +83,16 @@ setup(props, { attrs }) {
    add a `Vuecs convention:` note in the JSDoc explaining why.
 5. Internal-only props (e.g. `inline` for portal opt-out, `themeClass`)
    keep their concrete defaults and still get JSDoc.
+6. **`as:` declarations widen to `[String, Object]`** — match
+   `VCPrimitive` / Reka's `Primitive`:
+   ```ts
+   as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+   ```
+   Single-type `String` rejects component values (e.g. `RouterLink`,
+   `NuxtLink`) at prop validation, silently coercing them to the
+   default. The wider declaration is what the
+   `/guide/build-themable-component` page teaches; first-party
+   components mirror it.
 
 This convention applies to every Reka-wrapping component across
 `@vuecs/overlays`, `@vuecs/forms`, `@vuecs/elements`, `@vuecs/navigation`

--- a/packages/elements/src/components/alert/Alert.vue
+++ b/packages/elements/src/components/alert/Alert.vue
@@ -44,7 +44,7 @@ const alertProps = {
      */
     role: { type: String, default: undefined },
     /** HTML tag to render. */
-    as: { type: String, default: 'div' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
     ...themableProps<AlertThemeClasses>(),
 };
 

--- a/packages/elements/src/components/alert/AlertClose.vue
+++ b/packages/elements/src/components/alert/AlertClose.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
 import { alertThemeDefaults } from './theme';
@@ -8,7 +8,7 @@ import type { AlertThemeClasses } from './types';
 
 const alertCloseProps = {
     /** HTML tag to render. */
-    as: { type: String, default: 'button' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
     /**
      * Force the corner-X presentation (reads the theme's `closeIcon` slot).
      * When false (default), the slot-presence heuristic decides:

--- a/packages/elements/src/components/alert/AlertDescription.vue
+++ b/packages/elements/src/components/alert/AlertDescription.vue
@@ -1,13 +1,13 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
 import { alertDescriptionThemeDefaults } from './theme';
 import type { AlertDescriptionThemeClasses } from './types';
 
 const alertDescriptionProps = {
     /** HTML tag to render. */
-    as: { type: String, default: 'div' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
     ...themableProps<AlertDescriptionThemeClasses>(),
 };
 

--- a/packages/elements/src/components/alert/AlertTitle.vue
+++ b/packages/elements/src/components/alert/AlertTitle.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
 import { alertTitleThemeDefaults } from './theme';
 import type { AlertTitleThemeClasses } from './types';
@@ -12,7 +12,7 @@ const alertTitleProps = {
      * Vuecs convention: defaults to `'h4'` (semantically-correct alert
      * heading). Override via `:as` for nested-heading hierarchies.
      */
-    as: { type: String, default: 'h4' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'h4' },
     ...themableProps<AlertTitleThemeClasses>(),
 };
 

--- a/packages/elements/src/components/card/Card.vue
+++ b/packages/elements/src/components/card/Card.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import {
     VCPrimitive,
     themableProps,
@@ -19,7 +19,7 @@ const cardProps = {
     /** Adds hover / focus styling — useful for link-cards. */
     interactive: { type: Boolean, default: undefined },
     /** HTML tag to render. Use `:as-child` to compose onto an existing component. */
-    as: { type: String, default: 'div' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
     /** Render the consumer's slot child as the card root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<CardThemeClasses>(),

--- a/packages/elements/src/components/card/CardBody.vue
+++ b/packages/elements/src/components/card/CardBody.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { VCPrimitive, useComponentTheme } from '@vuecs/core';
 import type {
     ThemeClassesOverride,
@@ -13,7 +13,7 @@ import type { CardBodyThemeClasses } from './types';
 
 const cardBodyProps = {
     /** HTML tag to render. Use `:as-child` to compose onto an existing component. */
-    as: { type: String, default: 'div' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** Theme-class overrides for this component instance. */

--- a/packages/elements/src/components/card/CardDescription.vue
+++ b/packages/elements/src/components/card/CardDescription.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { VCPrimitive, useComponentTheme } from '@vuecs/core';
 import type {
     ThemeClassesOverride,
@@ -13,7 +13,7 @@ import type { CardDescriptionThemeClasses } from './types';
 
 const cardDescriptionProps = {
     /** HTML tag to render. Use `:as-child` to compose onto an existing component. */
-    as: { type: String, default: 'p' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'p' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** Theme-class overrides for this component instance. */

--- a/packages/elements/src/components/card/CardFooter.vue
+++ b/packages/elements/src/components/card/CardFooter.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { VCPrimitive, useComponentTheme } from '@vuecs/core';
 import type {
     ThemeClassesOverride,
@@ -13,7 +13,7 @@ import type { CardFooterThemeClasses } from './types';
 
 const cardFooterProps = {
     /** HTML tag to render. Use `:as-child` to compose onto an existing component. */
-    as: { type: String, default: 'footer' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'footer' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** Theme-class overrides for this component instance. */

--- a/packages/elements/src/components/card/CardHeader.vue
+++ b/packages/elements/src/components/card/CardHeader.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { VCPrimitive, useComponentTheme } from '@vuecs/core';
 import type {
     ThemeClassesOverride,
@@ -13,7 +13,7 @@ import type { CardHeaderThemeClasses } from './types';
 
 const cardHeaderProps = {
     /** HTML tag to render. Use `:as-child` to compose onto an existing component. */
-    as: { type: String, default: 'header' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'header' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** Theme-class overrides for this component instance. */

--- a/packages/elements/src/components/card/CardTitle.vue
+++ b/packages/elements/src/components/card/CardTitle.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { VCPrimitive, useComponentTheme } from '@vuecs/core';
 import type {
     ThemeClassesOverride,
@@ -13,7 +13,7 @@ import type { CardTitleThemeClasses } from './types';
 
 const cardTitleProps = {
     /** HTML tag to render. Use `:as-child` to compose onto an existing component. */
-    as: { type: String, default: 'h3' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'h3' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** Theme-class overrides for this component instance. */

--- a/packages/elements/src/components/collapse/Collapse.vue
+++ b/packages/elements/src/components/collapse/Collapse.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { CollapsibleRoot } from 'reka-ui';
 import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
 import { collapseThemeDefaults } from './theme';
@@ -21,7 +21,7 @@ const collapseProps = {
      */
     unmountOnHide: { type: Boolean, default: true },
     /** HTML tag to render. */
-    as: { type: String, default: 'div' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<CollapseThemeClasses>(),

--- a/packages/elements/src/components/collapse/CollapseContent.vue
+++ b/packages/elements/src/components/collapse/CollapseContent.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { CollapsibleContent } from 'reka-ui';
 import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
 import { collapseContentThemeDefaults } from './theme';
@@ -13,7 +13,7 @@ const collapseContentProps = {
      */
     forceMount: { type: Boolean, default: false },
     /** HTML tag to render. */
-    as: { type: String, default: 'div' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
     /** Render the consumer's slot child as the pane root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<CollapseContentThemeClasses>(),

--- a/packages/elements/src/components/collapse/CollapseTrigger.vue
+++ b/packages/elements/src/components/collapse/CollapseTrigger.vue
@@ -30,7 +30,7 @@ const collapseTriggerProps = {
      */
     chevron: { type: String as PropType<CollapseChevron>, default: undefined },
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: String, default: 'button' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
     /** Render the consumer's slot child as the trigger (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<CollapseTriggerThemeClasses>(),

--- a/packages/elements/src/components/visually-hidden/VisuallyHidden.vue
+++ b/packages/elements/src/components/visually-hidden/VisuallyHidden.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { VisuallyHidden } from 'reka-ui';
 
 const visuallyHiddenProps = {
     /** HTML tag to render. */
-    as: { type: String, default: 'span' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'span' },
 };
 
 export type VisuallyHiddenProps = ExtractPublicPropTypes<typeof visuallyHiddenProps>;

--- a/packages/navigation/src/components/stepper/StepperDescription.vue
+++ b/packages/navigation/src/components/stepper/StepperDescription.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { StepperDescription } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, UseComponentThemeProps, VariantValues } from '@vuecs/core';
@@ -12,7 +12,7 @@ const stepperDescriptionProps = {
     /** Render the consumer's slot child as the description root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** HTML tag to render. */
-    as: { type: String, default: 'p' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'p' },
     /** Theme-class overrides for this component instance. */
     themeClass: { type: Object as PropType<ThemeClassesOverride<StepperThemeClasses>>, default: undefined },
     /** Theme-variant values for this component instance. */

--- a/packages/navigation/src/components/stepper/StepperIndicator.vue
+++ b/packages/navigation/src/components/stepper/StepperIndicator.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { StepperIndicator } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, UseComponentThemeProps, VariantValues } from '@vuecs/core';
@@ -12,7 +12,7 @@ const stepperIndicatorProps = {
     /** Render the consumer's slot child as the indicator root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** HTML tag to render. */
-    as: { type: String, default: 'div' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
     /** Theme-class overrides for this component instance. */
     themeClass: { type: Object as PropType<ThemeClassesOverride<StepperThemeClasses>>, default: undefined },
     /** Theme-variant values for this component instance. */

--- a/packages/navigation/src/components/stepper/StepperSeparator.vue
+++ b/packages/navigation/src/components/stepper/StepperSeparator.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { StepperSeparator } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, UseComponentThemeProps, VariantValues } from '@vuecs/core';
@@ -12,7 +12,7 @@ const stepperSeparatorProps = {
     /** Render the consumer's slot child as the separator root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** HTML tag to render. */
-    as: { type: String, default: 'div' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
     /** Theme-class overrides for this component instance. */
     themeClass: { type: Object as PropType<ThemeClassesOverride<StepperThemeClasses>>, default: undefined },
     /** Theme-variant values for this component instance. */

--- a/packages/navigation/src/components/stepper/StepperTitle.vue
+++ b/packages/navigation/src/components/stepper/StepperTitle.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { StepperTitle } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, UseComponentThemeProps, VariantValues } from '@vuecs/core';
@@ -12,7 +12,7 @@ const stepperTitleProps = {
     /** Render the consumer's slot child as the title root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** HTML tag to render. */
-    as: { type: String, default: 'h4' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'h4' },
     /** Theme-class overrides for this component instance. */
     themeClass: { type: Object as PropType<ThemeClassesOverride<StepperThemeClasses>>, default: undefined },
     /** Theme-variant values for this component instance. */

--- a/packages/navigation/src/components/stepper/StepperTrigger.vue
+++ b/packages/navigation/src/components/stepper/StepperTrigger.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { StepperTrigger } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, UseComponentThemeProps, VariantValues } from '@vuecs/core';
@@ -12,7 +12,7 @@ const stepperTriggerProps = {
     /** Render the consumer's slot child as the trigger root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** HTML tag to render. */
-    as: { type: String, default: 'button' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
     /** Theme-class overrides for this component instance. */
     themeClass: { type: Object as PropType<ThemeClassesOverride<StepperThemeClasses>>, default: undefined },
     /** Theme-variant values for this component instance. */

--- a/packages/overlays/src/components/context-menu/ContextMenuItem.vue
+++ b/packages/overlays/src/components/context-menu/ContextMenuItem.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { ContextMenuItem } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { ContextMenuThemeClasses } from './types';
 
 const contextMenuItemProps = {
     /** HTML tag (or component) to render as. Reka default: `'div'`. */
-    as: { type: String, default: 'div' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** When true, prevents user interaction with the item. */

--- a/packages/overlays/src/components/context-menu/ContextMenuLabel.vue
+++ b/packages/overlays/src/components/context-menu/ContextMenuLabel.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { ContextMenuLabel } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { ContextMenuThemeClasses } from './types';
 
 const contextMenuLabelProps = {
     /** HTML tag (or component) to render as. Reka default: `'div'`. */
-    as: { type: String, default: 'div' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** Per-instance theme override — flat slot key map. */

--- a/packages/overlays/src/components/context-menu/ContextMenuSubTrigger.vue
+++ b/packages/overlays/src/components/context-menu/ContextMenuSubTrigger.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { ContextMenuSubTrigger } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { ContextMenuThemeClasses } from './types';
 
 const contextMenuSubTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'div'`. */
-    as: { type: String, default: 'div' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** When true, prevents user interaction with the sub-trigger. */

--- a/packages/overlays/src/components/context-menu/ContextMenuTrigger.vue
+++ b/packages/overlays/src/components/context-menu/ContextMenuTrigger.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { ContextMenuTrigger } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { ContextMenuThemeClasses } from './types';
 
 const contextMenuTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'span'`. */
-    as: { type: String, default: 'span' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'span' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** When true, the trigger does not open the menu on right-click / press. */

--- a/packages/overlays/src/components/dropdown-menu/DropdownMenuItem.vue
+++ b/packages/overlays/src/components/dropdown-menu/DropdownMenuItem.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { DropdownMenuItem } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { DropdownMenuThemeClasses } from './types';
 
 const dropdownMenuItemProps = {
     /** HTML tag (or component) to render as. Reka default: `'div'`. */
-    as: { type: String, default: 'div' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** When true, prevents user interaction with the item. */

--- a/packages/overlays/src/components/dropdown-menu/DropdownMenuLabel.vue
+++ b/packages/overlays/src/components/dropdown-menu/DropdownMenuLabel.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { DropdownMenuLabel } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { DropdownMenuThemeClasses } from './types';
 
 const dropdownMenuLabelProps = {
     /** HTML tag (or component) to render as. Reka default: `'div'`. */
-    as: { type: String, default: 'div' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** Per-instance theme override — flat slot key map. */

--- a/packages/overlays/src/components/dropdown-menu/DropdownMenuSubTrigger.vue
+++ b/packages/overlays/src/components/dropdown-menu/DropdownMenuSubTrigger.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { DropdownMenuSubTrigger } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { DropdownMenuThemeClasses } from './types';
 
 const dropdownMenuSubTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'div'`. */
-    as: { type: String, default: 'div' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** When true, prevents user interaction with the sub-trigger. */

--- a/packages/overlays/src/components/dropdown-menu/DropdownMenuTrigger.vue
+++ b/packages/overlays/src/components/dropdown-menu/DropdownMenuTrigger.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { DropdownMenuTrigger } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { DropdownMenuThemeClasses } from './types';
 
 const dropdownMenuTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: String, default: 'button' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** Per-instance theme override — flat slot key map. */

--- a/packages/overlays/src/components/hover-card/HoverCardTrigger.vue
+++ b/packages/overlays/src/components/hover-card/HoverCardTrigger.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { HoverCardTrigger } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { HoverCardThemeClasses } from './types';
 
 const hoverCardTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'a'` (hover-card triggers are typically links). */
-    as: { type: String, default: 'a' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'a' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** Per-instance theme override — flat slot key map. */

--- a/packages/overlays/src/components/modal/ModalClose.vue
+++ b/packages/overlays/src/components/modal/ModalClose.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { DialogClose } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { ModalThemeClasses } from './types';
 
 const modalCloseProps = {
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: String, default: 'button' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /**

--- a/packages/overlays/src/components/modal/ModalTrigger.vue
+++ b/packages/overlays/src/components/modal/ModalTrigger.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { DialogTrigger } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { ModalThemeClasses } from './types';
 
 const modalTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: String, default: 'button' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** Per-instance theme override — flat slot key map. */

--- a/packages/overlays/src/components/popover/PopoverClose.vue
+++ b/packages/overlays/src/components/popover/PopoverClose.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { PopoverClose } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { PopoverThemeClasses } from './types';
 
 const popoverCloseProps = {
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: String, default: 'button' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /**

--- a/packages/overlays/src/components/popover/PopoverTrigger.vue
+++ b/packages/overlays/src/components/popover/PopoverTrigger.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { PopoverTrigger } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { PopoverThemeClasses } from './types';
 
 const popoverTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: String, default: 'button' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** Per-instance theme override — flat slot key map. */

--- a/packages/overlays/src/components/toast/Toast.vue
+++ b/packages/overlays/src/components/toast/Toast.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { ToastRoot } from 'reka-ui';
 import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
 import { toastThemeDefaults } from './theme';
@@ -36,7 +36,7 @@ const toastProps = {
     /** Initial open state when `open` is undefined. */
     defaultOpen: { type: Boolean, default: true },
     /** HTML tag to render. */
-    as: { type: String, default: 'li' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'li' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<ToastThemeClasses>(),

--- a/packages/overlays/src/components/toast/ToastAction.vue
+++ b/packages/overlays/src/components/toast/ToastAction.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { ToastAction } from 'reka-ui';
 import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
 import { toastActionThemeDefaults } from './theme';
@@ -14,7 +14,7 @@ const toastActionProps = {
      */
     altText: { type: String, required: true },
     /** HTML tag to render. */
-    as: { type: String, default: 'button' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<ToastActionThemeClasses>(),

--- a/packages/overlays/src/components/toast/ToastClose.vue
+++ b/packages/overlays/src/components/toast/ToastClose.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { ToastClose } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { ToastThemeClasses } from './types';
 
 const toastCloseProps = {
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: String, default: 'button' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /**

--- a/packages/overlays/src/components/toast/ToastDescription.vue
+++ b/packages/overlays/src/components/toast/ToastDescription.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { ToastDescription } from 'reka-ui';
 import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
 import { toastDescriptionThemeDefaults } from './theme';
@@ -14,7 +14,7 @@ const toastDescriptionProps = {
      * `'div'`). `p` is the semantically-correct host for the toast body
      * text — overridable via `:as`.
      */
-    as: { type: String, default: 'p' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'p' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<ToastDescriptionThemeClasses>(),

--- a/packages/overlays/src/components/toast/ToastTitle.vue
+++ b/packages/overlays/src/components/toast/ToastTitle.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { ToastTitle } from 'reka-ui';
 import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
 import { toastTitleThemeDefaults } from './theme';
@@ -14,7 +14,7 @@ const toastTitleProps = {
      * `'div'`). `h3` is the semantically-correct host for an in-context
      * heading within a toast — overridable via `:as`.
      */
-    as: { type: String, default: 'h3' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'h3' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<ToastTitleThemeClasses>(),

--- a/packages/overlays/src/components/toast/Toaster.vue
+++ b/packages/overlays/src/components/toast/Toaster.vue
@@ -7,6 +7,7 @@ import {
     mergeProps,
 } from 'vue';
 import type {
+    Component,
     ExtractPublicPropTypes,
     PropType,
     SlotsType,
@@ -47,7 +48,7 @@ const toasterProps = {
     /** Aria label for the viewport landmark. */
     label: { type: String, default: undefined },
     /** HTML tag to render. */
-    as: { type: String, default: 'ol' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'ol' },
     ...themableProps<ToastViewportThemeClasses>(),
 };
 

--- a/packages/overlays/src/components/tooltip/TooltipTrigger.vue
+++ b/packages/overlays/src/components/tooltip/TooltipTrigger.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { TooltipTrigger } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
@@ -9,7 +9,7 @@ import type { TooltipThemeClasses } from './types';
 
 const tooltipTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: String, default: 'button' },
+    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** Per-instance theme override — flat slot key map. */


### PR DESCRIPTION
## Summary

Closes #1587.

- Widens `as:` prop type from `String` to `[String, Object] as PropType<string | Component>` across all **39 themable components** in `@vuecs/elements`, `@vuecs/overlays`, and `@vuecs/navigation`.
- Aligns first-party components with the pattern the `/guide/build-themable-component` docs page already teaches (added in #1586).
- Adds rule 6 to the "Wrapping Reka UI primitives" convention in `.agents/conventions.md` so the pattern is discoverable for future themable components.

## Why

Before this change, every wrapper declared:

```ts
as: { type: String, default: 'div' }
```

even though the underlying `VCPrimitive` / Reka `Primitive` accept both strings and components. A consumer writing

```vue
<VCCard :as="RouterLink" :to="`/article/${id}`">…</VCCard>
```

got a `[Vue warn]: Invalid prop: type check failed for prop "as". Expected String, got Function` and the prop was silently coerced to the wrapper's default tag. Pure type widening — no runtime behaviour change for existing string consumers.

## Files

- **`@vuecs/elements`** (14): Card + 5 bands, Alert + Title/Description/Close, Collapse + Trigger/Content, VisuallyHidden
- **`@vuecs/overlays`** (20): Modal Trigger/Close, Popover Trigger/Close, HoverCardTrigger, DropdownMenu Trigger/SubTrigger/Item/Label, ContextMenu Trigger/SubTrigger/Item/Label, Toast (Root/Action/Title/Description/Close), Toaster, TooltipTrigger
- **`@vuecs/navigation`** (5): Stepper Trigger/Indicator/Title/Description/Separator
- **`.agents/conventions.md`** — new rule 6 on `as:` declarations

## Test plan

- [x] `npm run lint` — 0 errors (only pre-existing warnings unrelated to this change)
- [x] `npm run build` — successful across all 27 projects
- [x] `npm run test` — all tests pass
- [ ] Smoke check `<VCCard :as="RouterLink" :to="...">` in a Vue Router app — `<a>` rendered, no prop-validation warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Components throughout the library now support custom Vue components via the `as` prop, in addition to HTML tag names, enabling more flexible component composition across Alert, Card, Collapse, Stepper, Modal, Dropdown Menu, Context Menu, Toast, Popover, Tooltip, and related components.

* **Documentation**
  * Updated component conventions guide with clarification on `as` prop typing requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->