### PR TITLE
fix(core): merge install options into existing manager (closes #1591)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -79,7 +79,7 @@ After slot class resolution, **variant resolution** applies:
 ### Key APIs
 
 - **`ThemeManager`** — Holds config state (themes, overrides) as `shallowRef`s, delegates to `resolveComponentTheme()` and `resolveVariantClasses()`. Supports runtime updates via `setThemes()` and `setOverrides()`.
-- **`installThemeManager(app, options)`** — Vue plugin that provides ThemeManager via `app.provide()`
+- **`installThemeManager(app, options)`** — Vue plugin that provides ThemeManager via `app.provide()`. **Install-order-safe (#1591):** if a manager already exists in the app context, the call **merges** `options.themes` (appended) and `options.overrides` (replaces) into it instead of returning early. This way `app.use(installNavigation)` running before `app.use(vuecs, { themes: [...] })` still applies the themes. The same merge-on-second-call pattern applies to `installDefaultsManager` (per-component deep merge via `DefaultsManager.mergeDefaults`) and `installConfigManager` (shallow merge of `options.config`).
 - **`injectThemeManager()`** — Retrieves ThemeManager from Vue inject
 - **`useComponentTheme(name, props, defaults)`** — Vue composable. `props` is the component's reactive props object; the composable reads `props.themeClass` and `props.themeVariant` internally. Returns `ComputedRef<T>` that recomputes when `props.themeClass`, `props.themeVariant`, or ThemeManager state changes. Throws if ThemeManager is not installed.
 - **`extend(value)`** — Marker function: merge with lower layer instead of replacing (only needed in overrides and instance props; themes always merge with defaults)

--- a/packages/core/src/config/install.ts
+++ b/packages/core/src/config/install.ts
@@ -16,6 +16,12 @@ export function installConfigManager(
 ): ConfigManager {
     const existing = inject<ConfigManager>(CONFIG_MANAGER_SYMBOL, app);
     if (existing) {
+        // Merge fresh config into the existing manager so the order of
+        // `app.use(...)` calls doesn't matter. Mirror of the theme/defaults
+        // managers' install-order fix (#1591).
+        if (options.config) {
+            existing.setConfig({ ...existing.config, ...options.config });
+        }
         return existing;
     }
 

--- a/packages/core/src/defaults/install.ts
+++ b/packages/core/src/defaults/install.ts
@@ -11,6 +11,12 @@ export function installDefaultsManager(
 ): DefaultsManager {
     const existing = inject<DefaultsManager>(DEFAULTS_MANAGER_SYMBOL, app);
     if (existing) {
+        // Merge fresh defaults into the existing manager so the order of
+        // `app.use(...)` calls doesn't matter. Mirror of the theme/config
+        // managers' install-order fix (#1591).
+        if (options.defaults) {
+            existing.mergeDefaults(options.defaults);
+        }
         return existing;
     }
 

--- a/packages/core/src/defaults/manager.ts
+++ b/packages/core/src/defaults/manager.ts
@@ -1,5 +1,6 @@
 import type { ShallowRef } from 'vue';
 import { shallowRef, triggerRef } from 'vue';
+import { isObject } from '../utils';
 import type { ComponentDefaults, DefaultsManagerOptions } from './types';
 
 export class DefaultsManager {
@@ -20,6 +21,29 @@ export class DefaultsManager {
         if (isSameRef) {
             triggerRef(this.defaultsRef);
         }
+    }
+
+    /**
+     * Per-component deep-merge of `partial` into the current defaults map.
+     * Later-wins per `(componentName, key)`; `undefined` values in `partial`
+     * are skipped so partial later layers don't accidentally clear a
+     * preset's value (matches `resolveDefaults` in `@vuecs/core`).
+     *
+     * Used by `installDefaultsManager` on its second-and-later invocation
+     * so install-order doesn't silently drop options (see #1591).
+     */
+    mergeDefaults(partial: Partial<ComponentDefaults> | undefined): void {
+        if (!partial) return;
+        const next: Record<string, any> = { ...this.defaultsRef.value };
+        for (const [name, value] of Object.entries(partial)) {
+            if (!isObject(value)) continue;
+            const existing = next[name] || Object.create(null);
+            const incoming = Object.fromEntries(
+                Object.entries(value).filter(([, v]) => v !== undefined),
+            );
+            next[name] = { ...existing, ...incoming };
+        }
+        this.defaultsRef.value = next as Partial<ComponentDefaults>;
     }
 
     get<K extends keyof ComponentDefaults>(componentName: K): ComponentDefaults[K] | undefined {

--- a/packages/core/src/theme/install.ts
+++ b/packages/core/src/theme/install.ts
@@ -11,6 +11,18 @@ export function installThemeManager(
 ): ThemeManager {
     const existing = inject<ThemeManager>(THEME_MANAGER_SYMBOL, app);
     if (existing) {
+        // Merge fresh options into the existing manager so the order of
+        // `app.use(...)` calls doesn't matter. Without this, a per-package
+        // `install()` that runs first would freeze the manager with no
+        // themes, and a later `app.use(vuecs, { themes: [...] })` would
+        // silently drop them. Themes append (matches install-order
+        // stacking); overrides replace (single-owner). See #1591.
+        if (options.themes && options.themes.length > 0) {
+            existing.setThemes([...existing.themes, ...options.themes]);
+        }
+        if (options.overrides !== undefined) {
+            existing.setOverrides(options.overrides);
+        }
         return existing;
     }
 

--- a/packages/core/test/unit/defaults/manager.spec.ts
+++ b/packages/core/test/unit/defaults/manager.spec.ts
@@ -10,9 +10,14 @@ type TestSubmitDefaults = {
     updateText: string;
 };
 
+type TestOtherDefaults = {
+    foo: string;
+};
+
 declare module '../../../src/defaults/types' {
     interface ComponentDefaults {
         __testSubmit?: ComponentDefaultValues<TestSubmitDefaults>;
+        __testOther?: ComponentDefaultValues<TestOtherDefaults>;
     }
 }
 
@@ -58,6 +63,38 @@ describe('DefaultsManager', () => {
 
         manager.setDefaults(undefined);
         expect(manager.get('__testSubmit')).toBeUndefined();
+    });
+
+    // #1591 — per-component deep merge so install-order doesn't drop options.
+    it('should per-component-merge via mergeDefaults() preserving keys not in the partial', () => {
+        const manager = new DefaultsManager({ defaults: { __testSubmit: { createText: 'Create', updateText: 'Update' } } });
+
+        manager.mergeDefaults({ __testSubmit: { createText: 'Erstellen' } });
+
+        expect(manager.get('__testSubmit')).toEqual({
+            createText: 'Erstellen',
+            updateText: 'Update',
+        });
+    });
+
+    it('should skip undefined fields in mergeDefaults so a partial does not clear existing values', () => {
+        const manager = new DefaultsManager({ defaults: { __testSubmit: { createText: 'Create', updateText: 'Update' } } });
+
+        manager.mergeDefaults({ __testSubmit: { createText: undefined, updateText: 'Aktualisieren' } });
+
+        expect(manager.get('__testSubmit')).toEqual({
+            createText: 'Create',
+            updateText: 'Aktualisieren',
+        });
+    });
+
+    it('should add a new component entry via mergeDefaults() without affecting others', () => {
+        const manager = new DefaultsManager({ defaults: { __testSubmit: { createText: 'Create' } } });
+
+        manager.mergeDefaults({ __testOther: { foo: 'bar' } });
+
+        expect(manager.get('__testSubmit')).toEqual({ createText: 'Create' });
+        expect(manager.get('__testOther')).toEqual({ foo: 'bar' });
     });
 
     it('should trigger reactive effects when setDefaults is called with the same reference', () => {

--- a/packages/core/test/unit/theme/install.spec.ts
+++ b/packages/core/test/unit/theme/install.spec.ts
@@ -20,6 +20,39 @@ describe('installThemeManager', () => {
         expect(first).toBe(second);
     });
 
+    // #1591 — per-package install() runs first with no themes, then top-level
+    // app.use(vuecs, { themes: [...] }) must still apply.
+    it('should merge themes from a second call into the existing manager', () => {
+        const app = createApp({ render: () => h('div') });
+        // First call: simulates a per-package install with no themes.
+        installThemeManager(app);
+        // Second call: simulates app.use(vuecs, { themes: [...] }) afterwards.
+        const tailwind: Theme = { elements: { button: { classes: { root: 'btn-tailwind' } } } };
+        const manager = installThemeManager(app, { themes: [tailwind] });
+
+        expect(manager.themes).toHaveLength(1);
+        expect(manager.themes[0]).toBe(tailwind);
+    });
+
+    it('should append themes when both calls supply themes', () => {
+        const app = createApp({ render: () => h('div') });
+        const a: Theme = { elements: { button: { classes: { root: 'btn-a' } } } };
+        const b: Theme = { elements: { button: { classes: { root: 'btn-b' } } } };
+        installThemeManager(app, { themes: [a] });
+        const manager = installThemeManager(app, { themes: [b] });
+
+        expect(manager.themes).toEqual([a, b]);
+    });
+
+    it('should apply overrides from a second call to the existing manager', () => {
+        const app = createApp({ render: () => h('div') });
+        installThemeManager(app);
+        const overrides: Theme = { elements: { button: { classes: { root: 'custom' } } } };
+        const manager = installThemeManager(app, { overrides });
+
+        expect(manager.overrides).toBe(overrides);
+    });
+
     it('should store themes from options', () => {
         const app = createApp({ render: () => h('div') });
         const theme: Theme = { elements: { button: { root: 'btn' } } };


### PR DESCRIPTION
## Summary

- `installThemeManager` / `installDefaultsManager` / `installConfigManager` returned the existing manager on second-and-later calls **without applying the fresh options** — so a per-package `install()` (which usually passes no theme options) running before `app.use(vuecs, { themes: [...] })` silently froze the manager with no themes. Symptom: every component rendered with only its `vc-*` default class.
- Fixed by merging fresh options into the existing manager instead of returning early:
  - **themes** append (matches install-order stacking)
  - **overrides** replace (single-owner)
  - **defaults** per-component deep-merge via new `DefaultsManager.mergeDefaults()` (skips `undefined` fields so partials don't clear preset values)
  - **config** shallow merge
- Added regression tests for the second-call merge on themes, overrides, and defaults.
- Documented the install-order semantic in `.agents/architecture.md`.

## Test plan

- [x] `npm run test --workspace=packages/core` — 315 passed
- [x] `npm run lint` — 0 errors
- [ ] Reviewer: reproduce the original Nuxt scenario (`installNavigation` plugin before `vuecs` plugin) and verify `<VCFormInput>` now renders with the bootstrap theme's `form-control` class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme, configuration, and default managers now merge settings when installed multiple times, enabling flexible plugin installation order.

* **Tests**
  * Added comprehensive test coverage for manager re-installation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->