### PR TITLE
fix(table): dispatch #cell-<key> / #header-<key> slots in auto-render

### DIFF
--- a/docs/src/components/table.md
+++ b/docs/src/components/table.md
@@ -183,9 +183,28 @@ The walker recurses into Fragments, so `<template v-if>` /
 `<VCTableBody>` still suppresses the auto-render correctly.
 
 Auto-cells use the default cell renderer (`accessor` / `formatter`)
-documented above. Per-cell rendering control still requires
-composing the manual chrome (`<VCTableBody>` + `<VCTableRow>` +
-`<VCTableCell>` with a slot).
+documented above. For per-column custom rendering inside the
+auto-render path, pass a `#cell-<key>` slot — its render result
+replaces the default cell content for that column. A matching
+`#header-<key>` slot replaces the column's header text.
+
+```vue
+<VCTable :columns :data>
+    <template #cell-options="{ row }">
+        <button @click="edit(row)">Edit</button>
+        <button @click="remove(row)">Delete</button>
+    </template>
+    <template #header-options="{ column }">
+        <span class="text-muted">{{ column.label }}</span>
+    </template>
+</VCTable>
+```
+
+Slot props match the exported `TableCellSlotProps` (`{ row, value,
+key, column, index }`) and `TableHeadCellSlotProps` (`{ column, key,
+sort, setSort }`) types. The cell-slot `value` honors the column's
+`accessor` (so dot-paths and accessor functions work transparently);
+the slot wins over the column's `formatter` if both are set.
 
 ## Row selection
 

--- a/packages/table/src/components/Table.vue
+++ b/packages/table/src/components/Table.vue
@@ -25,8 +25,10 @@ import type {
 import { useSortMachine } from '../composables/sort';
 import type {
     SortDirection,
+    TableCellSlotProps,
     TableColumn,
     TableColumnRaw,
+    TableHeadCellSlotProps,
     TableSlotProps,
     TableSortState,
     TableThemeClasses,
@@ -162,6 +164,19 @@ export default defineComponent({
         default(props: TableSlotProps): unknown;
         caption(): unknown;
         colgroup(): unknown;
+        /**
+         * Per-column cell override. Dispatched by the columns-driver
+         * auto-render path; the key suffix matches `TableColumn['key']`.
+         * Wins over `<VCTableCell>`'s `accessor` + `formatter` auto-
+         * render. (Closes #1592.)
+         */
+        [cellSlot: `cell-${string}`]: (props: TableCellSlotProps) => unknown;
+        /**
+         * Per-column header override. Dispatched by the columns-driver
+         * auto-render path; key suffix matches `TableColumn['key']`.
+         * Wins over the default `col.label` text. (Closes #1592.)
+         */
+        [headerSlot: `header-${string}`]: (props: TableHeadCellSlotProps) => unknown;
     }>,
     setup(props, {
         attrs, 
@@ -358,6 +373,9 @@ export default defineComponent({
                 slotChildren: slots.default?.(slotProps.value),
                 captionSlot: slots.caption,
                 colgroupSlot: slots.colgroup,
+                slots,
+                sort: sortMachine.state.value,
+                setSort: sortMachine.setSort,
                 placeholderRows: skeletonRowCount,
             });
 

--- a/packages/table/src/components/TableLite.vue
+++ b/packages/table/src/components/TableLite.vue
@@ -17,8 +17,10 @@ import {
 import { useRowSelectionMachine } from '../composables/selection';
 import type { RowSelectionKey } from '../composables/selection';
 import type {
+    TableCellSlotProps,
     TableColumn,
     TableColumnRaw,
+    TableHeadCellSlotProps,
     TableSlotProps,
     TableThemeClasses,
 } from '../types';
@@ -99,6 +101,19 @@ export default defineComponent({
         default(props: TableSlotProps): unknown;
         caption(): unknown;
         colgroup(): unknown;
+        /**
+         * Per-column cell override. Dispatched by the columns-driver
+         * auto-render path; the key suffix matches `TableColumn['key']`.
+         * Wins over `<VCTableCell>`'s `accessor` + `formatter` auto-
+         * render. (Closes #1592.)
+         */
+        [cellSlot: `cell-${string}`]: (props: TableCellSlotProps) => unknown;
+        /**
+         * Per-column header override. Dispatched by the columns-driver
+         * auto-render path; key suffix matches `TableColumn['key']`.
+         * Wins over the default `col.label` text. (Closes #1592.)
+         */
+        [headerSlot: `header-${string}`]: (props: TableHeadCellSlotProps) => unknown;
     }>,
     setup(props, { attrs, slots }) {
         const themeProps = useThemeProps(
@@ -206,6 +221,7 @@ export default defineComponent({
                 slotChildren: slots.default?.(slotProps.value),
                 captionSlot: slots.caption,
                 colgroupSlot: slots.colgroup,
+                slots,
                 placeholderRows: skeletonRowCount,
             });
 

--- a/packages/table/src/utils/auto-render.ts
+++ b/packages/table/src/utils/auto-render.ts
@@ -7,7 +7,14 @@ import VCTableFooter from '../components/TableFooter.vue';
 import VCTableHeadCell from '../components/TableHeadCell.vue';
 import VCTableHeader from '../components/TableHeader.vue';
 import VCTableRow from '../components/TableRow.vue';
-import type { TableColumn } from '../types';
+import type {
+    SortDirection,
+    TableCellSlotProps,
+    TableColumn,
+    TableHeadCellSlotProps,
+    TableSortState,
+} from '../types';
+import { resolveCellValue } from './render-utils';
 
 /**
  * Recursively check whether `nodes` (a slot return) contains a vnode
@@ -100,6 +107,32 @@ export function composeTableInner(opts: {
     captionSlot?: (() => unknown) | undefined;
     colgroupSlot?: (() => unknown) | undefined;
     /**
+     * Consumer's slot map. When set, the auto-render path dispatches
+     * `#cell-<key>` slots onto each `<VCTableCell>` and `#header-<key>`
+     * slots onto each `<VCTableHeadCell>`. Closes the gap between the
+     * documented `TableColumn` JSDoc (which advertises these slot
+     * names) and the auto-render runtime (which previously ignored
+     * them — see issue #1592).
+     *
+     * Typed as a permissive dynamic-key map (not Vue's `Slots` /
+     * `InternalSlots`) so callers can pass `slots` from a strictly-
+     * typed `defineComponent({ slots: SlotsType<{…}> })` setup
+     * argument without TS rejecting the assignment.
+     */
+    slots?: Record<string, ((slotProps?: unknown) => unknown) | undefined>;
+    /**
+     * Current sort state. Forwarded to the `#header-<key>` slot props
+     * (`sort` field) so consumers can render their own indicator. Only
+     * read when `slots` is provided.
+     */
+    sort?: TableSortState;
+    /**
+     * `setSort` callback. Forwarded to the `#header-<key>` slot props
+     * so a custom header can drive sort changes. Only read when
+     * `slots` is provided.
+     */
+    setSort?: (key: string, opts?: { direction?: SortDirection }) => void;
+    /**
      * When set, the body band is REPLACED by a skeleton `<tbody>`
      * with `placeholderRows × cols.length` placeholder bars. Header
      * still auto-renders from `cols` (real column labels); any
@@ -114,6 +147,9 @@ export function composeTableInner(opts: {
         slotChildren,
         captionSlot,
         colgroupSlot,
+        slots,
+        sort,
+        setSort,
         placeholderRows,
     } = opts;
 
@@ -126,9 +162,13 @@ export function composeTableInner(opts: {
     const hasBody = autoRender && containsComponent(slotChildren, VCTableBody);
 
     if (autoRender && !hasHeader) {
-        inner.push(h(VCTableHeader, null, () => h(VCTableRow, null, () => cols.map((col) => h(
-            VCTableHeadCell,
-            {
+        inner.push(h(VCTableHeader, null, () => h(VCTableRow, null, () => cols.map((col) => {
+            // Consumer `#header-<key>` slot wins over the default
+            // `col.label` text — see issue #1592. The auto-render path
+            // used to ignore these slots silently; now it dispatches
+            // them with the documented `TableHeadCellSlotProps` shape.
+            const headerSlot = slots?.[`header-${col.key}`];
+            const cellProps = {
                 key: col.key,
                 columnKey: col.key,
                 sortable: col.sortable,
@@ -138,9 +178,22 @@ export function composeTableInner(opts: {
                 // `column.class` applies to BOTH <th> and <td>; `headerClass`
                 // is the header-only additive. Vue normalizes the array.
                 class: [col.class, col.headerClass],
-            },
-            () => col.label,
-        )))));
+            };
+            if (headerSlot) {
+                const matched = sort?.find((s) => s.key === col.key);
+                const slotProps: TableHeadCellSlotProps<unknown> = {
+                    column: col,
+                    key: col.key,
+                    sort: matched ? matched.direction : null,
+                    setSort: (direction) => {
+                        if (!setSort) return;
+                        setSort(col.key, direction ? { direction } : undefined);
+                    },
+                };
+                return h(VCTableHeadCell, cellProps, () => headerSlot(slotProps));
+            }
+            return h(VCTableHeadCell, cellProps, () => col.label);
+        }))));
     }
 
     // Partition slot children so `<VCTableFooter>` always lands AFTER
@@ -190,14 +243,31 @@ export function composeTableInner(opts: {
             row: ({ row, index }: { row: unknown; index: number }) => h(
                 VCTableRow,
                 { row, index },
-                () => cols.map((col) => h(VCTableCell, {
-                    key: col.key,
-                    columnKey: col.key,
-                    isRowHeader: col.isRowHeader,
-                    stickyColumn: col.stickyColumn,
-                    dataLabel: col.label,
-                    class: [col.class, col.cellClass],
-                })),
+                () => cols.map((col) => {
+                    const cellProps = {
+                        key: col.key,
+                        columnKey: col.key,
+                        isRowHeader: col.isRowHeader,
+                        stickyColumn: col.stickyColumn,
+                        dataLabel: col.label,
+                        class: [col.class, col.cellClass],
+                    };
+                    // Consumer `#cell-<key>` slot wins over
+                    // `<VCTableCell>`'s auto-render path. Slot props
+                    // mirror `TableCellSlotProps` — see issue #1592.
+                    const cellSlot = slots?.[`cell-${col.key}`];
+                    if (cellSlot) {
+                        const slotProps: TableCellSlotProps<unknown> = {
+                            row,
+                            value: resolveCellValue(col, row),
+                            key: col.key,
+                            column: col,
+                            index,
+                        };
+                        return h(VCTableCell, cellProps, () => cellSlot(slotProps));
+                    }
+                    return h(VCTableCell, cellProps);
+                }),
             ),
         }));
     }

--- a/packages/table/test/unit/auto-render.spec.ts
+++ b/packages/table/test/unit/auto-render.spec.ts
@@ -297,4 +297,94 @@ describe('<VCTable> driver auto-render (plan 033 v0.2-B)', () => {
         expect(headerCells.length).toBe(1);
         expect(headerCells[0].textContent?.trim()).toBe('WRAPPED');
     });
+
+    // Issue #1592 — auto-render path must dispatch consumer
+    // `#cell-<key>` / `#header-<key>` slots, not silently drop them.
+    describe('per-column slot dispatch (issue #1592)', () => {
+        it('dispatches #cell-<key> slot for each row in the auto-body', () => {
+            const wrapper = mount(defineComponent({
+                setup() {
+                    return () => h(VCTable, {
+                        columns: columns as never,
+                        data: data as never,
+                    }, {
+                        'cell-name': (slotProps: {
+                            row: User; 
+                            value: unknown; 
+                            index: number 
+                        }) => h(
+                            'button',
+                            { class: 'edit-btn' },
+                            `edit:${slotProps.row.id}:${slotProps.value}:${slotProps.index}`,
+                        ),
+                    });
+                },
+            }), { global: { plugins: [...plugins] } });
+
+            const cells = wrapper.element.querySelectorAll('tbody td');
+            // Two columns × two rows = 4 cells; second column (name) is the slot.
+            expect(cells[1].querySelector('button.edit-btn')?.textContent).toBe('edit:1:Alice:0');
+            expect(cells[3].querySelector('button.edit-btn')?.textContent).toBe('edit:2:Bob:1');
+            // The id column (no slot) keeps the auto-rendered text value.
+            expect(cells[0].textContent).toBe('1');
+            expect(cells[2].textContent).toBe('2');
+        });
+
+        it('dispatches #header-<key> slot in the auto-header', () => {
+            const wrapper = mount(defineComponent({
+                setup() {
+                    return () => h(VCTable, {
+                        columns: columns as never,
+                        data: data as never,
+                    }, {
+                        'header-name': (slotProps: { column: { label?: string }; key: string }) => h(
+                            'span',
+                            { class: 'custom-header' },
+                            `${slotProps.key}:${slotProps.column.label}`,
+                        ),
+                    });
+                },
+            }), { global: { plugins: [...plugins] } });
+
+            const headers = wrapper.element.querySelectorAll('thead th');
+            expect(headers[0].textContent?.trim()).toBe('ID');
+            expect(headers[1].querySelector('span.custom-header')?.textContent).toBe('name:Name');
+        });
+
+        it('cell slot props expose accessor + formatter resolution', () => {
+            const cols = [
+                { key: 'id', label: 'ID' },
+                {
+                    key: 'fullName',
+                    label: 'Name',
+                    accessor: (row: User) => `Sir ${row.name}`,
+                    formatter: (ctx: { value: unknown }) => `[${ctx.value}]`,
+                },
+            ];
+            const observedValues: unknown[] = [];
+            const wrapper = mount(defineComponent({
+                setup() {
+                    return () => h(VCTable, {
+                        columns: cols as never,
+                        data: data as never,
+                    }, {
+                        'cell-fullName': ({ value }: { value: unknown }) => {
+                            observedValues.push(value);
+                            return h('span', null, String(value));
+                        },
+                    });
+                },
+            }), { global: { plugins: [...plugins] } });
+
+            // `value` is the accessor result, not the formatter output —
+            // matches TableColumnFormatterCtx.value semantics.
+            expect(observedValues).toContain('Sir Alice');
+            expect(observedValues).toContain('Sir Bob');
+            // The slot wins over `formatter` (which would have wrapped
+            // the value in brackets — no `[…]` in the rendered cell).
+            const rendered = Array.from(wrapper.element.querySelectorAll('tbody td:nth-child(2) span'))
+                .map((el) => el.textContent);
+            expect(rendered).toEqual(['Sir Alice', 'Sir Bob']);
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Closes #1592.

The `TableColumn` JSDoc advertises two slot patterns:

```ts
/** Heading text … Override per-column via `#header-<key>` slot. */
label?: string;
/** Default cell renderer when `#cell-<key>` slot isn't provided. */
formatter?: …;
```

But `<VCTable>`'s columns-driver auto-render path never dispatched those slots — only `slots.default` / `slots.caption` / `slots.colgroup` were forwarded. Consumers writing the documented `<template #cell-options="{ row }">` got the column's auto-rendered text instead, silently.

This PR wires the slots through `composeTableInner()`:

- **`#header-<key>`** — dispatched as `<VCTableHeadCell>`'s default slot with `TableHeadCellSlotProps` (`{ column, key, sort, setSort }`). Falls back to `col.label`.
- **`#cell-<key>`** — dispatched as `<VCTableCell>`'s default slot with `TableCellSlotProps` (`{ row, value, key, column, index }`). The `value` runs through `resolveCellValue` (honoring `accessor`); the slot wins over `column.formatter` when both are set.

Both `<VCTable>` and `<VCTableLite>` benefit (Lite passes no `sort` / `setSort` since it's stateless).

## Example

```vue
<VCTable :columns :data>
    <template #cell-options="{ row }">
        <button @click="edit(row)">Edit</button>
        <button @click="remove(row)">Delete</button>
    </template>
    <template #header-options="{ column }">
        <span class="text-muted">{{ column.label }}</span>
    </template>
</VCTable>
```

## Typing

Dynamic slot keys are typed via TS template-literal keys in `SlotsType<{…}>`:

```ts
[cellSlot: `cell-${string}`]: (props: TableCellSlotProps) => unknown;
[headerSlot: `header-${string}`]: (props: TableHeadCellSlotProps) => unknown;
```

Editor IntelliSense surfaces them when authoring `<template #cell-...>` blocks.

## Files

- **`packages/table/src/utils/auto-render.ts`** — `composeTableInner()` accepts `slots` / `sort` / `setSort`; dispatches per-column slots inside the auto-header / auto-body branches
- **`packages/table/src/components/Table.vue`** — passes `slots`, `sort`, `setSort` through; declares dynamic slot types
- **`packages/table/src/components/TableLite.vue`** — passes `slots` through (no sort plumbing); declares dynamic slot types
- **`packages/table/test/unit/auto-render.spec.ts`** — new `per-column slot dispatch (issue #1592)` describe block with three tests: cell slot per row, header slot, accessor/formatter resolution into slot props
- **`docs/src/components/table.md`** — documents the slot dispatch with a `#cell-options` / `#header-options` example + links to the exported slot-prop types

## Compatibility

Purely additive — no breaking change. Consumers without a `#cell-<key>` / `#header-<key>` slot get the existing default behaviour (cell auto-render via `accessor` + `formatter`, header from `col.label`).

## Test plan

- [x] `npm run test --workspace=packages/table` — 155 tests passing (3 new under the issue #1592 describe block)
- [x] `npm run build` — successful across all 27 projects
- [x] `npm run lint` — 0 errors
- [ ] Visual smoke: paste the `#cell-options` example from the docs into a consumer app, confirm the Edit / Delete buttons render inside the column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VCTable now supports per-column custom rendering via named slots, enabling column-specific customization for headers and cells without manual markup.
  * Slot prop values are derived from column accessors and override column formatters when both are provided.

* **Documentation**
  * Updated documentation for per-column slot support, including slot prop type specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->