### PR TITLE
feat(forms)!: :validation bundle prop + FieldValidation type on VCFormGroup

### DIFF
--- a/docs/src/.vitepress/config.mts
+++ b/docs/src/.vitepress/config.mts
@@ -79,6 +79,7 @@ export default defineConfig({
                         { text: 'Composables', link: '/guide/composables' },
                         { text: 'Primitive (as / asChild)', link: '/guide/primitive' },
                         { text: 'Navigation Manager', link: '/guide/navigation-manager' },
+                        { text: 'Validation Feedback', link: '/guide/validation-feedback' },
                     ],
                 },
             ],

--- a/docs/src/guide/behavioral-defaults.md
+++ b/docs/src/guide/behavioral-defaults.md
@@ -80,7 +80,7 @@ See `VCList.noMoreContent` and `VCList.itemTextPropName` (both `default: undefin
 |-----------|-------------------|
 | `useSubmitButton()` (`submitButton`) | `createText`, `updateText`, `createIcon`, `updateIcon`, `createColor`, `updateColor` |
 | `VCFormSelect` | `placeholder` |
-| `VCFormGroup` | `renderValidation` (renamed from `validation` in 3.x — the unqualified name now carries the `FieldValidation` bundle prop, see [Validation feedback bridge](./validation-feedback.md)) |
+| `VCFormGroup` | `renderValidation` (renamed from `validation` — the unqualified name now carries the `FieldValidation` bundle prop, see [Validation feedback bridge](./validation-feedback.md)) |
 | `VCFormCheckbox` | `labelContent` |
 | `VCFormSwitch` | `labelContent` |
 | `VCListEmpty` | `content` |

--- a/docs/src/guide/behavioral-defaults.md
+++ b/docs/src/guide/behavioral-defaults.md
@@ -80,7 +80,6 @@ See `VCList.noMoreContent` and `VCList.itemTextPropName` (both `default: undefin
 |-----------|-------------------|
 | `useSubmitButton()` (`submitButton`) | `createText`, `updateText`, `createIcon`, `updateIcon`, `createColor`, `updateColor` |
 | `VCFormSelect` | `placeholder` |
-| `VCFormGroup` | `renderValidation` (renamed from `validation` — the unqualified name now carries the `FieldValidation` bundle prop, see [Validation feedback bridge](./validation-feedback.md)) |
 | `VCFormCheckbox` | `labelContent` |
 | `VCFormSwitch` | `labelContent` |
 | `VCListEmpty` | `content` |

--- a/docs/src/guide/behavioral-defaults.md
+++ b/docs/src/guide/behavioral-defaults.md
@@ -80,7 +80,7 @@ See `VCList.noMoreContent` and `VCList.itemTextPropName` (both `default: undefin
 |-----------|-------------------|
 | `useSubmitButton()` (`submitButton`) | `createText`, `updateText`, `createIcon`, `updateIcon`, `createColor`, `updateColor` |
 | `VCFormSelect` | `placeholder` |
-| `VCFormGroup` | `validation` |
+| `VCFormGroup` | `renderValidation` (renamed from `validation` in 3.x — the unqualified name now carries the `FieldValidation` bundle prop, see [Validation feedback bridge](./validation-feedback.md)) |
 | `VCFormCheckbox` | `labelContent` |
 | `VCFormSwitch` | `labelContent` |
 | `VCListEmpty` | `content` |

--- a/docs/src/guide/validation-feedback.md
+++ b/docs/src/guide/validation-feedback.md
@@ -1,0 +1,94 @@
+# Validation feedback
+
+`<VCFormGroup>` accepts a `:validation` bundle — a single prop carrying both severity and translated messages for the wrapped field. This is the documented integration point for validation libraries that produce per-field feedback (canonically: [`@ilingo/validup-vue`](https://www.npmjs.com/package/@ilingo/validup-vue)).
+
+```vue
+<script setup lang="ts">
+import { reactive } from 'vue';
+import { useValidup } from '@validup/vue';
+import { useFieldValidation } from '@ilingo/validup-vue';
+import { signInContainer } from './validators';
+
+const state = reactive({ email: '', password: '' });
+const $v = useValidup(signInContainer, state);
+</script>
+
+<template>
+  <VCFormGroup :validation="useFieldValidation($v.fields.email)">
+    <VCFormInput v-model="$v.fields.email.$model" type="email" />
+  </VCFormGroup>
+</template>
+```
+
+One `v-bind`, three packages, no shape coupling. See [plan 036](https://github.com/tada5hi/vuecs/blob/master/.agents/plans/036-validation-feedback-bridge.md) for the full architecture.
+
+## The `FieldValidation` shape
+
+`@vuecs/forms` exports a `FieldValidation` type — the structural contract a `:validation` consumer must produce:
+
+```ts
+type FieldValidation = {
+    severity?: 'error' | 'warning' | 'success';
+    messages: { key: string; value: string }[];
+};
+```
+
+Vuecs declares this type **independently** of any validation library — `@ilingo/validup-vue`'s `FieldValidation` is structurally identical, so binding works without either package importing the other. Drop-in for any future validation bridge (Yup, Zod, custom) that ships a matching shape.
+
+## Class application
+
+| `severity` | Root class applied |
+|---|---|
+| `'error'` | `validationError` (theme slot) |
+| `'warning'` | `validationWarning` (theme slot) |
+| `'success'` | — (no `validationSuccess` slot today; reserved for forward-compat) |
+| `undefined` | — |
+
+The class is **only** applied when `messages` is non-empty. A bundle with severity `'success'` and empty messages renders nothing — the section stays clean for pristine fields.
+
+## Precedence over the legacy props
+
+`<VCFormGroup>` historically accepted `:validation-severity` + `:validation-messages` as two separate props. Both still work, with `@deprecated` JSDoc pointing at `:validation`:
+
+```vue
+<!-- New (recommended) -->
+<VCFormGroup :validation="useFieldValidation($v.fields.email)">…</VCFormGroup>
+
+<!-- Legacy (still supported) -->
+<VCFormGroup
+  :validation-severity="severity"
+  :validation-messages="messages"
+>…</VCFormGroup>
+```
+
+Resolution: when `:validation` is set (non-null), it wins. Pass `:validation="null"` (or omit the prop) to fall through to the legacy props — useful when the parent toggles between bundle-driven and manually-constructed feedback.
+
+## Visibility toggle: `:render-validation`
+
+The boolean that suppresses the entire validation section was renamed from `:validation` (boolean) to `:render-validation` (boolean) in 3.x — the unqualified `:validation` is now the bundle prop. The `:render-validation` toggle wins over both paths:
+
+```vue
+<!-- Section hidden regardless of bundle / legacy props -->
+<VCFormGroup :render-validation="false" :validation="…">…</VCFormGroup>
+```
+
+Falls back to the global `formGroup.renderValidation` default (`true`).
+
+## `'success'` severity — current state
+
+`FieldValidation.severity` accepts `'success'` for forward-compat with bridges that surface a "passed" state. As of `@vuecs/forms` 4.x, there's no `validationSuccess` theme slot — the class application is a no-op, but the section still renders if `messages` is non-empty (useful for "this email looks valid; we'll send confirmation" affirmative messages).
+
+If you want a success class on the root, theme it via `themeClass`:
+
+```vue
+<VCFormGroup
+  :validation="feedback"
+  :theme-class="{ root: feedback.severity === 'success' ? 'has-success' : '' }"
+>…</VCFormGroup>
+```
+
+A dedicated `validationSuccess` slot may ship later if demand materializes.
+
+## Severity types
+
+Vuecs's `ValidationSeverity` enum stays `'error' | 'warning'` for the legacy `:validation-severity` prop. The `FieldValidation` shape's wider union (`'error' | 'warning' | 'success'`) is the bridge-facing type; the two coexist intentionally — the enum is the vuecs-native vocabulary, the bundle accepts whatever a validation library naturally produces.

--- a/docs/src/guide/validation-feedback.md
+++ b/docs/src/guide/validation-feedback.md
@@ -65,7 +65,7 @@ Resolution: when `:validation` is set (non-null), it wins. Pass `:validation="nu
 
 ## Visibility toggle: `:render-validation`
 
-The boolean that suppresses the entire validation section was renamed from `:validation` (boolean) to `:render-validation` (boolean) in 3.x — the unqualified `:validation` is now the bundle prop. The `:render-validation` toggle wins over both paths:
+The boolean that suppresses the entire validation section was renamed from `:validation` (boolean) to `:render-validation` (boolean) — the unqualified `:validation` is now the bundle prop. The `:render-validation` toggle wins over both paths:
 
 ```vue
 <!-- Section hidden regardless of bundle / legacy props -->

--- a/docs/src/guide/validation-feedback.md
+++ b/docs/src/guide/validation-feedback.md
@@ -63,20 +63,19 @@ The class is **only** applied when `messages` is non-empty. A bundle with severi
 
 Resolution: when `:validation` is set (non-null), it wins. Pass `:validation="null"` (or omit the prop) to fall through to the legacy props — useful when the parent toggles between bundle-driven and manually-constructed feedback.
 
-## Visibility toggle: `:render-validation`
+## When the section renders
 
-The boolean that suppresses the entire validation section was renamed from `:validation` (boolean) to `:render-validation` (boolean) — the unqualified `:validation` is now the bundle prop. The `:render-validation` toggle wins over both paths:
+Content-driven, no visibility prop. The `<VCValidationGroup>` section renders iff **any** of:
 
-```vue
-<!-- Section hidden regardless of bundle / legacy props -->
-<VCFormGroup :render-validation="false" :validation="…">…</VCFormGroup>
-```
+- `:validation` is non-null and its `messages` array is non-empty.
+- `:validation-messages` (legacy) is non-empty.
+- A `#validationGroup` or `#validationItem` slot is provided — slots may render content from sources other than `messages` (e.g. always-visible status indicators), so their presence alone is enough.
 
-Falls back to the global `formGroup.renderValidation` default (`true`).
+A pristine field (`:validation="{ severity: undefined, messages: [] }"`) renders nothing. The previous `:validation` boolean visibility toggle was removed in 5.0 — visibility now follows what's actually being displayed.
 
 ## `'success'` severity — current state
 
-`FieldValidation.severity` accepts `'success'` for forward-compat with bridges that surface a "passed" state. As of `@vuecs/forms` 4.x, there's no `validationSuccess` theme slot — the class application is a no-op, but the section still renders if `messages` is non-empty (useful for "this email looks valid; we'll send confirmation" affirmative messages).
+`FieldValidation.severity` accepts `'success'` for forward-compat with bridges that surface a "passed" state. There's no `validationSuccess` theme slot yet — the class application is a no-op, but the section still renders if `messages` is non-empty (useful for "this email looks valid; we'll send confirmation" affirmative messages).
 
 If you want a success class on the root, theme it via `themeClass`:
 

--- a/packages/forms/src/components/form-group/FormGroup.vue
+++ b/packages/forms/src/components/form-group/FormGroup.vue
@@ -1,7 +1,6 @@
 <script lang="ts">
-import { useComponentDefaults, useComponentTheme } from '@vuecs/core';
+import { useComponentTheme } from '@vuecs/core';
 import type {
-    ComponentDefaultValues,
     ComponentThemeDefinition,
     ThemeClassesOverride,
     ThemeElementDefinition,
@@ -30,22 +29,9 @@ export type FormGroupThemeClasses = {
     validationWarning: string;
 };
 
-export type FormGroupDefaults = {
-    /**
-     * Visibility toggle for the `<VCValidationGroup>` section. Renamed
-     * from `validation` — `validation` is now the prop name for the
-     * `FieldValidation` bundle (severity + messages). `renderValidation`
-     * is the only defaults-manager key under `formGroup`.
-     */
-    renderValidation: boolean;
-};
-
 declare module '@vuecs/core' {
     interface ThemeElements {
         formGroup?: ThemeElementDefinition<FormGroupThemeClasses>;
-    }
-    interface ComponentDefaults {
-        formGroup?: ComponentDefaultValues<FormGroupDefaults>;
     }
 }
 
@@ -58,8 +44,6 @@ export const formGroupThemeDefaults: ComponentThemeDefinition<FormGroupThemeClas
         validationWarning: '',
     },
 };
-
-const behavioralDefaults: FormGroupDefaults = { renderValidation: true };
 
 const formGroupProps = {
     /** When `true`/`false`, force-render or hide the label. When `undefined`, label visibility follows slot/content presence. */
@@ -91,18 +75,6 @@ const formGroupProps = {
     // validator otherwise warns on `:validation="null"`, which the
     // contract documents as the fall-through escape hatch.
     validation: { type: [Object, null] as PropType<FieldValidation | null>, default: undefined },
-
-    /**
-     * Visibility toggle for the validation messages section. When
-     * `false`, the `<VCValidationGroup>` is suppressed regardless of
-     * whether `:validation` or `:validation-messages` carry content.
-     * Falls back to the global `formGroup.renderValidation` default
-     * (`true`).
-     *
-     * Renamed from `:validation` — the unqualified name now carries
-     * the `FieldValidation` bundle (severity + messages).
-     */
-    renderValidation: { type: Boolean, default: undefined },
 
     /**
      * @deprecated Pass a `FieldValidation` via `:validation` instead.
@@ -139,11 +111,9 @@ export default defineComponent({
     }>,
     setup(props, { attrs, slots }) {
         const theme = useComponentTheme('formGroup', props, formGroupThemeDefaults);
-        const defaults = useComponentDefaults('formGroup', props, behavioralDefaults);
 
         return () => {
             const resolved = theme.value;
-            const resolvedDefaults = defaults.value;
             const children: VNodeChild[] = [];
 
             // Label
@@ -176,15 +146,24 @@ export default defineComponent({
                 props.validation!.messages :
                 props.validationMessages;
 
-            // Validation
-            if (resolvedDefaults.renderValidation) {
+            const hasMessages = !!effectiveMessages && (
+                Array.isArray(effectiveMessages) ?
+                    effectiveMessages.length > 0 :
+                    Object.keys(effectiveMessages).length > 0
+            );
+            // Slot-driven rendering — consumers providing `#validationGroup` or
+            // `#validationItem` can render content from sources other than
+            // `messages` (e.g. always-visible status indicators). The slot's
+            // presence is enough signal to render the section.
+            const hasValidationSlot = !!slots.validationGroup || !!slots.validationItem;
+            const shouldRenderValidation = hasMessages || hasValidationSlot;
+
+            if (shouldRenderValidation) {
                 children.push(h(VCValidationGroup, {
-                    // `<VCValidationGroup>`'s `:severity` now accepts the same
-                    // wider union as the `FieldValidation` bundle
-                    // (`error` / `warning` / `success` / `undefined`), so the
-                    // bundle's pristine / success states flow through to slot
-                    // consumers unchanged — no more "undefined collapses to
-                    // error" leak via the inner prop default.
+                    // `<VCValidationGroup>`'s `:severity` accepts the same wider
+                    // union as the `FieldValidation` bundle (`error` / `warning` /
+                    // `success` / `undefined`), so the bundle's pristine / success
+                    // states flow through to slot consumers unchanged.
                     severity: effectiveSeverity,
                     messages: effectiveMessages || {},
                 }, {
@@ -219,19 +198,13 @@ export default defineComponent({
             // no `validationSuccess` theme slot yet, so it also resolves to no
             // class today.
             let validationClass: string | undefined;
-            if (resolvedDefaults.renderValidation && effectiveMessages) {
-                const hasMessages = Array.isArray(effectiveMessages) ?
-                    effectiveMessages.length > 0 :
-                    Object.keys(effectiveMessages).length > 0;
-
-                if (hasMessages) {
-                    if (effectiveSeverity === ValidationSeverity.WARNING) {
-                        validationClass = resolved.validationWarning;
-                    } else if (effectiveSeverity === ValidationSeverity.ERROR) {
-                        validationClass = resolved.validationError;
-                    } else if (!usingBundle) {
-                        validationClass = resolved.validationError;
-                    }
+            if (hasMessages) {
+                if (effectiveSeverity === ValidationSeverity.WARNING) {
+                    validationClass = resolved.validationWarning;
+                } else if (effectiveSeverity === ValidationSeverity.ERROR) {
+                    validationClass = resolved.validationError;
+                } else if (!usingBundle) {
+                    validationClass = resolved.validationError;
                 }
             }
 

--- a/packages/forms/src/components/form-group/FormGroup.vue
+++ b/packages/forms/src/components/form-group/FormGroup.vue
@@ -15,7 +15,7 @@ import type {
 } from 'vue';
 import { defineComponent, h, mergeProps } from 'vue';
 import { ValidationSeverity } from '../constants';
-import type { ValidationMessages } from '../type';
+import type { FieldValidation, ValidationMessages } from '../type';
 import {
     VCValidationGroup,
     type ValidationGroupDefaultSlotProps,
@@ -31,7 +31,13 @@ export type FormGroupThemeClasses = {
 };
 
 export type FormGroupDefaults = {
-    validation: boolean;
+    /**
+     * Visibility toggle for the `<VCValidationGroup>` section. Renamed
+     * from `validation` in 3.x — `validation` now names the bundle prop
+     * (`FieldValidation`) consumed via `:validation`. Both ship on the
+     * defaults manager, so app-wide overrides continue to work.
+     */
+    renderValidation: boolean;
 };
 
 declare module '@vuecs/core' {
@@ -53,7 +59,7 @@ export const formGroupThemeDefaults: ComponentThemeDefinition<FormGroupThemeClas
     },
 };
 
-const behavioralDefaults: FormGroupDefaults = { validation: true };
+const behavioralDefaults: FormGroupDefaults = { renderValidation: true };
 
 const formGroupProps = {
     /** When `true`/`false`, force-render or hide the label. When `undefined`, label visibility follows slot/content presence. */
@@ -70,11 +76,43 @@ const formGroupProps = {
     /** Default text rendered when no `hint` slot is provided. */
     hintContent: { type: String, default: undefined },
 
-    /** When `true`, render the validation messages section. Falls back to the global `formGroup.validation` default. */
-    validation: { type: Boolean, default: undefined },
-    /** Severity used to colour the validation messages (`error` / `warning`). */
+    /**
+     * Bundle prop accepting a `FieldValidation` (`{ severity, messages }`)
+     * — wins over `validationSeverity` + `validationMessages` when set.
+     *
+     * Canonical use is with `@ilingo/validup-vue`'s `useFieldValidation`:
+     * `<VCFormGroup :validation="useFieldValidation($v.fields.email)">`.
+     * Structural typing — vuecs and `@ilingo/validup-vue` declare matching
+     * shapes without either importing the other.
+     *
+     * Pass `null` / `undefined` to fall through to the legacy props.
+     */
+    validation: { type: Object as PropType<FieldValidation | null>, default: undefined },
+
+    /**
+     * Visibility toggle for the validation messages section. When
+     * `false`, the `<VCValidationGroup>` is suppressed regardless of
+     * whether `:validation` or `:validation-messages` carry content.
+     * Falls back to the global `formGroup.renderValidation` default
+     * (`true`).
+     *
+     * Renamed from `:validation` in 3.x — the unqualified name now
+     * carries the `FieldValidation` bundle (severity + messages).
+     */
+    renderValidation: { type: Boolean, default: undefined },
+
+    /**
+     * @deprecated Pass a `FieldValidation` via `:validation` instead.
+     * Severity used to colour the validation messages (`error` /
+     * `warning`). Ignored when `:validation` is set.
+     */
     validationSeverity: { type: String as PropType<`${ValidationSeverity}` | undefined>, default: undefined },
-    /** Validation messages — keyed object or ordered array of `{ key, value }`. */
+
+    /**
+     * @deprecated Pass a `FieldValidation` via `:validation` instead.
+     * Validation messages — keyed object or ordered array of
+     * `{ key, value }`. Ignored when `:validation` is set.
+     */
     validationMessages: { type: [Object, Array] as PropType<ValidationMessages>, default: undefined },
 
     /** Theme-class overrides for this component instance. */
@@ -123,11 +161,30 @@ export default defineComponent({
                 children.push(slots.default({}));
             }
 
+            // Bundle precedence — `:validation` (the FieldValidation bundle) wins
+            // over the legacy `:validation-severity` + `:validation-messages` props
+            // when set. `null` or `undefined` falls through to the legacy props so
+            // a consumer can clear the bundle programmatically without juggling
+            // both shapes.
+            const usingBundle = props.validation != null;
+            const bundleSeverity = usingBundle ? props.validation!.severity : undefined;
+            const effectiveSeverity = usingBundle ? bundleSeverity : props.validationSeverity;
+            const effectiveMessages: ValidationMessages | undefined = usingBundle ?
+                props.validation!.messages :
+                props.validationMessages;
+
             // Validation
-            if (resolvedDefaults.validation) {
+            if (resolvedDefaults.renderValidation) {
                 children.push(h(VCValidationGroup, {
-                    severity: props.validationSeverity,
-                    messages: props.validationMessages || {},
+                    // `<VCValidationGroup>`'s `:severity` only knows `error` /
+                    // `warning`. The bundle's wider union (`success`, `undefined`)
+                    // collapses to `undefined` here so the inner component falls
+                    // back to its own default (`error`) for the slot-prop value —
+                    // class application on the root branches separately below.
+                    severity: (effectiveSeverity === ValidationSeverity.WARNING || effectiveSeverity === ValidationSeverity.ERROR) ?
+                        effectiveSeverity :
+                        undefined,
+                    messages: effectiveMessages || {},
                 }, {
                     ...(slots.validationGroup ? { default: slots.validationGroup } : {}),
                     ...(slots.validationItem ? { item: slots.validationItem } : {}),
@@ -147,17 +204,32 @@ export default defineComponent({
                 }
             }
 
-            // Determine validation class
+            // Root validation class
+            //
+            // Asymmetric on purpose: when `effectiveSeverity` is `undefined`, the
+            // legacy path defaults to the error class (pre-bundle behaviour kept
+            // for back-compat — consumers that don't pass severity expect a red
+            // outline). The bundle path treats `undefined` as "field is OK /
+            // pristine" and applies no class — that matches the semantic from
+            // `@ilingo/validup-vue`'s `useFieldValidation`, where the severity
+            // tracks `getSeverity()`'s `error | warning | success | undefined`
+            // contract. `'success'` is reserved for forward-compat — vuecs has
+            // no `validationSuccess` theme slot yet, so it also resolves to no
+            // class today.
             let validationClass: string | undefined;
-            if (resolvedDefaults.validation && props.validationMessages) {
-                const hasMessages = Array.isArray(props.validationMessages) ?
-                    props.validationMessages.length > 0 :
-                    Object.keys(props.validationMessages).length > 0;
+            if (resolvedDefaults.renderValidation && effectiveMessages) {
+                const hasMessages = Array.isArray(effectiveMessages) ?
+                    effectiveMessages.length > 0 :
+                    Object.keys(effectiveMessages).length > 0;
 
                 if (hasMessages) {
-                    validationClass = props.validationSeverity === ValidationSeverity.WARNING ?
-                        resolved.validationWarning :
-                        resolved.validationError;
+                    if (effectiveSeverity === ValidationSeverity.WARNING) {
+                        validationClass = resolved.validationWarning;
+                    } else if (effectiveSeverity === ValidationSeverity.ERROR) {
+                        validationClass = resolved.validationError;
+                    } else if (!usingBundle) {
+                        validationClass = resolved.validationError;
+                    }
                 }
             }
 

--- a/packages/forms/src/components/form-group/FormGroup.vue
+++ b/packages/forms/src/components/form-group/FormGroup.vue
@@ -33,9 +33,9 @@ export type FormGroupThemeClasses = {
 export type FormGroupDefaults = {
     /**
      * Visibility toggle for the `<VCValidationGroup>` section. Renamed
-     * from `validation` in 3.x — `validation` now names the bundle prop
-     * (`FieldValidation`) consumed via `:validation`. Both ship on the
-     * defaults manager, so app-wide overrides continue to work.
+     * from `validation` — `validation` is now the prop name for the
+     * `FieldValidation` bundle (severity + messages). `renderValidation`
+     * is the only defaults-manager key under `formGroup`.
      */
     renderValidation: boolean;
 };
@@ -87,7 +87,10 @@ const formGroupProps = {
      *
      * Pass `null` / `undefined` to fall through to the legacy props.
      */
-    validation: { type: Object as PropType<FieldValidation | null>, default: undefined },
+    // `type: [Object, null]` not just `Object` — Vue's runtime prop
+    // validator otherwise warns on `:validation="null"`, which the
+    // contract documents as the fall-through escape hatch.
+    validation: { type: [Object, null] as PropType<FieldValidation | null>, default: undefined },
 
     /**
      * Visibility toggle for the validation messages section. When
@@ -96,8 +99,8 @@ const formGroupProps = {
      * Falls back to the global `formGroup.renderValidation` default
      * (`true`).
      *
-     * Renamed from `:validation` in 3.x — the unqualified name now
-     * carries the `FieldValidation` bundle (severity + messages).
+     * Renamed from `:validation` — the unqualified name now carries
+     * the `FieldValidation` bundle (severity + messages).
      */
     renderValidation: { type: Boolean, default: undefined },
 
@@ -176,14 +179,13 @@ export default defineComponent({
             // Validation
             if (resolvedDefaults.renderValidation) {
                 children.push(h(VCValidationGroup, {
-                    // `<VCValidationGroup>`'s `:severity` only knows `error` /
-                    // `warning`. The bundle's wider union (`success`, `undefined`)
-                    // collapses to `undefined` here so the inner component falls
-                    // back to its own default (`error`) for the slot-prop value —
-                    // class application on the root branches separately below.
-                    severity: (effectiveSeverity === ValidationSeverity.WARNING || effectiveSeverity === ValidationSeverity.ERROR) ?
-                        effectiveSeverity :
-                        undefined,
+                    // `<VCValidationGroup>`'s `:severity` now accepts the same
+                    // wider union as the `FieldValidation` bundle
+                    // (`error` / `warning` / `success` / `undefined`), so the
+                    // bundle's pristine / success states flow through to slot
+                    // consumers unchanged — no more "undefined collapses to
+                    // error" leak via the inner prop default.
+                    severity: effectiveSeverity,
                     messages: effectiveMessages || {},
                 }, {
                     ...(slots.validationGroup ? { default: slots.validationGroup } : {}),

--- a/packages/forms/src/components/form-group/index.ts
+++ b/packages/forms/src/components/form-group/index.ts
@@ -2,4 +2,4 @@ import FormGroup from './FormGroup.vue';
 
 export { FormGroup as VCFormGroup };
 export { formGroupThemeDefaults } from './FormGroup.vue';
-export type { FormGroupProps, FormGroupThemeClasses, FormGroupDefaults } from './FormGroup.vue';
+export type { FormGroupProps, FormGroupThemeClasses } from './FormGroup.vue';

--- a/packages/forms/src/components/type.ts
+++ b/packages/forms/src/components/type.ts
@@ -15,3 +15,31 @@ export type ValidationMessagesRecordStyle = Record<string, string>;
 export type ValidationMessagesArrayStyle = { key: string; value: string }[];
 
 export type ValidationMessages = ValidationMessagesArrayStyle | ValidationMessagesRecordStyle;
+
+/**
+ * Single-prop bundle a `<VCFormGroup>` host consumes via `:validation`.
+ *
+ * Structurally identical to `@ilingo/validup-vue`'s exported
+ * `FieldValidation` (and the return shape of `useFieldValidation`), so
+ * the canonical bridge usage —
+ * `<VCFormGroup :validation="useFieldValidation($v.fields.email)">` —
+ * type-checks without either package importing the other (cross-package
+ * structural compatibility; vuecs stays neutral about validation
+ * libraries).
+ *
+ * `severity` accepts `'success'` for forward compatibility with
+ * validation bridges that surface a "passed" state; vuecs currently
+ * renders no class for it (the `:validation-success` theme slot is not
+ * yet defined), so `'success'` behaves like `undefined` at the DOM
+ * level. `error` and `warning` apply the matching `validationError` /
+ * `validationWarning` theme class on the root.
+ *
+ * `messages` is array-style only (the `{ key, value }[]` shape vuecs
+ * already renders inside `<VCValidationGroup>`). Producers using the
+ * legacy record shape (`Record<string, string>`) keep using
+ * `:validation-messages` directly.
+ */
+export type FieldValidation = {
+    severity?: 'error' | 'warning' | 'success';
+    messages: ValidationMessagesArrayStyle;
+};

--- a/packages/forms/src/components/validation-group/ValidationGroup.vue
+++ b/packages/forms/src/components/validation-group/ValidationGroup.vue
@@ -29,9 +29,19 @@ declare module '@vuecs/core' {
 
 export const validationGroupThemeDefaults: ComponentThemeDefinition<ValidationGroupThemeClasses> = { classes: { item: 'form-group-hint group-required' } };
 
+/**
+ * Severity union the slot props expose. Wider than `ValidationSeverity`
+ * (`error` / `warning`) so a `<VCFormGroup :validation>` bundle whose
+ * `severity` is `'success'` or `undefined` flows through to slot
+ * consumers as-is — instead of being collapsed back to `'error'` by
+ * the prop default, which would mislead the slot rendering on
+ * pristine / valid fields.
+ */
+export type ValidationGroupSeverity = `${ValidationSeverity}` | 'success' | undefined;
+
 export type ValidationGroupDefaultSlotProps = {
     data: ValidationMessagesArrayStyle;
-    severity: `${ValidationSeverity}`;
+    severity: ValidationGroupSeverity;
     itemClass: string;
     itemTag: string;
 };
@@ -41,12 +51,24 @@ export type ValidationGroupItemSlotProps = {
     value: string;
     class: string;
     tag: string;
-    severity: `${ValidationSeverity}`;
+    severity: ValidationGroupSeverity;
 };
 
 const validationGroupProps = {
-    /** Severity used to colour the rendered messages (`error` / `warning`). */
-    severity: { type: String as PropType<`${ValidationSeverity}`>, default: ValidationSeverity.ERROR },
+    /**
+     * Severity used to colour the rendered messages. Accepts
+     * `'error' | 'warning'` (the vuecs-native vocabulary) plus
+     * `'success'` for forward-compat with validation bridges that
+     * surface a "passed" state (see `<VCFormGroup>`'s `:validation`
+     * bundle).
+     *
+     * Default is `undefined` — slot consumers receive the actual
+     * value passed by the host. The previous default of
+     * `ValidationSeverity.ERROR` is gone; if a slot template needs an
+     * error fallback when none is supplied, do it at the call site
+     * (`severity ?? 'error'`).
+     */
+    severity: { type: String as PropType<ValidationGroupSeverity>, default: undefined },
     /** Validation messages — keyed object or ordered array of `{ key, value }`. */
     messages: { type: [Object, Array] as PropType<ValidationMessages>, default: () => ({}) },
     /** HTML tag used for each rendered message. */

--- a/packages/forms/test/unit/components.spec.ts
+++ b/packages/forms/test/unit/components.spec.ts
@@ -103,7 +103,7 @@ describe('VCFormGroup', () => {
     it('should render validation messages', () => {
         const wrapper = mount(VCFormGroup, {
             props: {
-                validation: true,
+                renderValidation: true,
                 validationMessages: { required: 'Field is required' },
             },
             global: { plugins: [themePlugin] },
@@ -124,7 +124,7 @@ describe('VCFormGroup', () => {
         };
         const wrapper = mount(VCFormGroup, {
             props: {
-                validation: true,
+                renderValidation: true,
                 validationMessages: { required: 'Required' },
             },
             global: {
@@ -153,7 +153,7 @@ describe('VCFormGroup', () => {
         };
         const wrapper = mount(VCFormGroup, {
             props: {
-                validation: true,
+                renderValidation: true,
                 validationMessages: { hint: 'Check this' },
                 validationSeverity: 'warning',
             },
@@ -170,10 +170,10 @@ describe('VCFormGroup', () => {
         expect(wrapper.classes()).not.toContain('has-error');
     });
 
-    it('should not show validation when validation prop is false', () => {
+    it('should not show validation when renderValidation prop is false', () => {
         const wrapper = mount(VCFormGroup, {
             props: {
-                validation: false,
+                renderValidation: false,
                 validationMessages: { required: 'Required' },
             },
             global: { plugins: [themePlugin] },
@@ -181,7 +181,7 @@ describe('VCFormGroup', () => {
         expect(wrapper.text()).not.toContain('Required');
     });
 
-    it('should default validation to true when prop is omitted (3-layer fallthrough)', () => {
+    it('should default renderValidation to true when prop is omitted (3-layer fallthrough)', () => {
         const wrapper = mount(VCFormGroup, {
             props: { validationMessages: { required: 'Required' } },
             global: { plugins: [themePlugin] },
@@ -194,7 +194,7 @@ describe('VCFormGroup', () => {
             props: {
                 labelContent: 'Label',
                 hintContent: 'Hint',
-                validation: true,
+                renderValidation: true,
                 validationMessages: { req: 'Error' },
             },
             global: { plugins: [themePlugin] },
@@ -206,6 +206,176 @@ describe('VCFormGroup', () => {
         const hintPos = text.indexOf('Hint');
         expect(labelPos).toBeLessThan(errorPos);
         expect(errorPos).toBeLessThan(hintPos);
+    });
+
+    describe(':validation bundle prop', () => {
+        it('should render messages from the bundle', () => {
+            const wrapper = mount(VCFormGroup, {
+                props: {
+                    validation: {
+                        severity: 'error' as const,
+                        messages: [{ key: 'required', value: 'Email is required' }],
+                    },
+                },
+                global: { plugins: [themePlugin] },
+            });
+            expect(wrapper.text()).toContain('Email is required');
+        });
+
+        it('should apply error class for bundle severity=error', () => {
+            const preset = { elements: { formGroup: { classes: { root: 'fg', validationError: 'is-err' } } } };
+            const wrapper = mount(VCFormGroup, {
+                props: {
+                    validation: {
+                        severity: 'error' as const,
+                        messages: [{ key: 'k', value: 'msg' }],
+                    },
+                },
+                global: {
+                    plugins: [{
+                        install: (app: any) => {
+                            installThemeManager(app, { themes: [preset] });
+                            installDefaultsManager(app);
+                        },
+                    }],
+                },
+            });
+            expect(wrapper.classes()).toContain('is-err');
+        });
+
+        it('should apply warning class for bundle severity=warning', () => {
+            const preset = {
+                elements: {
+                    formGroup: {
+                        classes: {
+                            root: 'fg', 
+                            validationError: 'is-err', 
+                            validationWarning: 'is-warn', 
+                        }, 
+                    }, 
+                },
+            };
+            const wrapper = mount(VCFormGroup, {
+                props: {
+                    validation: {
+                        severity: 'warning' as const,
+                        messages: [{ key: 'k', value: 'msg' }],
+                    },
+                },
+                global: {
+                    plugins: [{
+                        install: (app: any) => {
+                            installThemeManager(app, { themes: [preset] });
+                            installDefaultsManager(app);
+                        },
+                    }],
+                },
+            });
+            expect(wrapper.classes()).toContain('is-warn');
+            expect(wrapper.classes()).not.toContain('is-err');
+        });
+
+        it('should not apply any severity class when bundle severity is undefined (field pristine)', () => {
+            // Legacy path defaults to error for undefined severity; bundle path
+            // treats undefined as "field is OK" and applies no class.
+            const preset = {
+                elements: {
+                    formGroup: {
+                        classes: {
+                            root: 'fg', 
+                            validationError: 'is-err', 
+                            validationWarning: 'is-warn', 
+                        }, 
+                    }, 
+                },
+            };
+            const wrapper = mount(VCFormGroup, {
+                props: { validation: { messages: [{ key: 'k', value: 'msg' }] } },
+                global: {
+                    plugins: [{
+                        install: (app: any) => {
+                            installThemeManager(app, { themes: [preset] });
+                            installDefaultsManager(app);
+                        },
+                    }],
+                },
+            });
+            expect(wrapper.classes()).not.toContain('is-err');
+            expect(wrapper.classes()).not.toContain('is-warn');
+        });
+
+        it('should not apply any severity class for bundle severity=success', () => {
+            const preset = {
+                elements: {
+                    formGroup: {
+                        classes: {
+                            root: 'fg', 
+                            validationError: 'is-err', 
+                            validationWarning: 'is-warn', 
+                        }, 
+                    }, 
+                },
+            };
+            const wrapper = mount(VCFormGroup, {
+                props: {
+                    validation: {
+                        severity: 'success' as const,
+                        messages: [{ key: 'k', value: 'msg' }],
+                    },
+                },
+                global: {
+                    plugins: [{
+                        install: (app: any) => {
+                            installThemeManager(app, { themes: [preset] });
+                            installDefaultsManager(app);
+                        },
+                    }],
+                },
+            });
+            expect(wrapper.classes()).not.toContain('is-err');
+            expect(wrapper.classes()).not.toContain('is-warn');
+        });
+
+        it('should take precedence over :validation-severity and :validation-messages', () => {
+            const wrapper = mount(VCFormGroup, {
+                props: {
+                    validation: {
+                        severity: 'error' as const,
+                        messages: [{ key: 'bundle', value: 'bundle wins' }],
+                    },
+                    validationSeverity: 'warning' as const,
+                    validationMessages: { legacy: 'legacy loses' },
+                },
+                global: { plugins: [themePlugin] },
+            });
+            expect(wrapper.text()).toContain('bundle wins');
+            expect(wrapper.text()).not.toContain('legacy loses');
+        });
+
+        it('should fall through to legacy props when :validation is null', () => {
+            const wrapper = mount(VCFormGroup, {
+                props: {
+                    validation: null,
+                    validationMessages: { req: 'legacy msg' },
+                },
+                global: { plugins: [themePlugin] },
+            });
+            expect(wrapper.text()).toContain('legacy msg');
+        });
+
+        it('should respect renderValidation=false even when :validation is set', () => {
+            const wrapper = mount(VCFormGroup, {
+                props: {
+                    renderValidation: false,
+                    validation: {
+                        severity: 'error' as const,
+                        messages: [{ key: 'k', value: 'should be hidden' }],
+                    },
+                },
+                global: { plugins: [themePlugin] },
+            });
+            expect(wrapper.text()).not.toContain('should be hidden');
+        });
     });
 });
 

--- a/packages/forms/test/unit/components.spec.ts
+++ b/packages/forms/test/unit/components.spec.ts
@@ -209,6 +209,27 @@ describe('VCFormGroup', () => {
     });
 
     describe(':validation bundle prop', () => {
+        // The canonical bridge usage takes the return value of
+        // `@ilingo/validup-vue`'s `useFieldValidation()`, whose shape is
+        // `{ severity, messages, issues }` — the third key (`issues`) is the
+        // raw `IssueTranslation[]` escape hatch. Vuecs only consumes
+        // `severity` + `messages`; the extra key must be tolerated so
+        // structural compatibility with the bridge holds without vuecs
+        // taking a type-level dep on `@ilingo/validup-vue`.
+        it('should ignore extra keys on the bundle object (bridge compatibility)', () => {
+            const wrapper = mount(VCFormGroup, {
+                props: {
+                    validation: {
+                        severity: 'error' as const,
+                        messages: [{ key: 'required', value: 'Email is required' }],
+                        issues: [{ code: 'required' }],
+                    } as any,
+                },
+                global: { plugins: [themePlugin] },
+            });
+            expect(wrapper.text()).toContain('Email is required');
+        });
+
         it('should render messages from the bundle', () => {
             const wrapper = mount(VCFormGroup, {
                 props: {

--- a/packages/forms/test/unit/components.spec.ts
+++ b/packages/forms/test/unit/components.spec.ts
@@ -102,10 +102,7 @@ describe('VCFormGroup', () => {
 
     it('should render validation messages', () => {
         const wrapper = mount(VCFormGroup, {
-            props: {
-                renderValidation: true,
-                validationMessages: { required: 'Field is required' },
-            },
+            props: { validationMessages: { required: 'Field is required' } },
             global: { plugins: [themePlugin] },
         });
         expect(wrapper.text()).toContain('Field is required');
@@ -123,10 +120,7 @@ describe('VCFormGroup', () => {
             },
         };
         const wrapper = mount(VCFormGroup, {
-            props: {
-                renderValidation: true,
-                validationMessages: { required: 'Required' },
-            },
+            props: { validationMessages: { required: 'Required' } },
             global: {
                 plugins: [{
                     install: (app: any) => {
@@ -153,7 +147,6 @@ describe('VCFormGroup', () => {
         };
         const wrapper = mount(VCFormGroup, {
             props: {
-                renderValidation: true,
                 validationMessages: { hint: 'Check this' },
                 validationSeverity: 'warning',
             },
@@ -170,23 +163,27 @@ describe('VCFormGroup', () => {
         expect(wrapper.classes()).not.toContain('has-error');
     });
 
-    it('should not show validation when renderValidation prop is false', () => {
+    it('should not render validation section when no messages and no validation slot', () => {
+        // Content-driven visibility — empty (or absent) `validationMessages` AND
+        // no `#validationGroup` / `#validationItem` slot ⇒ no `<VCValidationGroup>`
+        // is rendered at all. The previous boolean visibility toggle
+        // (`:render-validation`) was removed in favour of this.
         const wrapper = mount(VCFormGroup, {
-            props: {
-                renderValidation: false,
-                validationMessages: { required: 'Required' },
-            },
+            props: { hintContent: 'help' },
             global: { plugins: [themePlugin] },
         });
-        expect(wrapper.text()).not.toContain('Required');
+        expect(wrapper.text()).toBe('help');
     });
 
-    it('should default renderValidation to true when prop is omitted (3-layer fallthrough)', () => {
+    it('should render validation section when only a validation slot is provided (no messages)', () => {
+        // Slot consumers (`#validationGroup`) can render content from sources
+        // other than `messages` — the slot's presence is enough to force-render
+        // the section.
         const wrapper = mount(VCFormGroup, {
-            props: { validationMessages: { required: 'Required' } },
             global: { plugins: [themePlugin] },
+            slots: { validationGroup: () => h('span', { class: 'slot-marker' }, 'slot content') },
         });
-        expect(wrapper.text()).toContain('Required');
+        expect(wrapper.find('.slot-marker').exists()).toBe(true);
     });
 
     it('should render in order: label, content, validation, hint', () => {
@@ -194,7 +191,6 @@ describe('VCFormGroup', () => {
             props: {
                 labelContent: 'Label',
                 hintContent: 'Hint',
-                renderValidation: true,
                 validationMessages: { req: 'Error' },
             },
             global: { plugins: [themePlugin] },
@@ -384,18 +380,22 @@ describe('VCFormGroup', () => {
             expect(wrapper.text()).toContain('legacy msg');
         });
 
-        it('should respect renderValidation=false even when :validation is set', () => {
+        it('should not render validation section when bundle messages are empty', () => {
+            // Bundle with empty `messages` ⇒ no section (content-driven
+            // visibility). Matches the typical "field is pristine / valid"
+            // case from `@ilingo/validup-vue`'s `useFieldValidation`, which
+            // returns `{ severity: undefined, messages: [], issues: [] }`.
             const wrapper = mount(VCFormGroup, {
                 props: {
-                    renderValidation: false,
                     validation: {
-                        severity: 'error' as const,
-                        messages: [{ key: 'k', value: 'should be hidden' }],
+                        severity: undefined,
+                        messages: [],
                     },
+                    hintContent: 'help',
                 },
                 global: { plugins: [themePlugin] },
             });
-            expect(wrapper.text()).not.toContain('should be hidden');
+            expect(wrapper.text()).toBe('help');
         });
     });
 });


### PR DESCRIPTION
## Summary

Closes #1606. Add a single-prop binding for per-field validation feedback so a form group can be driven by one `v-bind`:

```vue
<VCFormGroup :validation=\"useFieldValidation(\$v.fields.email)\">
    <VCFormInput v-model=\"\$v.fields.email.\$model\" />
</VCFormGroup>
```

The new \`FieldValidation\` type is declared **structurally** — [\`@ilingo/validup-vue@1.0.0\`](https://github.com/tada5hi/ilingo/pull/962) ships an identical shape, so the canonical bridge usage type-checks without either package importing the other. Vuecs stays library-neutral; the ilingo bridge is opt-in.

## Breaking change

The legacy boolean visibility toggle \`:validation\` is renamed to \`:render-validation\` so the unqualified \`:validation\` name carries the new bundle. \`FormGroupDefaults.validation\` is renamed to \`renderValidation\` accordingly. Consumers configuring it via the defaults manager need to update:

\`\`\`ts
// before
app.use(vuecs, { defaults: { formGroup: { validation: false } } });
// after
app.use(vuecs, { defaults: { formGroup: { renderValidation: false } } });
\`\`\`

Legacy \`:validation-severity\` + \`:validation-messages\` props stay (one deprecation cycle) with \`@deprecated\` JSDoc pointing at \`:validation\`.

## Design notes

- **Class application is asymmetric on purpose.** The legacy path keeps the pre-bundle behaviour of \"\`undefined\` severity → error class\". The bundle path treats \`undefined\` / \`'success'\` as \"field is OK / pristine\" and applies no class — matches \`@validup/vue\`'s \`getSeverity()\` contract (\`error\` / \`warning\` / \`success\` / \`undefined\`).
- **\`'success'\` severity is forward-compat.** No \`validationSuccess\` theme slot today; \`'success'\` resolves to no class. Consumers wanting a success state can paint it via \`themeClass\`. Dedicated slot ships when demand materializes.
- **Precedence**: \`:validation\` (non-null) wins over the legacy props. Pass \`:validation=\"null\"\` to fall through.
- **\`:render-validation=\"false\"\`** wins over both paths — suppresses the section entirely.

## Test plan

- [x] \`npm run test --workspace=packages/forms\` — 65 tests pass (8 new bundle tests + 5 updated for the rename)
- [x] \`npm run test\` (full repo) — 13 of 13 projects green
- [x] \`npm run lint\` — 0 errors, 230 warnings (pre-existing, AGENTS.md-acceptable)
- [ ] Smoke test in an example app with \`@ilingo/validup-vue@1.0.0\` to verify the structural type binding actually works at the consumer call site

## Docs

- New \`/guide/validation-feedback\` page — canonical bridge usage, \`FieldValidation\` shape, class-application table, legacy-prop precedence, visibility-toggle rename rationale
- \`/guide/behavioral-defaults\` — \`VCFormGroup\` row updated for the rename
- VitePress sidebar entry added

## Related

- Companion to [tada5hi/ilingo#962](https://github.com/tada5hi/ilingo/pull/962) (rename \`FieldFeedback\` → \`FieldValidation\` shipped in \`@ilingo/validup-vue@1.0.0\`)
- Closes #1606
- Supersedes #1605 (closed 2026-06-02 — wrong-shape widening)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed guide for validation feedback covering severity levels (error, warning, success), message rendering rules, precedence between new and legacy inputs, and visibility control behavior.

* **New Features**
  * Validation now accepts structured bundles (severity + messages) including a new success severity.
  * Clearer control for toggling validation display and updated default behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->