### PR TITLE
feat(pagination): smart icon/text fallback + hide edge controls at boundaries

### DIFF
--- a/docs/demos/src/pagination.ts
+++ b/docs/demos/src/pagination.ts
@@ -36,7 +36,7 @@ announceProps(
         },
         hideDisabled: {
             type: 'boolean',
-            default: false,
+            default: true,
             section: 'State',
         },
         withText: {
@@ -61,7 +61,7 @@ announceProps(
         total: 100,
         limit: 10,
         busy: false,
-        hideDisabled: false,
+        hideDisabled: true,
         withText: false,
         'themeVariant.variant': 'outline',
         'themeVariant.size': 'md',

--- a/docs/demos/src/pagination.ts
+++ b/docs/demos/src/pagination.ts
@@ -35,9 +35,14 @@ announceProps(
             section: 'State', 
         },
         hideDisabled: {
-            type: 'boolean', 
-            default: false, 
-            section: 'State', 
+            type: 'boolean',
+            default: false,
+            section: 'State',
+        },
+        withText: {
+            type: 'boolean',
+            default: false,
+            section: 'State',
         },
         'themeVariant.variant': {
             type: 'enum', 
@@ -57,6 +62,7 @@ announceProps(
         limit: 10,
         busy: false,
         hideDisabled: false,
+        withText: false,
         'themeVariant.variant': 'outline',
         'themeVariant.size': 'md',
     },

--- a/docs/src/components/pagination.md
+++ b/docs/src/components/pagination.md
@@ -116,7 +116,7 @@ Pass `''` to a single label prop (e.g. `:prev-label="''"`) to suppress that one 
 | `offset` | `number` | `0` | Current offset |
 | `limit` | `number` | `0` | Items per page (must be > 0 for the component to render any pages) |
 | `busy` | `boolean` | `false` | Disable controls during loading |
-| `hideDisabled` | `boolean` | `false` | When `true`, edge controls (First/Prev at page 1, Next/Last at the last page) are unrendered instead of rendered-disabled. Does not apply to the `busy` state. |
+| `hideDisabled` | `boolean` | `true` | When `true`, edge controls (First/Prev at page 1, Next/Last at the last page) are unrendered instead of rendered-disabled. Pass `:hide-disabled="false"` to keep them rendered-disabled. Does not apply to the `busy` state. |
 | `withText` | `boolean` | `false` | When `true`, the resolved label string (First / Previous / Next / Last) is rendered as visible text next to each edge button. Defaults to icon-only. |
 | `tag` | `string` | `'ul'` | Root element tag |
 | `itemTag` | `string` | `'li'` | Item wrapper tag |

--- a/docs/src/components/pagination.md
+++ b/docs/src/components/pagination.md
@@ -79,7 +79,17 @@ Per-instance overrides: pass any of the four icon-name props directly. Pass `''`
 
 ## Labels (i18n)
 
-Each edge button renders an icon + text label. Defaults: `'First'`, `'Previous'`, `'Next'`, `'Last'`. Override per-instance via `firstLabel` / `prevLabel` / `nextLabel` / `lastLabel`, or globally via the [Behavioral Defaults](/guide/behavioral-defaults) system:
+Edge buttons are **icon-only by default**. Pass `with-text` to render the resolved label string alongside the icon. Reka's `aria-label="First Page"` etc. keeps the buttons accessible regardless of whether the visible text is shown.
+
+```vue
+<VCPagination
+    :total="100" :offset="0" :limit="10"
+    with-text
+    @load="load"
+/>
+```
+
+Label defaults: `'First'`, `'Previous'`, `'Next'`, `'Last'`. Override per-instance via `firstLabel` / `prevLabel` / `nextLabel` / `lastLabel`, or globally via the [Behavioral Defaults](/guide/behavioral-defaults) system:
 
 ```ts
 import { computed } from 'vue';
@@ -96,7 +106,7 @@ app.use(vuecs, {
 });
 ```
 
-Pass `''` to suppress the label for icon-only buttons.
+Pass `''` to a single label prop (e.g. `:prev-label="''"`) to suppress that one button's text even when `with-text` is enabled.
 
 ## Props
 
@@ -107,16 +117,17 @@ Pass `''` to suppress the label for icon-only buttons.
 | `limit` | `number` | `0` | Items per page (must be > 0 for the component to render any pages) |
 | `busy` | `boolean` | `false` | Disable controls during loading |
 | `hideDisabled` | `boolean` | `false` | When `true`, edge controls (First/Prev at page 1, Next/Last at the last page) are unrendered instead of rendered-disabled. Does not apply to the `busy` state. |
+| `withText` | `boolean` | `false` | When `true`, the resolved label string (First / Previous / Next / Last) is rendered as visible text next to each edge button. Defaults to icon-only. |
 | `tag` | `string` | `'ul'` | Root element tag |
 | `itemTag` | `string` | `'li'` | Item wrapper tag |
 | `firstIcon` | `string` | (preset) | Iconify name for the First-page button. `''` suppresses. |
 | `prevIcon` | `string` | (preset) | Iconify name for the Previous-page button. `''` suppresses. |
 | `nextIcon` | `string` | (preset) | Iconify name for the Next-page button. `''` suppresses. |
 | `lastIcon` | `string` | (preset) | Iconify name for the Last-page button. `''` suppresses. |
-| `firstLabel` | `string` | `'First'` | Visible text for the First-page button. `''` suppresses. |
-| `prevLabel` | `string` | `'Previous'` | Visible text for the Previous-page button. `''` suppresses. |
-| `nextLabel` | `string` | `'Next'` | Visible text for the Next-page button. `''` suppresses. |
-| `lastLabel` | `string` | `'Last'` | Visible text for the Last-page button. `''` suppresses. |
+| `firstLabel` | `string` | `'First'` | Visible text for the First-page button when `with-text` is enabled. `''` suppresses. |
+| `prevLabel` | `string` | `'Previous'` | Visible text for the Previous-page button when `with-text` is enabled. `''` suppresses. |
+| `nextLabel` | `string` | `'Next'` | Visible text for the Next-page button when `with-text` is enabled. `''` suppresses. |
+| `lastLabel` | `string` | `'Last'` | Visible text for the Last-page button when `with-text` is enabled. `''` suppresses. |
 
 ## Slots
 

--- a/docs/src/components/pagination.md
+++ b/docs/src/components/pagination.md
@@ -79,14 +79,22 @@ Per-instance overrides: pass any of the four icon-name props directly. Pass `''`
 
 ## Labels (i18n)
 
-Edge buttons are **icon-only by default**. Pass `with-text` to render the resolved label string alongside the icon. Reka's `aria-label="First Page"` etc. keeps the buttons accessible regardless of whether the visible text is shown.
+Edge-button display behaviour depends on whether an icon resolves for the button:
+
+- **Icon resolved** (icon preset installed or `firstIcon` / `prevIcon` / `nextIcon` / `lastIcon` passed) → **icon-only** by default. Pass `with-text` to render the label string alongside the icon.
+- **No icon resolved** → falls back to the **label string** so the button isn't visually empty.
+
+Reka's `aria-label="First Page"` etc. keeps the buttons accessible regardless.
 
 ```vue
-<VCPagination
-    :total="100" :offset="0" :limit="10"
-    with-text
-    @load="load"
-/>
+<!-- Icon preset installed → icon-only -->
+<VCPagination :total="100" :offset="0" :limit="10" @load="load" />
+
+<!-- Icon preset installed → icon + label -->
+<VCPagination :total="100" :offset="0" :limit="10" with-text @load="load" />
+
+<!-- No icon preset → label text fallback -->
+<VCPagination :total="100" :offset="0" :limit="10" @load="load" />
 ```
 
 Label defaults: `'First'`, `'Previous'`, `'Next'`, `'Last'`. Override per-instance via `firstLabel` / `prevLabel` / `nextLabel` / `lastLabel`, or globally via the [Behavioral Defaults](/guide/behavioral-defaults) system:
@@ -117,7 +125,7 @@ Pass `''` to a single label prop (e.g. `:prev-label="''"`) to suppress that one 
 | `limit` | `number` | `0` | Items per page (must be > 0 for the component to render any pages) |
 | `busy` | `boolean` | `false` | Disable controls during loading |
 | `hideDisabled` | `boolean` | `true` | When `true`, edge controls (First/Prev at page 1, Next/Last at the last page) are unrendered instead of rendered-disabled. Pass `:hide-disabled="false"` to keep them rendered-disabled. Does not apply to the `busy` state. |
-| `withText` | `boolean` | `false` | When `true`, the resolved label string (First / Previous / Next / Last) is rendered as visible text next to each edge button. Defaults to icon-only. |
+| `withText` | `boolean` | `false` | When `true`, forces the resolved label string (First / Previous / Next / Last) to render as visible text next to each edge button. When `false` (default), edge buttons are icon-only **if an icon resolves** for that button; otherwise the label string is rendered as a fallback so the button isn't empty. |
 | `tag` | `string` | `'ul'` | Root element tag |
 | `itemTag` | `string` | `'li'` | Item wrapper tag |
 | `firstIcon` | `string` | (preset) | Iconify name for the First-page button. `''` suppresses. |

--- a/examples/_shared/src/views/Pagination.vue
+++ b/examples/_shared/src/views/Pagination.vue
@@ -13,7 +13,7 @@ withDefaults(defineProps<{
     total: 100,
     limit: 10,
     busy: false,
-    hideDisabled: false,
+    hideDisabled: true,
     withText: false,
     themeVariant: () => ({}),
 });

--- a/examples/_shared/src/views/Pagination.vue
+++ b/examples/_shared/src/views/Pagination.vue
@@ -7,12 +7,14 @@ withDefaults(defineProps<{
     limit?: number;
     busy?: boolean;
     hideDisabled?: boolean;
+    withText?: boolean;
     themeVariant?: Record<string, string | boolean>;
 }>(), {
     total: 100,
     limit: 10,
     busy: false,
     hideDisabled: false,
+    withText: false,
     themeVariant: () => ({}),
 });
 
@@ -34,6 +36,7 @@ const load = (next: { offset: number }) => {
         :limit="limit"
         :busy="busy"
         :hide-disabled="hideDisabled"
+        :with-text="withText"
         :theme-variant="themeVariant"
         :offset="offset"
         @load="load"

--- a/packages/pagination/src/component.vue
+++ b/packages/pagination/src/component.vue
@@ -41,6 +41,15 @@ const paginationProps = {
     /** When true, edge controls are unrendered (vs rendered-disabled) at page boundaries. Does not apply to `busy`. */
     hideDisabled: { type: Boolean, default: false },
     /**
+     * When true, the resolved label strings (First / Previous / Next /
+     * Last) are rendered as visible text next to each edge button. When
+     * false (default), edge buttons show their icon only. Reka's
+     * `aria-label="First Page"` etc. keeps the buttons accessible
+     * either way. Has no effect on a button when a named slot (`#first`,
+     * `#prev`, `#next`, `#last`) replaces its content.
+     */
+    withText: { type: Boolean, default: false },
+    /**
      * Number of sibling page items on either side of the current
      * page in the rendered range. Forwarded to Reka `siblingCount`.
      */
@@ -204,7 +213,17 @@ export default defineComponent({
                             v-if="defaults.firstIcon"
                             :name="defaults.firstIcon"
                         />
-                        <span v-if="defaults.firstLabel">{{ defaults.firstLabel }}</span>
+                        <span v-if="withText && defaults.firstLabel">{{ defaults.firstLabel }}</span>
+                        <!-- Placeholder fills Reka's default slot when
+                             neither icon nor visible label is rendered, so
+                             Reka's `<slot>First page</slot>` fallback
+                             doesn't leak into the DOM. Reka's
+                             `aria-label="First Page"` keeps the button
+                             accessible. -->
+                        <span
+                            v-if="!defaults.firstIcon && !(withText && defaults.firstLabel)"
+                            aria-hidden="true"
+                        />
                     </template>
                 </PaginationFirst>
             </component>
@@ -223,7 +242,11 @@ export default defineComponent({
                             v-if="defaults.prevIcon"
                             :name="defaults.prevIcon"
                         />
-                        <span v-if="defaults.prevLabel">{{ defaults.prevLabel }}</span>
+                        <span v-if="withText && defaults.prevLabel">{{ defaults.prevLabel }}</span>
+                        <span
+                            v-if="!defaults.prevIcon && !(withText && defaults.prevLabel)"
+                            aria-hidden="true"
+                        />
                     </template>
                 </PaginationPrev>
             </component>
@@ -285,7 +308,11 @@ export default defineComponent({
                             v-if="defaults.nextIcon"
                             :name="defaults.nextIcon"
                         />
-                        <span v-if="defaults.nextLabel">{{ defaults.nextLabel }}</span>
+                        <span v-if="withText && defaults.nextLabel">{{ defaults.nextLabel }}</span>
+                        <span
+                            v-if="!defaults.nextIcon && !(withText && defaults.nextLabel)"
+                            aria-hidden="true"
+                        />
                     </template>
                 </PaginationNext>
             </component>
@@ -304,7 +331,11 @@ export default defineComponent({
                             v-if="defaults.lastIcon"
                             :name="defaults.lastIcon"
                         />
-                        <span v-if="defaults.lastLabel">{{ defaults.lastLabel }}</span>
+                        <span v-if="withText && defaults.lastLabel">{{ defaults.lastLabel }}</span>
+                        <span
+                            v-if="!defaults.lastIcon && !(withText && defaults.lastLabel)"
+                            aria-hidden="true"
+                        />
                     </template>
                 </PaginationLast>
             </component>

--- a/packages/pagination/src/component.vue
+++ b/packages/pagination/src/component.vue
@@ -39,7 +39,7 @@ const paginationProps = {
     /** Theme variant values. Vuecs theme concern, never forwarded to Reka. */
     themeVariant: { type: Object as PropType<VariantValues>, default: undefined },
     /** When true, edge controls are unrendered (vs rendered-disabled) at page boundaries. Does not apply to `busy`. */
-    hideDisabled: { type: Boolean, default: false },
+    hideDisabled: { type: Boolean, default: true },
     /**
      * When true, the resolved label strings (First / Previous / Next /
      * Last) are rendered as visible text next to each edge button. When

--- a/packages/pagination/src/component.vue
+++ b/packages/pagination/src/component.vue
@@ -41,11 +41,19 @@ const paginationProps = {
     /** When true, edge controls are unrendered (vs rendered-disabled) at page boundaries. Does not apply to `busy`. */
     hideDisabled: { type: Boolean, default: true },
     /**
-     * When true, the resolved label strings (First / Previous / Next /
-     * Last) are rendered as visible text next to each edge button. When
-     * false (default), edge buttons show their icon only. Reka's
+     * Forces the resolved label string (First / Previous / Next / Last)
+     * to render as visible text next to each edge button.
+     *
+     * When `false` (default), the per-button behaviour depends on
+     * whether an icon resolves for that button:
+     * - icon configured (via `firstIcon` / `prevIcon` / … or an icon
+     *   preset) → icon-only, no visible label;
+     * - no icon → falls back to the resolved label so the button
+     *   isn't empty.
+     *
+     * Set `withText: true` to render text alongside the icon. Reka's
      * `aria-label="First Page"` etc. keeps the buttons accessible
-     * either way. Has no effect on a button when a named slot (`#first`,
+     * either way. No effect on a button when a named slot (`#first`,
      * `#prev`, `#next`, `#last`) replaces its content.
      */
     withText: { type: Boolean, default: false },
@@ -213,15 +221,18 @@ export default defineComponent({
                             v-if="defaults.firstIcon"
                             :name="defaults.firstIcon"
                         />
-                        <span v-if="withText && defaults.firstLabel">{{ defaults.firstLabel }}</span>
+                        <!-- Label shows when either `withText` is forced
+                             on OR no icon resolved (text fallback so the
+                             button isn't visually empty). -->
+                        <span v-if="(withText || !defaults.firstIcon) && defaults.firstLabel">{{ defaults.firstLabel }}</span>
                         <!-- Placeholder fills Reka's default slot when
-                             neither icon nor visible label is rendered, so
-                             Reka's `<slot>First page</slot>` fallback
-                             doesn't leak into the DOM. Reka's
+                             both icon and label are suppressed, so Reka's
+                             `<slot>First page</slot>` fallback doesn't
+                             leak into the DOM. Reka's
                              `aria-label="First Page"` keeps the button
                              accessible. -->
                         <span
-                            v-if="!defaults.firstIcon && !(withText && defaults.firstLabel)"
+                            v-if="!defaults.firstIcon && !defaults.firstLabel"
                             aria-hidden="true"
                         />
                     </template>
@@ -242,9 +253,9 @@ export default defineComponent({
                             v-if="defaults.prevIcon"
                             :name="defaults.prevIcon"
                         />
-                        <span v-if="withText && defaults.prevLabel">{{ defaults.prevLabel }}</span>
+                        <span v-if="(withText || !defaults.prevIcon) && defaults.prevLabel">{{ defaults.prevLabel }}</span>
                         <span
-                            v-if="!defaults.prevIcon && !(withText && defaults.prevLabel)"
+                            v-if="!defaults.prevIcon && !defaults.prevLabel"
                             aria-hidden="true"
                         />
                     </template>
@@ -308,9 +319,9 @@ export default defineComponent({
                             v-if="defaults.nextIcon"
                             :name="defaults.nextIcon"
                         />
-                        <span v-if="withText && defaults.nextLabel">{{ defaults.nextLabel }}</span>
+                        <span v-if="(withText || !defaults.nextIcon) && defaults.nextLabel">{{ defaults.nextLabel }}</span>
                         <span
-                            v-if="!defaults.nextIcon && !(withText && defaults.nextLabel)"
+                            v-if="!defaults.nextIcon && !defaults.nextLabel"
                             aria-hidden="true"
                         />
                     </template>
@@ -331,9 +342,9 @@ export default defineComponent({
                             v-if="defaults.lastIcon"
                             :name="defaults.lastIcon"
                         />
-                        <span v-if="withText && defaults.lastLabel">{{ defaults.lastLabel }}</span>
+                        <span v-if="(withText || !defaults.lastIcon) && defaults.lastLabel">{{ defaults.lastLabel }}</span>
                         <span
-                            v-if="!defaults.lastIcon && !(withText && defaults.lastLabel)"
+                            v-if="!defaults.lastIcon && !defaults.lastLabel"
                             aria-hidden="true"
                         />
                     </template>

--- a/packages/pagination/test/unit/component.spec.ts
+++ b/packages/pagination/test/unit/component.spec.ts
@@ -197,12 +197,40 @@ describe('VCPagination', () => {
         expect(pageButtons[0].text().trim()).toBe('1');
     });
 
-    it('renders default English text labels on edge buttons when no slots/icons provided', () => {
+    it('does NOT render visible label text on edge buttons by default', () => {
+        // `withText` defaults to `false`. The label span is rendered with
+        // `v-show` so it stays in the vnode tree (suppressing Reka's
+        // `<slot>First page</slot>` fallback) but is hidden via inline
+        // `display: none`. Reka's `aria-label="… Page"` keeps the button
+        // accessible regardless.
         const wrapper = mount(VCPagination, {
             props: {
-                total: 50, 
-                limit: 10, 
-                offset: 20, 
+                total: 50,
+                limit: 10,
+                offset: 20,
+            },
+            global: { plugins: [themePlugin] },
+        });
+        const first = wrapper.find('button[aria-label="First Page"]');
+        const prev = wrapper.find('button[aria-label="Previous Page"]');
+        const next = wrapper.find('button[aria-label="Next Page"]');
+        const last = wrapper.find('button[aria-label="Last Page"]');
+        // Reka's slot fallback ('First page' / 'Prev page' / …) must not
+        // leak through, and the visible text (`.text()` ignores nodes
+        // hidden with `display: none`) must be empty.
+        expect(first.text()).toBe('');
+        expect(prev.text()).toBe('');
+        expect(next.text()).toBe('');
+        expect(last.text()).toBe('');
+    });
+
+    it('renders default English text labels on edge buttons when withText is enabled', () => {
+        const wrapper = mount(VCPagination, {
+            props: {
+                total: 50,
+                limit: 10,
+                offset: 20,
+                withText: true,
             },
             global: { plugins: [themePlugin] },
         });
@@ -212,12 +240,13 @@ describe('VCPagination', () => {
         expect(wrapper.find('button[aria-label="Last Page"]').text()).toBe('Last');
     });
 
-    it('per-instance label props override the defaults', () => {
+    it('per-instance label props override the defaults when withText is enabled', () => {
         const wrapper = mount(VCPagination, {
             props: {
                 total: 50,
                 limit: 10,
                 offset: 20,
+                withText: true,
                 prevLabel: 'Zurück',
                 nextLabel: 'Weiter',
             },
@@ -227,16 +256,17 @@ describe('VCPagination', () => {
         expect(wrapper.find('button[aria-label="Next Page"]').text()).toBe('Weiter');
     });
 
-    it('empty-string label suppresses the vuecs-rendered label content', () => {
-        // The default 'Previous' label appears in the button when no override
-        // is set. Setting `prevLabel: ''` suppresses vuecs's own label span;
-        // any remaining text is Reka UI's screen-reader-only "Prev page" /
-        // "Next page" affordance, which is intentional and out of scope.
+    it('empty-string label suppresses the vuecs-rendered label content (with withText enabled)', () => {
+        // With `withText: true` the default 'Previous' label appears.
+        // Setting `prevLabel: ''` suppresses vuecs's own label span; any
+        // remaining text is Reka UI's screen-reader-only "Prev page"
+        // affordance, which is intentional and out of scope.
         const withDefault = mount(VCPagination, {
             props: {
-                total: 50, 
-                limit: 10, 
-                offset: 20, 
+                total: 50,
+                limit: 10,
+                offset: 20,
+                withText: true,
             },
             global: { plugins: [themePlugin] },
         });
@@ -244,10 +274,11 @@ describe('VCPagination', () => {
 
         const withEmpty = mount(VCPagination, {
             props: {
-                total: 50, 
-                limit: 10, 
-                offset: 20, 
-                prevLabel: '', 
+                total: 50,
+                limit: 10,
+                offset: 20,
+                withText: true,
+                prevLabel: '',
             },
             global: { plugins: [themePlugin] },
         });

--- a/packages/pagination/test/unit/component.spec.ts
+++ b/packages/pagination/test/unit/component.spec.ts
@@ -198,40 +198,15 @@ describe('VCPagination', () => {
         expect(pageButtons[0].text().trim()).toBe('1');
     });
 
-    it('does NOT render visible label text on edge buttons by default', () => {
-        // `withText` defaults to `false`. The label span is rendered with
-        // `v-show` so it stays in the vnode tree (suppressing Reka's
-        // `<slot>First page</slot>` fallback) but is hidden via inline
-        // `display: none`. Reka's `aria-label="… Page"` keeps the button
-        // accessible regardless.
+    it('falls back to visible label text on edge buttons when no icon resolves', () => {
+        // No icon preset installed → `defaults.<edge>Icon` is empty.
+        // The label string falls back to visible text so the button isn't
+        // empty, even with `withText: false`.
         const wrapper = mount(VCPagination, {
             props: {
                 total: 50,
                 limit: 10,
                 offset: 20,
-            },
-            global: { plugins: [themePlugin] },
-        });
-        const first = wrapper.find('button[aria-label="First Page"]');
-        const prev = wrapper.find('button[aria-label="Previous Page"]');
-        const next = wrapper.find('button[aria-label="Next Page"]');
-        const last = wrapper.find('button[aria-label="Last Page"]');
-        // Reka's slot fallback ('First page' / 'Prev page' / …) must not
-        // leak through, and the visible text (`.text()` ignores nodes
-        // hidden with `display: none`) must be empty.
-        expect(first.text()).toBe('');
-        expect(prev.text()).toBe('');
-        expect(next.text()).toBe('');
-        expect(last.text()).toBe('');
-    });
-
-    it('renders default English text labels on edge buttons when withText is enabled', () => {
-        const wrapper = mount(VCPagination, {
-            props: {
-                total: 50,
-                limit: 10,
-                offset: 20,
-                withText: true,
             },
             global: { plugins: [themePlugin] },
         });
@@ -241,13 +216,54 @@ describe('VCPagination', () => {
         expect(wrapper.find('button[aria-label="Last Page"]').text()).toBe('Last');
     });
 
-    it('per-instance label props override the defaults when withText is enabled', () => {
+    it('renders icon-only (no label) by default when an icon resolves', () => {
+        // Icon configured per-instance — text label suppressed because
+        // `withText` defaults to `false`. Reka's `aria-label="… Page"`
+        // carries the accessible name regardless.
+        const wrapper = mount(VCPagination, {
+            props: {
+                total: 50,
+                limit: 10,
+                offset: 20,
+                firstIcon: 'lucide:chevrons-left',
+                prevIcon: 'lucide:chevron-left',
+                nextIcon: 'lucide:chevron-right',
+                lastIcon: 'lucide:chevrons-right',
+            },
+            global: { plugins: [themePlugin] },
+        });
+        expect(wrapper.find('button[aria-label="First Page"]').text()).toBe('');
+        expect(wrapper.find('button[aria-label="Previous Page"]').text()).toBe('');
+        expect(wrapper.find('button[aria-label="Next Page"]').text()).toBe('');
+        expect(wrapper.find('button[aria-label="Last Page"]').text()).toBe('');
+    });
+
+    it('withText: true forces label text alongside the icon', () => {
         const wrapper = mount(VCPagination, {
             props: {
                 total: 50,
                 limit: 10,
                 offset: 20,
                 withText: true,
+                firstIcon: 'lucide:chevrons-left',
+                prevIcon: 'lucide:chevron-left',
+                nextIcon: 'lucide:chevron-right',
+                lastIcon: 'lucide:chevrons-right',
+            },
+            global: { plugins: [themePlugin] },
+        });
+        expect(wrapper.find('button[aria-label="First Page"]').text()).toBe('First');
+        expect(wrapper.find('button[aria-label="Previous Page"]').text()).toBe('Previous');
+        expect(wrapper.find('button[aria-label="Next Page"]').text()).toBe('Next');
+        expect(wrapper.find('button[aria-label="Last Page"]').text()).toBe('Last');
+    });
+
+    it('per-instance label props override the defaults', () => {
+        const wrapper = mount(VCPagination, {
+            props: {
+                total: 50,
+                limit: 10,
+                offset: 20,
                 prevLabel: 'Zurück',
                 nextLabel: 'Weiter',
             },
@@ -257,35 +273,24 @@ describe('VCPagination', () => {
         expect(wrapper.find('button[aria-label="Next Page"]').text()).toBe('Weiter');
     });
 
-    it('empty-string label suppresses the vuecs-rendered label content (with withText enabled)', () => {
-        // With `withText: true` the default 'Previous' label appears.
-        // Setting `prevLabel: ''` suppresses vuecs's own label span; any
-        // remaining text is Reka UI's screen-reader-only "Prev page"
-        // affordance, which is intentional and out of scope.
-        const withDefault = mount(VCPagination, {
+    it('empty-string label + no icon suppresses vuecs label content (Reka fallback also suppressed)', () => {
+        // Setting `prevLabel: ''` AND no icon means both the icon and
+        // label branches are empty. The `aria-hidden` placeholder span
+        // fills Reka's default slot so its "Prev page" fallback doesn't
+        // leak. Reka's `aria-label="Previous Page"` still names the
+        // button.
+        const wrapper = mount(VCPagination, {
             props: {
                 total: 50,
                 limit: 10,
                 offset: 20,
-                withText: true,
-            },
-            global: { plugins: [themePlugin] },
-        });
-        expect(withDefault.find('button[aria-label="Previous Page"]').text()).toContain('Previous');
-
-        const withEmpty = mount(VCPagination, {
-            props: {
-                total: 50,
-                limit: 10,
-                offset: 20,
-                withText: true,
                 prevLabel: '',
             },
             global: { plugins: [themePlugin] },
         });
-        // 'Previous' specifically (capitalised, vuecs's contribution) is gone.
-        // Reka's sr-only "Prev page" (lowercase 'p') may remain.
-        expect(withEmpty.find('button[aria-label="Previous Page"]').text()).not.toMatch(/Previous/);
+        const prev = wrapper.find('button[aria-label="Previous Page"]');
+        expect(prev.text()).toBe('');
+        expect(prev.attributes('aria-label')).toBe('Previous Page');
     });
 
     it('full-button slot wins over icon prop and label default', () => {

--- a/packages/pagination/test/unit/component.spec.ts
+++ b/packages/pagination/test/unit/component.spec.ts
@@ -172,6 +172,7 @@ describe('VCPagination', () => {
                 total: 50,
                 limit: 10,
                 offset: 0,
+                hideDisabled: false,
             },
             global: { plugins: [themePlugin] },
         });


### PR DESCRIPTION
## Summary

Three related default-behaviour changes to `<VCPagination>` so the bare `<VCPagination :total :limit />` call site is visually minimal but never empty:

1. **New `withText: Boolean` (default `false`)** — forces the resolved label string (First / Previous / Next / Last) to render alongside each edge button.
2. **Per-button icon/text fallback** — when `withText` is `false` (the default), each edge button picks its rendering based on whether an icon resolves:
   - icon configured → **icon-only**;
   - no icon → **label string** falls back as visible text so the button isn't empty.

   Reka's `aria-label="First Page"` etc. keeps the buttons screen-reader-accessible regardless.
3. **`hideDisabled` default flipped from `false` → `true`** — edge controls (First/Prev at page 1, Next/Last at the last page) are now unrendered by default instead of rendered-disabled. Opt back into rendered-disabled with `:hide-disabled="false"`. The `busy` state is unaffected.

## Why

Before this change, `<VCPagination />` rendered "First / Previous / Next / Last" text by default — fine when no icon preset was installed, but visually duplicate once an icon preset filled in icons. Edge buttons also rendered as disabled at boundaries, adding clutter to bare call sites.

```vue
<!-- No icon preset installed -->
<VCPagination :total="100" :limit="10" />
<!-- → [First] [Previous] 1 2 3 4 5 [Next] [Last]
       — label text fallback so buttons aren't empty -->

<!-- With @vuecs/icons-lucide installed -->
<VCPagination :total="100" :limit="10" />
<!-- → [«] [‹] 1 2 3 4 5 [›] [»]   — icon-only -->

<!-- Force text alongside the icon -->
<VCPagination :total="100" :limit="10" with-text />
<!-- → [« First] [‹ Previous] 1 2 3 4 5 [Next ›] [Last »] -->

<!-- All boundary buttons are hidden on page 1 by default;
     opt back into rendered-disabled: -->
<VCPagination :total="100" :limit="10" :hide-disabled="false" />
```

## Implementation note

Reka's `<PaginationFirst>` ships a default-slot fallback (`<slot>First page</slot>`). If vuecs's slot returned no vnodes (icon AND label both suppressed via `firstIcon: ''` + `firstLabel: ''`), Vue would fall back to Reka's text. To prevent that leaking into the DOM, the template emits a small `<span aria-hidden="true" />` placeholder in that case — Reka sees a filled slot, no fallback fires.

## Files

- **`packages/pagination/src/component.vue`** — new `withText` prop + `hideDisabled` default flip + icon/text fallback + placeholder spans
- **`packages/pagination/test/unit/component.spec.ts`** — three new tests covering the fallback / icon-only / `withText` matrix; `:hide-disabled="false"` added to the rendered-disabled test
- **`docs/src/components/pagination.md`** — rewrote the Labels (i18n) section to document the per-button icon/text fallback; updated the Props table
- **`docs/demos/src/pagination.ts`** — added `withText` to the playground toolbar, flipped `hideDisabled` default
- **`examples/_shared/src/views/Pagination.vue`** — forwarded `withText`, flipped `hideDisabled`

## Breaking change

**Yes — two breaking default changes:**

- Bare `<VCPagination />` **with an icon preset installed** no longer renders visible label text by default (was: label always rendered). Add `with-text` to keep the old appearance.
- Bare `<VCPagination />` **unrenders edge controls at boundaries** by default (was: rendered-disabled). Add `:hide-disabled="false"` to keep them rendered-disabled.

Bare `<VCPagination />` **without an icon preset** is visually unchanged (label fallback matches the previous always-on label rendering).

The label-default values (`'First'`, `'Previous'`, `'Next'`, `'Last'`) are unchanged.

release-please note: the commits use `feat:` which will land as a **minor bump** under release-please's default config. If the project considers these default-rendering changes a major semver event, the commits should be reworded to `feat(pagination)!:` ahead of merge to trigger a major bump.

## Test plan

- [x] `npm run test --workspace=packages/pagination` — 30 tests passing
- [x] `npm run build` — successful across all 27 projects
- [x] `npm run lint` — 0 errors
- [ ] Visual smoke in the demo iframe: bare `<VCPagination />` renders icon-only with boundary controls hidden once `@vuecs/icons-lucide` is installed; remove the preset → text fallback fills the buttons; toggle `with-text` to add text alongside icons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `withText` prop to control whether Pagination edge labels render as visible text alongside icons.

* **Changes**
  * Changed `hideDisabled` default value to `true`.
  * Edge buttons now render icon-only by default, with labels visible only when `withText` is enabled or no icon resolves.

* **Documentation**
  * Updated Pagination documentation and examples to reflect new rendering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->