### PR TITLE
fix(forms): widen VCFormInput / VCFormTextarea modelValue to accept null

### DIFF
--- a/docs/src/components/form-input.md
+++ b/docs/src/components/form-input.md
@@ -46,7 +46,7 @@ const value = ref('');
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `modelValue` | `string` | `''` | The bound value |
+| `modelValue` | `string \| null` | `''` | The bound value. `null` is accepted as the "unset" value for binding nullable entity fields |
 | `type` | `string` | `'text'` | Native input type |
 | `debounce` | `number` | `0` | Debounce input updates by N milliseconds |
 | `group` | `boolean` | `false` | Render with input-group prepend/append wrappers |

--- a/docs/src/components/form-textarea.md
+++ b/docs/src/components/form-textarea.md
@@ -43,7 +43,7 @@ const value = ref('');
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `modelValue` | `string` | `''` | The bound value |
+| `modelValue` | `string \| null` | `''` | The bound value. `null` is accepted as the "unset" value for binding nullable entity fields |
 | `debounce` | `number` | `0` | Debounce input updates by N milliseconds |
 
 `rows`, `placeholder`, `disabled`, and any other native `<textarea>` attributes are forwarded via `attrs`.

--- a/packages/forms/src/components/form-input/FormInput.vue
+++ b/packages/forms/src/components/form-input/FormInput.vue
@@ -49,8 +49,8 @@ export type FormInputGroupSlotProps = {
 };
 
 const formInputProps = {
-    /** Controlled string value (v-model). */
-    modelValue: { type: String, default: '' },
+    /** Controlled string value (v-model). `null` is the documented "unset" value. */
+    modelValue: { type: [String, null] as PropType<string | null | undefined>, default: '' },
     /** Native `<input type>` attribute. */
     type: { type: String, default: 'text' },
     /** Force-render the input-group wrapper even without prepend/append content. */
@@ -93,7 +93,7 @@ export default defineComponent({
     }) {
         const theme = useComponentTheme('formInput', props, formInputThemeDefaults);
 
-        const localValue = ref(props.modelValue);
+        const localValue = ref<string | null | undefined>(props.modelValue);
         watch(() => props.modelValue, (value) => {
             localValue.value = value;
         });

--- a/packages/forms/src/components/form-textarea/FormTextarea.vue
+++ b/packages/forms/src/components/form-textarea/FormTextarea.vue
@@ -29,8 +29,8 @@ declare module '@vuecs/core' {
 export const formTextareaThemeDefaults: ComponentThemeDefinition<FormTextareaThemeClasses> = { classes: { root: '' } };
 
 const formTextareaProps = {
-    /** Controlled string value (v-model). */
-    modelValue: { type: String, default: '' },
+    /** Controlled string value (v-model). `null` is the documented "unset" value. */
+    modelValue: { type: [String, null] as PropType<string | null | undefined>, default: '' },
     /** Debounce window (ms) for `update:modelValue` emissions. `0` disables debouncing. */
     debounce: { type: Number, default: 0 },
     /** Theme-class overrides for this component instance. */
@@ -48,7 +48,7 @@ export default defineComponent({
     setup(props, { attrs, emit }) {
         const theme = useComponentTheme('formTextarea', props, formTextareaThemeDefaults);
 
-        const localValue = ref(props.modelValue);
+        const localValue = ref<string | null | undefined>(props.modelValue);
         watch(() => props.modelValue, (value) => {
             localValue.value = value;
         });


### PR DESCRIPTION
Both text inputs typed modelValue as `string | undefined`, breaking v-model bindings against nullable string fields on backend-shared entity types. Widen to `[String, null] as PropType<string | null | undefined>`, matching the existing VCFormNumber / VCFormSelect precedent. Non-breaking: string and undefined keep type-checking, and the update:modelValue payload stays string.

Closes #1610