### PR TITLE
fix(design): wrap :root and .dark token blocks in @layer vuecs (closes #1595)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1052,6 +1052,10 @@ via a `<style id="vc-color-palette">` block, leaving layers 1-2 and 4-5 untouche
 ```
 @vuecs/design/
   assets/index.css       <- :root (concrete OKLCH defaults) + .dark + @import "./animations.css"
+                            `:root` + `.dark` blocks are wrapped in `@layer vuecs`
+                            (#1595) so consumer overrides placed inside any other
+                            cascade layer win without `!important`. animations.css
+                            stays unlayered (structural CSS rule); palettes.css too.
   assets/animations.css  <- Motion primitives — vanilla-CSS port of tw-animate-css (MIT, attributed in header)
   src/
     palette.ts                   <- applyColorPaletteCss(), bindColorPalette<T>(), COLOR_PALETTE_STYLE_ELEMENT_ID

--- a/docs/src/guide/design-tokens.md
+++ b/docs/src/guide/design-tokens.md
@@ -174,6 +174,36 @@ Use these on text/icon elements that sit on top of a filled semantic background 
 These do not flip with dark mode. Override at the `:root` level if you want different values across the whole app.
 </details>
 
+## Overriding tokens from a cascade layer
+
+`@vuecs/design`'s `:root` and `.dark` blocks are wrapped in a named cascade layer — `@layer vuecs`. Consumers can override any token (semantic alias, scale shade, radius) from within their own cascade layer without resorting to `!important` or hoisting the override outside their layer structure.
+
+The minimal pattern is just "place your override inside any other layer, after the design import":
+
+```css
+@import "@vuecs/design";
+
+@layer base {
+    .dark {
+        --vc-color-bg: var(--vc-color-neutral-700);  /* softer dark-mode bg */
+    }
+}
+```
+
+Layer order is established at first appearance. Since `@vuecs/design` is imported first, the order ends up as `vuecs, base, …` — and `base` wins over `vuecs` per the cascade-layer spec, regardless of selector specificity.
+
+If you want an explicit order (e.g. you import vuecs after Tailwind, which itself declares `theme, base, components, utilities`), declare it once at the top of your stylesheet:
+
+```css
+@layer reset, vuecs, base, utilities;
+```
+
+Layers declared later win. The `vuecs` layer name is stable; treat it as the integration seam for any consumer-side token override.
+
+::: tip Top-level (unlayered) overrides
+You can also override from the unlayered top level — unlayered author CSS beats *all* layered rules, so `:root { --vc-color-bg: … }` outside any `@layer` still works. The cascade-layer wrap is what's new: it makes layered overrides work too. See [#1595](https://github.com/tada5hi/vuecs/issues/1595) for the rationale.
+:::
+
 ## Bridging another CSS framework
 
 If you bring your own non-Tailwind framework (Bootstrap, Bulma, Foundation, UIkit, your own design system…) and want `setColorPalette()` calls to re-tint native framework components alongside vuecs ones, write a CSS-variable bridge that maps the framework's runtime tokens onto `--vc-color-*`.

--- a/packages/design/assets/index.css
+++ b/packages/design/assets/index.css
@@ -46,6 +46,30 @@
    for motion-only or skip this file and pull a custom subset. */
 @import "./animations.css";
 
+/* -----------------------------------------------------------------
+   Cascade layer (#1595) — `:root` and `.dark` token blocks are wrapped
+   in `@layer vuecs` so consumer overrides placed inside any
+   later-declared layer (e.g. Tailwind's `@layer base`) win without
+   resorting to `!important` or hoisting outside their own layer
+   structure.
+
+   Layer order is established at first appearance, so importing this
+   file BEFORE the consumer's own layered CSS automatically positions
+   `vuecs` ahead of `base` / `utilities` / etc. Consumers who
+   need an explicit order can declare:
+
+       @layer vuecs, base, utilities;
+       @import "@vuecs/design";
+
+   `animations.css` and the standalone `palettes.css` stay unlayered —
+   their selectors are either class-based (animation utility classes)
+   or vendor catalog values (Tailwind palette defaults) where the
+   typical override seam is `--vc-color-<scale>-*` rather than the raw
+   `--color-<palette>-*` source. See #1595.
+   ----------------------------------------------------------------- */
+
+@layer vuecs {
+
 :root {
     /* -------------------------------------------------------------
        Semantic scales — references onto the Tailwind palette catalog.
@@ -195,3 +219,5 @@
 
     --vc-color-on-warning: var(--vc-color-neutral-950);
 }
+
+} /* @layer vuecs */


### PR DESCRIPTION
## Summary

`@vuecs/design`'s `:root` + `.dark` token blocks were declared at the top level (no `@layer`). Per the CSS cascade-layers spec, rules outside any layer beat rules inside *any* layer — so a consumer who organises their own design tokens cleanly inside `@layer base { ... }` couldn't override `--vc-color-bg` (or any other semantic alias) from there:

```css
@import "@vuecs/design";

@layer base {
    .dark {
        --vc-color-bg: var(--vc-color-neutral-700);  /* silently lost */
    }
}
```

Wrapped the blocks in `@layer vuecs`. Consumer-side `@layer base { ... }` overrides now win on layer order, no hoisting / `!important` needed. Consumers who want an explicit ordering declare it once:

```css
@layer reset, vuecs, base, utilities;
```

## Decisions

- **Layer name `vuecs`** (over `vuecs-design` / `theme`) — short, scope-namespaced, no collision risk with Tailwind v4's conventional `theme` layer (which `@theme {}` already manages).
- **`palettes.css` stays unlayered** — vendor catalog values; the natural consumer override seam is `--vc-color-<scale>-*` (already handled by `index.css`'s tokens).
- **`animations.css` stays unlayered** — structural CSS rule (a layered animation class would lose to Bootstrap's unlayered reboot, mirrors the [existing structural-CSS doctrine](https://github.com/tada5hi/vuecs/blob/master/CLAUDE.md)).
- **Values unchanged** — purely a cascade-layer structural change. Visual-regression baselines should be byte-identical; no baseline regeneration needed.

## Docs

- New "Overriding tokens from a cascade layer" section in `docs/src/guide/design-tokens.md` with the integration pattern and the explicit-order trick.
- `.agents/architecture.md` notes the new layer wrap next to the design package layout.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run test --workspace=packages/design` — 57 passed
- [x] `npm run build --workspace=packages/design` — clean
- [ ] Reviewer: in a Tailwind-using example app, place `@layer base { .dark { --vc-color-bg: red } }` and verify the page background goes red in dark mode (this fails on master, passes on this branch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Design tokens can now be overridden using CSS cascade layers, eliminating the need for `!important` declarations.

* **Documentation**
  * Added guide explaining how to override design tokens using CSS cascade layers, including minimal override patterns and best practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/vuecs/pull/1597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->