### PR TITLE
feat(forms): propagate FormGroup severity to child inputs via context

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -229,7 +229,7 @@ unless the variant is structural (e.g. orientation-driven layout).
 | TableHeadCell | `align` / `stickyColumn` / `sorted` | left/center/right × boolean × asc/desc/none | `sorted` drives the indicator span + `aria-sort` |
 | TableEmpty | `filtered` | boolean | Distinct copy / style for empty-after-filter vs empty-no-data |
 | TableLoading | `overlay` | boolean | In-table band default vs absolute overlay for refresh-feedback |
-| FormInput / FormTextarea / FormSelect / FormNumber / FormTags | `size` | sm/md/lg | theme-tailwind uses padding+font utilities; theme-bootstrap uses `form-control-{sm,lg}` (and input-group-{sm,lg} for groups) |
+| FormInput / FormTextarea / FormSelect / FormNumber / FormTags / FormSelectSearch | `size` × `severity` | sm/md/lg × error/warning | theme-tailwind uses padding+font utilities + `border-error/warning-500` rings; theme-bootstrap uses `form-control-{sm,lg}` (+ `is-invalid` for both severities — BS5 doesn't ship a soft variant); theme-bulma uses `is-small/large` + native `is-danger`/`is-warning`. `severity` is folded in automatically from the surrounding `<VCFormGroup>` via `provideFormGroupContext` — no per-input wiring. |
 | FormCheckbox / FormSwitch / FormRadio | `size` | sm/md/lg | theme-bootstrap uses `vc-form-{checkbox,switch,radio}-{sm,lg}` helpers from @vuecs/forms structural CSS |
 | Modal | `size` | sm/md/lg/xl | theme-tailwind uses `max-w-*`; theme-bootstrap uses `modal-{sm,lg,xl}` |
 | Popover / HoverCard | `size` | sm/md/lg | Width + padding tier |

--- a/docs/src/components/form-input.md
+++ b/docs/src/components/form-input.md
@@ -46,7 +46,7 @@ const value = ref('');
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `modelValue` | `string \| null` | — | The bound value. `null`/`undefined` are accepted as the "unset" value (renders empty) for binding nullable entity fields |
+| `modelValue` | `string \| null \| undefined` | — | The bound value. `null`/`undefined` are accepted as the "unset" value (renders empty) for binding nullable entity fields |
 | `type` | `string` | `'text'` | Native input type |
 | `debounce` | `number` | `0` | Debounce input updates by N milliseconds |
 | `group` | `boolean` | `false` | Render with input-group prepend/append wrappers |

--- a/docs/src/components/form-input.md
+++ b/docs/src/components/form-input.md
@@ -46,7 +46,7 @@ const value = ref('');
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `modelValue` | `string \| null` | `''` | The bound value. `null` is accepted as the "unset" value for binding nullable entity fields |
+| `modelValue` | `string \| null` | — | The bound value. `null`/`undefined` are accepted as the "unset" value (renders empty) for binding nullable entity fields |
 | `type` | `string` | `'text'` | Native input type |
 | `debounce` | `number` | `0` | Debounce input updates by N milliseconds |
 | `group` | `boolean` | `false` | Render with input-group prepend/append wrappers |

--- a/docs/src/components/form-textarea.md
+++ b/docs/src/components/form-textarea.md
@@ -43,7 +43,7 @@ const value = ref('');
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `modelValue` | `string \| null` | `''` | The bound value. `null` is accepted as the "unset" value for binding nullable entity fields |
+| `modelValue` | `string \| null` | — | The bound value. `null`/`undefined` are accepted as the "unset" value (renders empty) for binding nullable entity fields |
 | `debounce` | `number` | `0` | Debounce input updates by N milliseconds |
 
 `rows`, `placeholder`, `disabled`, and any other native `<textarea>` attributes are forwarded via `attrs`.

--- a/docs/src/components/form-textarea.md
+++ b/docs/src/components/form-textarea.md
@@ -43,7 +43,7 @@ const value = ref('');
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `modelValue` | `string \| null` | — | The bound value. `null`/`undefined` are accepted as the "unset" value (renders empty) for binding nullable entity fields |
+| `modelValue` | `string \| null \| undefined` | — | The bound value. `null`/`undefined` are accepted as the "unset" value (renders empty) for binding nullable entity fields |
 | `debounce` | `number` | `0` | Debounce input updates by N milliseconds |
 
 `rows`, `placeholder`, `disabled`, and any other native `<textarea>` attributes are forwarded via `attrs`.

--- a/docs/src/guide/validation-feedback.md
+++ b/docs/src/guide/validation-feedback.md
@@ -91,3 +91,56 @@ A dedicated `validationSuccess` slot may ship later if demand materializes.
 ## Severity types
 
 Vuecs's `ValidationSeverity` enum stays `'error' | 'warning'` for the legacy `:validation-severity` prop. The `FieldValidation` shape's wider union (`'error' | 'warning' | 'success'`) is the bridge-facing type; the two coexist intentionally — the enum is the vuecs-native vocabulary, the bundle accepts whatever a validation library naturally produces.
+
+## Severity flows down to the child input
+
+`<VCFormGroup>` provides its resolved severity through a Vue context (`provideFormGroupContext`) and every form-input component in `@vuecs/forms` (`VCFormInput`, `VCFormTextarea`, `VCFormSelect`, `VCFormSelectSearch`, `VCFormNumber`, `VCFormTags`, `VCFormCheckbox`, `VCFormSwitch`, `VCFormRadio`, `VCFormPin`, `VCFormSlider`, plus the matching `*Group`s) reads it and folds it into its own `themeVariant.severity`.
+
+What that means in practice: if your theme declares a `severity` variant on a form-input element, just wrapping the input in `<VCFormGroup :validation>` is enough to repaint the input's border / focus ring to match the validation state. **No per-input wiring required.**
+
+```vue
+<VCFormGroup :validation="useFieldValidation($v.fields.email)">
+  <VCFormInput v-model="$v.fields.email.$model" />
+</VCFormGroup>
+```
+
+When the field becomes `error`, the input picks up the theme's `formInput.variants.severity.error` classes (e.g. red border + red focus ring in `theme-tailwind`). When it becomes `warning`, the `warning` cell. When pristine (`severity: undefined`), no override — the input renders with its default border.
+
+### All shipping themes declare it
+
+| Theme | `error` / `warning` chrome |
+|---|---|
+| `theme-tailwind` | `border-error-500 focus:border-error-500 focus:ring-error-500` / matching `warning-*` |
+| `theme-bootstrap` | `.is-invalid` (BS5 doesn't ship a soft-severity utility, so `warning` maps to `.is-invalid` too — override if needed) |
+| `theme-bulma` | `.is-danger` / `.is-warning` |
+
+### Per-instance override
+
+If a specific input shouldn't follow its parent FormGroup's severity, pass `themeVariant.severity` explicitly — per-instance wins:
+
+```vue
+<VCFormGroup :validation="parentBundle">
+  <!-- Inherits parent severity -->
+  <VCFormInput v-model="state.email" />
+  <!-- Explicit override; ignores the FormGroup context -->
+  <VCFormInput v-model="state.note" :theme-variant="{ severity: undefined }" />
+</VCFormGroup>
+```
+
+### Outside a FormGroup
+
+Form inputs mounted standalone (no surrounding `<VCFormGroup>`) render with their default border. The context is optional — the helper short-circuits when no parent context exists.
+
+### Public API
+
+The plumbing is exported for downstream component libraries that want to build their own form-input variants on the same context:
+
+```ts
+import {
+    provideFormGroupContext,
+    useFormGroupContext,
+    useFormInputThemeProps,
+} from '@vuecs/forms';
+```
+
+`useFormInputThemeProps(props)` is the helper every shipped input uses — pass it as the second arg to `useComponentTheme()` and your input picks up the inherited severity automatically.

--- a/docs/src/guide/validation-feedback.md
+++ b/docs/src/guide/validation-feedback.md
@@ -114,6 +114,8 @@ When the field becomes `error`, the input picks up the theme's `formInput.varian
 | `theme-bootstrap` | `.is-invalid` | `.is-invalid` (same — Bootstrap 5 ships no soft-severity form-control utility, so `error` and `warning` collapse) | Override `formInput.variants.severity.warning` to a custom amber class if you need a real distinction |
 | `theme-bulma` | `.is-danger` | `.is-warning` | Bulma's input states tint **background + border + focus shadow** — more saturated than the Tailwind look. The HSL-channel mechanism means there's no pure-border-only variant |
 
+The validation **message text** below the input picks up the matching colour too. `<VCValidationGroup>` folds the `:severity` prop into `themeVariant.severity` so each rendered message gets the right `text-*-600` class per state. Without this layered severity, warning messages used to inherit `text-error-600` from `validationGroup.item`'s base — looking red even though the input border went amber.
+
 ### Severity covers more than just "validation failed"
 
 Severity flows from your validation source's notion of state, which typically includes more than just pass/fail. Using [`@validup/vue`](https://www.npmjs.com/package/@validup/vue)'s `getSeverity()` as a reference (see the [validup-vue source](https://github.com/tada5hi/validup/blob/master/packages/vue/src/helpers/severity.ts)):

--- a/docs/src/guide/validation-feedback.md
+++ b/docs/src/guide/validation-feedback.md
@@ -108,15 +108,34 @@ When the field becomes `error`, the input picks up the theme's `formInput.varian
 
 ### All shipping themes declare it
 
-| Theme | `error` / `warning` chrome |
-|---|---|
-| `theme-tailwind` | `border-error-500 focus:border-error-500 focus:ring-error-500` / matching `warning-*` |
-| `theme-bootstrap` | `.is-invalid` (BS5 doesn't ship a soft-severity utility, so `warning` maps to `.is-invalid` too — override if needed) |
-| `theme-bulma` | `.is-danger` / `.is-warning` |
+| Theme | `error` chrome | `warning` chrome | Notes |
+|---|---|---|---|
+| `theme-tailwind` | `border-error-500 focus:border-error-500 focus:ring-error-500` | `border-warning-500` + matching focus ring | Border + focus ring only; input background stays neutral |
+| `theme-bootstrap` | `.is-invalid` | `.is-invalid` (same — Bootstrap 5 ships no soft-severity form-control utility, so `error` and `warning` collapse) | Override `formInput.variants.severity.warning` to a custom amber class if you need a real distinction |
+| `theme-bulma` | `.is-danger` | `.is-warning` | Bulma's input states tint **background + border + focus shadow** — more saturated than the Tailwind look. The HSL-channel mechanism means there's no pure-border-only variant |
+
+### Severity covers more than just "validation failed"
+
+Severity flows from your validation source's notion of state, which typically includes more than just pass/fail. Using [`@validup/vue`](https://www.npmjs.com/package/@validup/vue)'s `getSeverity()` as a reference (see the [validup-vue source](https://github.com/tada5hi/validup/blob/master/packages/vue/src/helpers/severity.ts)):
+
+| State | Severity | What the input looks like |
+|---|---|---|
+| Field is pristine + valid | `undefined` | Default border |
+| Validators are currently running (`$pending`) | `'warning'` | Amber border, message may be empty |
+| Pristine but the schema requires a value (pre-touch hint) | `'warning'` | Amber border, no message text yet |
+| Touched + invalid (required mount failed) | `'error'` | Red border + red message |
+| Touched + invalid (only optional mounts failed) | `'warning'` | Amber border + amber message |
+| Touched + valid (passed) | `'success'` | Default border today (no theme class) — forward-compat for themes that add a green-border variant |
+
+The pending-state and pre-touch-hint cases mean the input border may colour before any message text appears. That's intentional — the border alone is the "something is up with this field" affordance.
+
+### `success` severity (forward-compat)
+
+Today none of the three shipping themes declare a `severity.success` variant — `validation.severity === 'success'` propagates through the context but produces no class change on the input (same end result as `undefined`). The wiring is in place though: any consumer theme that adds a `severity.success` entry on `formInput` (etc.) will automatically light up green borders on passed fields. The validation-message `validationSuccess` slot is on the same forward-compat track.
 
 ### Per-instance override
 
-If a specific input shouldn't follow its parent FormGroup's severity, pass `themeVariant.severity` explicitly — per-instance wins:
+If a specific input shouldn't follow its parent FormGroup's severity, pass `themeVariant.severity` explicitly — per-instance wins. Setting it to `undefined` is the "force pristine" escape hatch:
 
 ```vue
 <VCFormGroup :validation="parentBundle">
@@ -127,9 +146,17 @@ If a specific input shouldn't follow its parent FormGroup's severity, pass `them
 </VCFormGroup>
 ```
 
+### Nested FormGroups
+
+Stacking `<VCFormGroup>`s (unusual but supported) — the **inner** group's severity wins for its children, because Vue's `provide` shadows the outer key. So a `<VCFormGroup :validation="warningBundle">` inside a `<VCFormGroup :validation="errorBundle">` paints its child input amber, not red.
+
 ### Outside a FormGroup
 
 Form inputs mounted standalone (no surrounding `<VCFormGroup>`) render with their default border. The context is optional — the helper short-circuits when no parent context exists.
+
+### Toggle controls have no severity variants today
+
+`VCFormCheckbox`, `VCFormCheckboxGroup`, `VCFormSwitch`, `VCFormRadio`, `VCFormRadioGroup`, `VCFormPin`, and `VCFormSlider` consume the FormGroup context (forward-compat) but no shipping theme declares `severity` variants on them — toggles are usually too small for a meaningful border ring, and the FormGroup's message text below the control covers the UX. Themes that want amber/red toggle outlines can add their own `severity` variant entries; the wiring is already in place.
 
 ### Public API
 

--- a/examples/_shared/src/routes.ts
+++ b/examples/_shared/src/routes.ts
@@ -83,6 +83,12 @@ export const sharedRoutes: SharedRoute[] = [
         view: () => import('./views/FormCheckbox.vue').then((m) => m.default),
     },
     {
+        path: '/form-group',
+        name: 'form-group',
+        label: 'Form Group (severity)',
+        view: () => import('./views/FormGroup.vue').then((m) => m.default),
+    },
+    {
         path: '/form-input',
         name: 'form-input',
         label: 'Form Input',

--- a/examples/_shared/src/views/FormGroup.vue
+++ b/examples/_shared/src/views/FormGroup.vue
@@ -1,0 +1,177 @@
+<script setup lang="ts">
+import {
+    type FieldValidation,
+    VCFormGroup,
+    VCFormInput,
+    VCFormSelect,
+    VCFormTextarea,
+} from '@vuecs/forms';
+import { computed, ref } from 'vue';
+
+/**
+ * Demonstrates `<VCFormGroup :validation>` propagating severity down
+ * to the wrapped form-input — the border (and focus ring) repaint in
+ * sync with the message, no per-input `:theme-variant="{ severity }"`
+ * wiring required.
+ *
+ * No validation library is wired in here to keep the demo
+ * dependency-free; instead, the cycle button steps through four
+ * representative `FieldValidation` bundles to show each visual state:
+ *
+ *   pristine → warning → error → success → pristine
+ *
+ * In real apps, the bundle comes from `@ilingo/validup-vue`'s
+ * `useFieldValidation()` (or any equivalent bridge) — its return
+ * shape matches the `FieldValidation` type used below.
+ */
+
+defineProps<{
+    themeVariant?: Record<string, string | boolean>;
+}>();
+
+const value = ref('hello');
+const description = ref('');
+const role = ref<string | undefined>(undefined);
+
+type State = 'pristine' | 'warning' | 'error' | 'success';
+const stateOrder: State[] = ['pristine', 'warning', 'error', 'success'];
+const stateIndex = ref(0);
+const state = computed<State>(() => stateOrder[stateIndex.value]!);
+
+const cycle = () => {
+    stateIndex.value = (stateIndex.value + 1) % stateOrder.length;
+};
+
+const bundle = computed<FieldValidation | null>(() => {
+    switch (state.value) {
+        case 'pristine':
+            // No severity, no messages — input renders with default border.
+            return { severity: undefined, messages: [] };
+        case 'warning':
+            // Validation in flight (or pre-touch hint) — amber border, optional message.
+            return {
+                severity: 'warning',
+                messages: [{ key: 'pending', value: 'Looks unusual — double-check this value' }],
+            };
+        case 'error':
+            // Failed validation — red border + red message.
+            return {
+                severity: 'error',
+                messages: [{ key: 'required', value: 'This field is required' }],
+            };
+        case 'success':
+            // Passed (forward-compat — no shipping theme has a success class yet,
+            // so the border stays default; the message text still renders).
+            return {
+                severity: 'success',
+                messages: [{ key: 'ok', value: 'Looks good' }],
+            };
+        default:
+            return null;
+    }
+});
+</script>
+
+<template>
+    <div style="display: flex; flex-direction: column; gap: 1rem; max-width: 32rem;">
+        <div style="display: flex; align-items: center; gap: 0.75rem;">
+            <button
+                type="button"
+                style="
+                    padding: 0.25rem 0.75rem;
+                    border: 1px solid var(--vc-color-border);
+                    border-radius: 0.375rem;
+                    background: var(--vc-color-bg);
+                    cursor: pointer;
+                    font-size: 0.875rem;
+                "
+                @click="cycle"
+            >
+                Cycle state →
+            </button>
+            <span style="font-size: 0.875rem; color: var(--vc-color-fg-muted);">
+                Current: <code>{{ state }}</code>
+            </span>
+        </div>
+
+        <!--
+          A single FormGroup-wrapped input. The `:validation` bundle is
+          rebuilt by `cycle()` above. The input picks up the matching
+          severity variant from the active theme (border + focus ring)
+          *and* the message text below — both driven by the same
+          single prop on the FormGroup. No per-input wiring.
+        -->
+        <VCFormGroup
+            :validation="bundle"
+            label-content="Email"
+        >
+            <VCFormInput
+                v-model="value"
+                placeholder="you@example.com"
+                :theme-variant="themeVariant"
+            />
+        </VCFormGroup>
+
+        <!--
+          A textarea — same story. Every shipping form-input component
+          consumes the FormGroup context, so any input you drop inside
+          a FormGroup automatically tracks its severity.
+        -->
+        <VCFormGroup
+            :validation="bundle"
+            label-content="Description"
+        >
+            <VCFormTextarea
+                v-model="description"
+                rows="3"
+                placeholder="Tell us about yourself"
+                :theme-variant="themeVariant"
+            />
+        </VCFormGroup>
+
+        <!--
+          And a select. Severity flows the same way; theme-bulma uses
+          its native `.is-danger` / `.is-warning` states, theme-tailwind
+          uses the `border-error/warning-500` ring, theme-bootstrap uses
+          `.is-invalid` (no warning-soft state — BS5 limitation, both
+          severities collapse to red).
+        -->
+        <VCFormGroup
+            :validation="bundle"
+            label-content="Role"
+        >
+            <VCFormSelect
+                v-model="role"
+                :options="[
+                    { value: 'admin', label: 'Administrator' },
+                    { value: 'user', label: 'User' },
+                    { value: 'guest', label: 'Guest' },
+                ]"
+                :theme-variant="themeVariant"
+            />
+        </VCFormGroup>
+
+        <!--
+          Per-instance opt-out — passing `severity: undefined` explicitly
+          blocks inheritance even when the surrounding FormGroup has a
+          severity. This input always renders with its default border,
+          regardless of which state the demo is cycled to.
+        -->
+        <VCFormGroup
+            :validation="bundle"
+            label-content="Always neutral (opt-out)"
+        >
+            <VCFormInput
+                model-value="opted out"
+                placeholder="ignores the FormGroup's severity"
+                :theme-variant="{ ...themeVariant, severity: undefined }"
+            />
+        </VCFormGroup>
+
+        <p style="font-size: 0.8125rem; color: var(--vc-color-fg-muted); margin: 0;">
+            Click <strong>Cycle state</strong> to step through pristine → warning → error → success.
+            The first three inputs all repaint together; the last one is opted-out via
+            <code>:theme-variant="{ severity: undefined }"</code> and stays neutral.
+        </p>
+    </div>
+</template>

--- a/examples/_shared/src/views/FormGroup.vue
+++ b/examples/_shared/src/views/FormGroup.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import {
     type FieldValidation,
+    type FormOption,
     VCFormGroup,
     VCFormInput,
     VCFormSelect,
@@ -32,6 +33,15 @@ defineProps<{
 const value = ref('hello');
 const description = ref('');
 const role = ref<string | undefined>(undefined);
+
+// Setup-side const, matching the canonical FormSelect demo's
+// pattern. Inline `:options="[…]"` in the template also works, but
+// hoisting keeps the array reference stable across renders.
+const roles: FormOption[] = [
+    { value: 'admin', label: 'Administrator' },
+    { value: 'user', label: 'User' },
+    { value: 'guest', label: 'Guest' },
+];
 
 type State = 'pristine' | 'warning' | 'error' | 'success';
 const stateOrder: State[] = ['pristine', 'warning', 'error', 'success'];
@@ -142,11 +152,8 @@ const bundle = computed<FieldValidation | null>(() => {
         >
             <VCFormSelect
                 v-model="role"
-                :options="[
-                    { value: 'admin', label: 'Administrator' },
-                    { value: 'user', label: 'User' },
-                    { value: 'guest', label: 'Guest' },
-                ]"
+                :options="roles"
+                placeholder="-- Pick a role --"
                 :theme-variant="themeVariant"
             />
         </VCFormGroup>

--- a/examples/nuxt/config/layout/module.ts
+++ b/examples/nuxt/config/layout/module.ts
@@ -128,14 +128,19 @@ const elementsItems: NavigationItem[] = [
 
 const formsItems: NavigationItem[] = [
     {
-        name: 'Checkbox', 
-        type: 'link', 
-        url: '/forms/checkbox', 
+        name: 'Checkbox',
+        type: 'link',
+        url: '/forms/checkbox',
     },
     {
-        name: 'Input', 
-        type: 'link', 
-        url: '/forms/input', 
+        name: 'Group (severity)',
+        type: 'link',
+        url: '/forms/group',
+    },
+    {
+        name: 'Input',
+        type: 'link',
+        url: '/forms/input',
     },
     {
         name: 'Number', 

--- a/examples/nuxt/pages/forms/group.vue
+++ b/examples/nuxt/pages/forms/group.vue
@@ -1,0 +1,12 @@
+<script lang="ts">
+import DemoView from '@vuecs-examples/shared/views/FormGroup.vue';
+import { defineNuxtComponent } from '#app';
+
+export default defineNuxtComponent({ components: { DemoView } });
+</script>
+
+<template>
+    <div class="mx-auto max-w-5xl">
+        <DemoView />
+    </div>
+</template>

--- a/packages/forms/src/components/form-checkbox-group/FormCheckboxGroup.vue
+++ b/packages/forms/src/components/form-checkbox-group/FormCheckboxGroup.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useComponentTheme } from '@vuecs/core';
+import { useFormInputThemeProps } from '../form-group/context';
 import type {
     ComponentThemeDefinition,
     ThemeClassesOverride,
@@ -64,7 +65,7 @@ export default defineComponent({
         emit,
         slots,
     }) {
-        const theme = useComponentTheme('formCheckboxGroup', props, formCheckboxGroupThemeDefaults);
+        const theme = useComponentTheme('formCheckboxGroup', useFormInputThemeProps(props), formCheckboxGroupThemeDefaults);
 
         return () => h(
             CheckboxGroupRoot,

--- a/packages/forms/src/components/form-checkbox/FormCheckbox.vue
+++ b/packages/forms/src/components/form-checkbox/FormCheckbox.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useComponentDefaults, useComponentTheme, useId } from '@vuecs/core';
+import { useFormInputThemeProps } from '../form-group/context';
 import type {
     ComponentDefaultValues,
     ComponentThemeDefinition,
@@ -101,7 +102,7 @@ export default defineComponent({
         emit,
         slots,
     }) {
-        const theme = useComponentTheme('formCheckbox', props, formCheckboxThemeDefaults);
+        const theme = useComponentTheme('formCheckbox', useFormInputThemeProps(props), formCheckboxThemeDefaults);
         const defaults = useComponentDefaults('formCheckbox', props, behavioralDefaults);
         // SSR-safe stable id (Vue 3.5's native `useId` under the hood).
         // Replaces a `Math.random()` fallback that caused hydration

--- a/packages/forms/src/components/form-group/FormGroup.vue
+++ b/packages/forms/src/components/form-group/FormGroup.vue
@@ -114,10 +114,22 @@ export default defineComponent({
         const theme = useComponentTheme('formGroup', props, formGroupThemeDefaults);
 
         // Expose the effective severity to descendant inputs via context.
-        // Same precedence as the render-side computation: bundle wins over
-        // the legacy `:validationSeverity` prop; bundle-`undefined` means
-        // "pristine / OK" (no severity), legacy-`undefined` falls through
-        // to the prop. Inputs read this and fold it into their own
+        // Mirrors the render-side `validationClass` computation exactly:
+        //
+        //   1. Bundle path (`:validation` set): return the bundle's
+        //      severity verbatim. Bundle-`undefined` means "pristine /
+        //      OK" — no fallback.
+        //   2. Legacy path with explicit `:validation-severity`: return
+        //      that.
+        //   3. Legacy path without severity but with non-empty
+        //      `:validation-messages`: fall back to `'error'`. This
+        //      matches the pre-bundle behaviour where the FormGroup root
+        //      auto-painted red when consumers passed only messages —
+        //      child inputs now match that styling instead of staying
+        //      neutral while the message goes red.
+        //   4. Otherwise: undefined.
+        //
+        // Inputs read the result and fold it into their own
         // `themeVariant` so the input's border colour tracks validation
         // state without per-instance wiring.
         provideFormGroupContext({
@@ -125,7 +137,16 @@ export default defineComponent({
                 if (props.validation != null) {
                     return props.validation.severity;
                 }
-                return props.validationSeverity;
+                if (props.validationSeverity !== undefined) {
+                    return props.validationSeverity;
+                }
+                const messages = props.validationMessages;
+                const hasMessages = !!messages && (
+                    Array.isArray(messages) ?
+                        messages.length > 0 :
+                        Object.keys(messages).length > 0
+                );
+                return hasMessages ? ValidationSeverity.ERROR : undefined;
             },
         });
 

--- a/packages/forms/src/components/form-group/FormGroup.vue
+++ b/packages/forms/src/components/form-group/FormGroup.vue
@@ -20,6 +20,7 @@ import {
     type ValidationGroupDefaultSlotProps,
     type ValidationGroupItemSlotProps,
 } from '../validation-group';
+import { provideFormGroupContext } from './context';
 
 export type FormGroupThemeClasses = {
     root: string;
@@ -111,6 +112,22 @@ export default defineComponent({
     }>,
     setup(props, { attrs, slots }) {
         const theme = useComponentTheme('formGroup', props, formGroupThemeDefaults);
+
+        // Expose the effective severity to descendant inputs via context.
+        // Same precedence as the render-side computation: bundle wins over
+        // the legacy `:validationSeverity` prop; bundle-`undefined` means
+        // "pristine / OK" (no severity), legacy-`undefined` falls through
+        // to the prop. Inputs read this and fold it into their own
+        // `themeVariant` so the input's border colour tracks validation
+        // state without per-instance wiring.
+        provideFormGroupContext({
+            severity: () => {
+                if (props.validation != null) {
+                    return props.validation.severity;
+                }
+                return props.validationSeverity;
+            },
+        });
 
         return () => {
             const resolved = theme.value;

--- a/packages/forms/src/components/form-group/context.ts
+++ b/packages/forms/src/components/form-group/context.ts
@@ -1,9 +1,4 @@
-import type { 
-    ThemeClasses, 
-    ThemeClassesOverride, 
-    UseComponentThemeProps, 
-    VariantValues, 
-} from '@vuecs/core';
+import type { ThemeClasses, UseComponentThemeProps } from '@vuecs/core';
 import type { InjectionKey } from 'vue';
 import { inject, provide } from 'vue';
 import type { ValidationSeverity } from '../constants';
@@ -16,16 +11,22 @@ import type { ValidationSeverity } from '../constants';
  *
  * Children read the context and fold the inherited severity into
  * their own `themeVariant`, lighting up each theme's `severity` variant
- * (red border for `error`, amber for `warning`). Per-instance values
- * on a child still win — pass `:theme-variant="{ severity: 'error' }"`
- * to override the inherited one.
+ * (red border for `error`, amber for `warning`, green for `success`
+ * once themes declare it). Per-instance values on a child still win —
+ * pass `:theme-variant="{ severity: 'error' }"` to override the
+ * inherited one, or `:theme-variant="{ severity: undefined }"` to
+ * explicitly opt out of inheritance for a single input.
  *
  * Optional — children render with their default border when mounted
  * outside `<VCFormGroup>` (ad-hoc usage, unit tests, custom layouts).
  *
- * The severity getter is reactive (a function rather than a plain
- * value) so the child re-renders when the parent's `:validation`
- * bundle updates.
+ * Nested `<VCFormGroup>`s: the inner provider wins, so an input
+ * mounted inside two stacked groups sees the inner group's severity.
+ *
+ * The severity getter is a function (not a plain value) so reads track
+ * Vue's reactive deps: when the parent's `:validation` bundle updates,
+ * descendants re-render automatically through `useComponentTheme`'s
+ * computed wrapper.
  */
 export type FormGroupContext = {
     severity: () => `${ValidationSeverity}` | 'success' | undefined;
@@ -47,14 +48,14 @@ export function useFormGroupContext(): FormGroupContext | null {
  * — lighting up the theme's `severity` variant on the input without
  * the consumer wiring it per-instance.
  *
- * Per-instance values win: if the caller already set
- * `themeVariant.severity`, the inherited one is ignored. Outside a
- * `<VCFormGroup>` the helper is a pass-through.
+ * Per-instance values win: if the caller's `themeVariant` already has
+ * a `severity` key (even one set to `undefined`), the inherited value
+ * is ignored. Outside a `<VCFormGroup>` the helper is a pass-through.
  *
  * Pass directly to `useComponentTheme(name, useFormInputThemeProps(props), defaults)`.
  */
 export function useFormInputThemeProps<T extends ThemeClasses>(
-    props: UseComponentThemeProps<T> & { themeClass?: ThemeClassesOverride<T>; themeVariant?: VariantValues },
+    props: UseComponentThemeProps<T>,
 ): UseComponentThemeProps<T> {
     const ctx = useFormGroupContext();
     return {
@@ -64,8 +65,9 @@ export function useFormInputThemeProps<T extends ThemeClasses>(
         get themeVariant() {
             const own = props.themeVariant;
             // Per-instance severity wins. Skip inheritance entirely when
-            // the consumer already set one — even to an explicit `undefined`,
-            // which is the documented "force pristine" escape hatch.
+            // the consumer already set the key — even to an explicit
+            // `undefined`, which is the documented "force pristine"
+            // escape hatch.
             if (own && 'severity' in own) {
                 return own;
             }

--- a/packages/forms/src/components/form-group/context.ts
+++ b/packages/forms/src/components/form-group/context.ts
@@ -1,0 +1,79 @@
+import type { 
+    ThemeClasses, 
+    ThemeClassesOverride, 
+    UseComponentThemeProps, 
+    VariantValues, 
+} from '@vuecs/core';
+import type { InjectionKey } from 'vue';
+import { inject, provide } from 'vue';
+import type { ValidationSeverity } from '../constants';
+
+/**
+ * Context shared from `<VCFormGroup>` to its descendant form-input
+ * children (`<VCFormInput>`, `<VCFormTextarea>`, `<VCFormSelect>`, …)
+ * so the resolved validation severity propagates down without the
+ * consumer wiring `:theme-variant="{ severity }"` on every input.
+ *
+ * Children read the context and fold the inherited severity into
+ * their own `themeVariant`, lighting up each theme's `severity` variant
+ * (red border for `error`, amber for `warning`). Per-instance values
+ * on a child still win — pass `:theme-variant="{ severity: 'error' }"`
+ * to override the inherited one.
+ *
+ * Optional — children render with their default border when mounted
+ * outside `<VCFormGroup>` (ad-hoc usage, unit tests, custom layouts).
+ *
+ * The severity getter is reactive (a function rather than a plain
+ * value) so the child re-renders when the parent's `:validation`
+ * bundle updates.
+ */
+export type FormGroupContext = {
+    severity: () => `${ValidationSeverity}` | 'success' | undefined;
+};
+
+const FORM_GROUP_CONTEXT_KEY: InjectionKey<FormGroupContext> = Symbol('vcFormGroupContext');
+
+export function provideFormGroupContext(ctx: FormGroupContext): void {
+    provide(FORM_GROUP_CONTEXT_KEY, ctx);
+}
+
+export function useFormGroupContext(): FormGroupContext | null {
+    return inject(FORM_GROUP_CONTEXT_KEY, null);
+}
+
+/**
+ * Wrap a form-input component's props so that any inherited severity
+ * from the surrounding `<VCFormGroup>` flows into `themeVariant.severity`
+ * — lighting up the theme's `severity` variant on the input without
+ * the consumer wiring it per-instance.
+ *
+ * Per-instance values win: if the caller already set
+ * `themeVariant.severity`, the inherited one is ignored. Outside a
+ * `<VCFormGroup>` the helper is a pass-through.
+ *
+ * Pass directly to `useComponentTheme(name, useFormInputThemeProps(props), defaults)`.
+ */
+export function useFormInputThemeProps<T extends ThemeClasses>(
+    props: UseComponentThemeProps<T> & { themeClass?: ThemeClassesOverride<T>; themeVariant?: VariantValues },
+): UseComponentThemeProps<T> {
+    const ctx = useFormGroupContext();
+    return {
+        get themeClass() {
+            return props.themeClass;
+        },
+        get themeVariant() {
+            const own = props.themeVariant;
+            // Per-instance severity wins. Skip inheritance entirely when
+            // the consumer already set one — even to an explicit `undefined`,
+            // which is the documented "force pristine" escape hatch.
+            if (own && 'severity' in own) {
+                return own;
+            }
+            const inherited = ctx?.severity();
+            if (inherited === undefined) {
+                return own;
+            }
+            return { ...(own ?? {}), severity: inherited };
+        },
+    };
+}

--- a/packages/forms/src/components/form-group/index.ts
+++ b/packages/forms/src/components/form-group/index.ts
@@ -3,5 +3,5 @@ import FormGroup from './FormGroup.vue';
 export { FormGroup as VCFormGroup };
 export { formGroupThemeDefaults } from './FormGroup.vue';
 export type { FormGroupProps, FormGroupThemeClasses } from './FormGroup.vue';
-export { provideFormGroupContext, useFormGroupContext } from './context';
+export { provideFormGroupContext, useFormGroupContext, useFormInputThemeProps } from './context';
 export type { FormGroupContext } from './context';

--- a/packages/forms/src/components/form-group/index.ts
+++ b/packages/forms/src/components/form-group/index.ts
@@ -3,3 +3,5 @@ import FormGroup from './FormGroup.vue';
 export { FormGroup as VCFormGroup };
 export { formGroupThemeDefaults } from './FormGroup.vue';
 export type { FormGroupProps, FormGroupThemeClasses } from './FormGroup.vue';
+export { provideFormGroupContext, useFormGroupContext } from './context';
+export type { FormGroupContext } from './context';

--- a/packages/forms/src/components/form-input/FormInput.vue
+++ b/packages/forms/src/components/form-input/FormInput.vue
@@ -20,6 +20,7 @@ import {
     ref,
     watch,
 } from 'vue';
+import { useFormInputThemeProps } from '../form-group/context';
 
 export type FormInputThemeClasses = {
     root: string;
@@ -49,8 +50,16 @@ export type FormInputGroupSlotProps = {
 };
 
 const formInputProps = {
-    /** Controlled string value (v-model). `null` is the documented "unset" value. */
-    modelValue: { type: [String, null] as PropType<string | null | undefined>, default: '' },
+    /**
+     * Controlled string value (v-model). `null` is the documented "unset" value.
+     *
+     * No `default` on purpose: vue-tsc strips `null`/`undefined` (via `NonNullable`)
+     * when folding a prop default into the emitted `DefaultProps`, which then
+     * intersects `$props['modelValue']` back down to `string` and breaks v-model
+     * against nullable entity fields (#1613). The render coerces `null`/`undefined`
+     * to `''`, so the empty-input behaviour is unchanged.
+     */
+    modelValue: { type: [String, null] as PropType<string | null | undefined> },
     /** Native `<input type>` attribute. */
     type: { type: String, default: 'text' },
     /** Force-render the input-group wrapper even without prepend/append content. */
@@ -91,7 +100,7 @@ export default defineComponent({
         emit,
         slots,
     }) {
-        const theme = useComponentTheme('formInput', props, formInputThemeDefaults);
+        const theme = useComponentTheme('formInput', useFormInputThemeProps(props), formInputThemeDefaults);
 
         const localValue = ref<string | null | undefined>(props.modelValue);
         watch(() => props.modelValue, (value) => {

--- a/packages/forms/src/components/form-number/FormNumber.vue
+++ b/packages/forms/src/components/form-number/FormNumber.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useComponentTheme } from '@vuecs/core';
+import { useFormInputThemeProps } from '../form-group/context';
 import type {
     ComponentThemeDefinition,
     ThemeClassesOverride,
@@ -82,7 +83,7 @@ export default defineComponent({
     props: formNumberProps,
     emits: ['update:modelValue'],
     setup(props, { attrs, emit }) {
-        const theme = useComponentTheme('formNumber', props, formNumberThemeDefaults);
+        const theme = useComponentTheme('formNumber', useFormInputThemeProps(props), formNumberThemeDefaults);
 
         return () => h(
             NumberFieldRoot,

--- a/packages/forms/src/components/form-pin/FormPin.vue
+++ b/packages/forms/src/components/form-pin/FormPin.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useComponentTheme } from '@vuecs/core';
+import { useFormInputThemeProps } from '../form-group/context';
 import type {
     ComponentThemeDefinition,
     ThemeClassesOverride,
@@ -73,7 +74,7 @@ export default defineComponent({
     props: formPinProps,
     emits: ['update:modelValue', 'complete'],
     setup(props, { attrs, emit }) {
-        const theme = useComponentTheme('formPin', props, formPinThemeDefaults);
+        const theme = useComponentTheme('formPin', useFormInputThemeProps(props), formPinThemeDefaults);
 
         return () => h(
             PinInputRoot,

--- a/packages/forms/src/components/form-radio-group/FormRadioGroup.vue
+++ b/packages/forms/src/components/form-radio-group/FormRadioGroup.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useComponentTheme } from '@vuecs/core';
+import { useFormInputThemeProps } from '../form-group/context';
 import type {
     ComponentThemeDefinition,
     ThemeClassesOverride,
@@ -70,7 +71,7 @@ export default defineComponent({
         emit,
         slots,
     }) {
-        const theme = useComponentTheme('formRadioGroup', props, formRadioGroupThemeDefaults);
+        const theme = useComponentTheme('formRadioGroup', useFormInputThemeProps(props), formRadioGroupThemeDefaults);
 
         return () => h(
             RadioGroupRoot,

--- a/packages/forms/src/components/form-radio/FormRadio.vue
+++ b/packages/forms/src/components/form-radio/FormRadio.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useComponentDefaults, useComponentTheme, useId } from '@vuecs/core';
+import { useFormInputThemeProps } from '../form-group/context';
 import type {
     ComponentDefaultValues,
     ComponentThemeDefinition,
@@ -93,7 +94,7 @@ export default defineComponent({
         indicator: FormRadioIndicatorSlotProps;
     }>,
     setup(props, { attrs, slots }) {
-        const theme = useComponentTheme('formRadio', props, formRadioThemeDefaults);
+        const theme = useComponentTheme('formRadio', useFormInputThemeProps(props), formRadioThemeDefaults);
         const defaults = useComponentDefaults('formRadio', props, behavioralDefaults);
         // SSR-safe stable id (Vue 3.5's native `useId` under the hood) —
         // see FormCheckbox.vue.

--- a/packages/forms/src/components/form-select-search/FormSelectSearch.vue
+++ b/packages/forms/src/components/form-select-search/FormSelectSearch.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useComponentTheme } from '@vuecs/core';
+import { useFormInputThemeProps } from '../form-group/context';
 import type {
     ComponentThemeDefinition,
     ThemeClassesOverride,
@@ -123,7 +124,7 @@ export default defineComponent({
     props: formSelectSearchProps,
     emits: ['update:modelValue', 'change'],
     setup(props, { emit }) {
-        const theme = useComponentTheme('formSelectSearch', props, formSelectSearchThemeDefaults);
+        const theme = useComponentTheme('formSelectSearch', useFormInputThemeProps(props), formSelectSearchThemeDefaults);
 
         const listElement = ref<globalThis.HTMLElement | null>(null);
         const inputElement = ref<globalThis.HTMLElement | null>(null);

--- a/packages/forms/src/components/form-select/FormSelect.vue
+++ b/packages/forms/src/components/form-select/FormSelect.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useComponentDefaults, useComponentTheme } from '@vuecs/core';
+import { useFormInputThemeProps } from '../form-group/context';
 import type {
     ComponentDefaultValues,
     ComponentThemeDefinition,
@@ -150,7 +151,7 @@ export default defineComponent({
     props: formSelectProps,
     emits: ['update:modelValue'],
     setup(props, { attrs, emit }) {
-        const theme = useComponentTheme('formSelect', props, formSelectThemeDefaults);
+        const theme = useComponentTheme('formSelect', useFormInputThemeProps(props), formSelectThemeDefaults);
         const defaults = useComponentDefaults('formSelect', props, behavioralDefaults);
 
         return () => {

--- a/packages/forms/src/components/form-slider/FormSlider.vue
+++ b/packages/forms/src/components/form-slider/FormSlider.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useComponentTheme } from '@vuecs/core';
+import { useFormInputThemeProps } from '../form-group/context';
 import type {
     ComponentThemeDefinition,
     ThemeClassesOverride,
@@ -90,7 +91,7 @@ export default defineComponent({
     props: formSliderProps,
     emits: ['update:modelValue', 'valueCommit'],
     setup(props, { attrs, emit }) {
-        const theme = useComponentTheme('formSlider', props, formSliderThemeDefaults);
+        const theme = useComponentTheme('formSlider', useFormInputThemeProps(props), formSliderThemeDefaults);
 
         // Reka's SliderRoot only accepts number[]; we support a scalar for the
         // common single-thumb case and bridge here. The shape we emit on

--- a/packages/forms/src/components/form-switch/FormSwitch.vue
+++ b/packages/forms/src/components/form-switch/FormSwitch.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useComponentDefaults, useComponentTheme, useId } from '@vuecs/core';
+import { useFormInputThemeProps } from '../form-group/context';
 import type {
     ComponentDefaultValues,
     ComponentThemeDefinition,
@@ -95,7 +96,7 @@ export default defineComponent({
         emit,
         slots,
     }) {
-        const theme = useComponentTheme('formSwitch', props, formSwitchThemeDefaults);
+        const theme = useComponentTheme('formSwitch', useFormInputThemeProps(props), formSwitchThemeDefaults);
         const defaults = useComponentDefaults('formSwitch', props, behavioralDefaults);
         // SSR-safe stable id (Vue 3.5's native `useId` under the hood) —
         // see FormCheckbox.vue.

--- a/packages/forms/src/components/form-tags/FormTags.vue
+++ b/packages/forms/src/components/form-tags/FormTags.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useComponentTheme } from '@vuecs/core';
+import { useFormInputThemeProps } from '../form-group/context';
 import type {
     ComponentThemeDefinition,
     ThemeClassesOverride,
@@ -88,7 +89,7 @@ export default defineComponent({
     props: formTagsProps,
     emits: ['update:modelValue', 'invalid'],
     setup(props, { attrs, emit }) {
-        const theme = useComponentTheme('formTags', props, formTagsThemeDefaults);
+        const theme = useComponentTheme('formTags', useFormInputThemeProps(props), formTagsThemeDefaults);
 
         return () => h(
             TagsInputRoot,

--- a/packages/forms/src/components/form-textarea/FormTextarea.vue
+++ b/packages/forms/src/components/form-textarea/FormTextarea.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useComponentTheme } from '@vuecs/core';
+import { useFormInputThemeProps } from '../form-group/context';
 import type {
     ComponentThemeDefinition,
     ThemeClassesOverride,
@@ -29,8 +30,16 @@ declare module '@vuecs/core' {
 export const formTextareaThemeDefaults: ComponentThemeDefinition<FormTextareaThemeClasses> = { classes: { root: '' } };
 
 const formTextareaProps = {
-    /** Controlled string value (v-model). `null` is the documented "unset" value. */
-    modelValue: { type: [String, null] as PropType<string | null | undefined>, default: '' },
+    /**
+     * Controlled string value (v-model). `null` is the documented "unset" value.
+     *
+     * No `default` on purpose: vue-tsc strips `null`/`undefined` (via `NonNullable`)
+     * when folding a prop default into the emitted `DefaultProps`, which then
+     * intersects `$props['modelValue']` back down to `string` and breaks v-model
+     * against nullable entity fields (#1613). The render coerces `null`/`undefined`
+     * to `''`, so the empty-textarea behaviour is unchanged.
+     */
+    modelValue: { type: [String, null] as PropType<string | null | undefined> },
     /** Debounce window (ms) for `update:modelValue` emissions. `0` disables debouncing. */
     debounce: { type: Number, default: 0 },
     /** Theme-class overrides for this component instance. */
@@ -46,7 +55,7 @@ export default defineComponent({
     props: formTextareaProps,
     emits: ['update:modelValue'],
     setup(props, { attrs, emit }) {
-        const theme = useComponentTheme('formTextarea', props, formTextareaThemeDefaults);
+        const theme = useComponentTheme('formTextarea', useFormInputThemeProps(props), formTextareaThemeDefaults);
 
         const localValue = ref<string | null | undefined>(props.modelValue);
         watch(() => props.modelValue, (value) => {

--- a/packages/forms/src/components/validation-group/ValidationGroup.vue
+++ b/packages/forms/src/components/validation-group/ValidationGroup.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { useComponentTheme } from '@vuecs/core';
+import { useComponentTheme, useThemeProps } from '@vuecs/core';
 import type {
     ComponentThemeDefinition,
     ThemeClassesOverride,
@@ -89,7 +89,19 @@ export default defineComponent({
         item: ValidationGroupItemSlotProps;
     }>,
     setup(props, { slots }) {
-        const theme = useComponentTheme('validationGroup', props, validationGroupThemeDefaults);
+        // Fold the `severity` prop into `themeVariant.severity` so the
+        // theme's `severity` variant axis paints each message in the
+        // matching colour (amber on warning, red on error, green on
+        // success). Without this every message took `validationGroup.item`'s
+        // base colour regardless of state — the FormGroup root's
+        // `validationWarning`/`validationError` class set the inherited
+        // text-color but each message's explicit `text-*-600` class won
+        // CSS specificity.
+        const theme = useComponentTheme(
+            'validationGroup',
+            useThemeProps(props, 'severity'),
+            validationGroupThemeDefaults,
+        );
 
         return () => {
             const resolved = theme.value;

--- a/packages/forms/test/unit/components.spec.ts
+++ b/packages/forms/test/unit/components.spec.ts
@@ -1181,4 +1181,52 @@ describe('VCValidationGroup', () => {
         });
         expect(wrapper.text()).toBe('');
     });
+
+    it('should colour each message via the severity variant', () => {
+        // The `:severity` prop is folded into `themeVariant.severity`
+        // by `useThemeProps`. With a theme that declares matching
+        // `severity` variants on `validationGroup.item`, each rendered
+        // message picks up the matching colour — so warning messages
+        // turn amber instead of inheriting the base 'red' colour that
+        // was applied unconditionally before.
+        const preset = {
+            elements: {
+                validationGroup: {
+                    classes: { item: 'msg-base' },
+                    variants: {
+                        severity: {
+                            error: { item: 'msg-error' },
+                            warning: { item: 'msg-warning' },
+                            success: { item: 'msg-success' },
+                        },
+                    },
+                },
+            },
+        };
+        const buildPlugin = () => ({
+            install: (app: any) => {
+                installThemeManager(app, { themes: [preset] });
+                installDefaultsManager(app);
+            },
+        });
+        const warningWrapper = mount(VCValidationGroup, {
+            props: {
+                severity: 'warning',
+                messages: [{ key: 'p', value: 'pending' }],
+            },
+            global: { plugins: [buildPlugin()] },
+        });
+        const item = warningWrapper.find('div');
+        expect(item.classes()).toContain('msg-warning');
+        expect(item.classes()).not.toContain('msg-error');
+
+        const errorWrapper = mount(VCValidationGroup, {
+            props: {
+                severity: 'error',
+                messages: [{ key: 'f', value: 'failed' }],
+            },
+            global: { plugins: [buildPlugin()] },
+        });
+        expect(errorWrapper.find('div').classes()).toContain('msg-error');
+    });
 });

--- a/packages/forms/test/unit/components.spec.ts
+++ b/packages/forms/test/unit/components.spec.ts
@@ -24,6 +24,7 @@ import { default as VCFormSwitch } from '../../src/components/form-switch/FormSw
 import { default as VCFormTags } from '../../src/components/form-tags/FormTags.vue';
 import { default as VCFormTextarea } from '../../src/components/form-textarea/FormTextarea.vue';
 import { default as VCValidationGroup } from '../../src/components/validation-group/ValidationGroup.vue';
+import type { FieldValidation } from '../../src/components/type';
 
 // Reka's `useSize` (used by Slider) constructs a `ResizeObserver`. jsdom does
 // not implement it. Reka's `SelectTrigger` calls `target.hasPointerCapture`
@@ -427,9 +428,12 @@ describe('VCFormGroup', () => {
         it('should propagate error severity from FormGroup to child input', () => {
             const wrapper = mount(VCFormGroup, {
                 props: {
+                    // Array-style `messages` matches the canonical
+                    // `FieldValidation` contract — what `@ilingo/validup-vue`'s
+                    // `useFieldValidation()` produces in real-world usage.
                     validation: {
                         severity: 'error',
-                        messages: { required: 'Required' },
+                        messages: [{ key: 'required', value: 'Required' }],
                     },
                 },
                 global: { plugins: [buildPlugin()] },
@@ -443,7 +447,7 @@ describe('VCFormGroup', () => {
                 props: {
                     validation: {
                         severity: 'warning',
-                        messages: { soft: 'Heads up' },
+                        messages: [{ key: 'soft', value: 'Heads up' }],
                     },
                 },
                 global: { plugins: [buildPlugin()] },
@@ -455,10 +459,10 @@ describe('VCFormGroup', () => {
         it('should not apply any severity class when bundle severity is undefined (pristine)', () => {
             const wrapper = mount(VCFormGroup, {
                 props: {
-                    // No severity — the FieldValidation bundle's "pristine /
-                    // success" state — explicitly `undefined` so the optional
-                    // chain in the input picks up no inherited severity.
-                    validation: { severity: undefined, messages: {} },
+                    // No severity + empty `messages` array — the FieldValidation
+                    // bundle's "pristine / success" state. The input picks up no
+                    // inherited severity.
+                    validation: { severity: undefined, messages: [] },
                 },
                 global: { plugins: [buildPlugin()] },
                 slots: { default: () => h(VCFormInput) },
@@ -481,7 +485,7 @@ describe('VCFormGroup', () => {
                 props: {
                     validation: {
                         severity: 'error',
-                        messages: { e: 'parent says error' },
+                        messages: [{ key: 'e', value: 'parent says error' }],
                     },
                 },
                 global: { plugins: [buildPlugin()] },
@@ -495,6 +499,42 @@ describe('VCFormGroup', () => {
             const inputClasses = wrapper.find('input').classes();
             expect(inputClasses).toContain('severity-warning-class');
             expect(inputClasses).not.toContain('severity-error-class');
+        });
+
+        it('should treat per-instance themeVariant.severity: undefined as an explicit opt-out', () => {
+            // Documented escape hatch — passing `severity: undefined`
+            // explicitly (any key, even with undefined value) opts the
+            // input out of inheriting the FormGroup's severity. Pins
+            // down the `'severity' in own` check; switching to
+            // `own.severity !== undefined` would silently regress this.
+            const wrapper = mount(VCFormGroup, {
+                props: {
+                    validation: {
+                        severity: 'error',
+                        messages: [{ key: 'e', value: 'parent says error' }],
+                    },
+                },
+                global: { plugins: [buildPlugin()] },
+                slots: { default: () => h(VCFormInput, { themeVariant: { severity: undefined } }) },
+            });
+            const inputClasses = wrapper.find('input').classes();
+            expect(inputClasses).not.toContain('severity-error-class');
+            expect(inputClasses).not.toContain('severity-warning-class');
+        });
+
+        it('should fall back to error severity for legacy :validation-messages with no explicit :validation-severity', () => {
+            // FormGroup's render-side `validationClass` computation falls
+            // back to the error class when consumers use the legacy props
+            // path with non-empty `validationMessages` but no
+            // `validationSeverity`. The context mirrors that fallback so
+            // the child input border tracks the (red) FormGroup root
+            // instead of staying neutral.
+            const wrapper = mount(VCFormGroup, {
+                props: { validationMessages: { required: 'Required' } },
+                global: { plugins: [buildPlugin()] },
+                slots: { default: () => h(VCFormInput) },
+            });
+            expect(wrapper.find('input').classes()).toContain('severity-error-class');
         });
 
         it('should propagate severity from the legacy :validation-severity prop', () => {
@@ -526,7 +566,12 @@ describe('VCFormGroup', () => {
                 },
             };
             const wrapper = mount(VCFormGroup, {
-                props: { validation: { severity: 'success', messages: { ok: 'looks good' } } },
+                props: {
+                    validation: {
+                        severity: 'success',
+                        messages: [{ key: 'ok', value: 'looks good' }],
+                    },
+                },
                 global: {
                     plugins: [{
                         install: (app: any) => {
@@ -545,9 +590,9 @@ describe('VCFormGroup', () => {
             // severity, should re-render the child input with the new
             // class — the context's function-valued severity getter
             // tracks Vue's reactive deps through `useComponentTheme`.
-            const validation = ref<{ severity: 'error' | 'warning' | 'success' | undefined; messages: any } | null>({
+            const validation = ref<FieldValidation | null>({
                 severity: undefined,
-                messages: {},
+                messages: [],
             });
             const wrapper = mount(VCFormGroup, {
                 props: { validation: validation.value },
@@ -561,13 +606,13 @@ describe('VCFormGroup', () => {
             // Mutate the bundle in place (the underlying reactive that
             // `useFieldValidation` produces does this on every $errors
             // change — verifying the reactive chain).
-            validation.value = { severity: 'error', messages: { f: 'failed' } };
+            validation.value = { severity: 'error', messages: [{ key: 'f', value: 'failed' }] };
             await wrapper.setProps({ validation: validation.value });
             await nextTick();
             expect(wrapper.find('input').classes()).toContain('severity-error-class');
 
             // And again — error → warning.
-            validation.value = { severity: 'warning', messages: { p: 'pending' } };
+            validation.value = { severity: 'warning', messages: [{ key: 'p', value: 'pending' }] };
             await wrapper.setProps({ validation: validation.value });
             await nextTick();
             expect(wrapper.find('input').classes()).toContain('severity-warning-class');
@@ -580,8 +625,8 @@ describe('VCFormGroup', () => {
             // worth nailing down behaviour.
             const Outer = {
                 template: `
-                    <VCFormGroup :validation="{ severity: 'error', messages: { e: 'outer' } }">
-                        <VCFormGroup :validation="{ severity: 'warning', messages: { w: 'inner' } }">
+                    <VCFormGroup :validation="{ severity: 'error', messages: [{ key: 'e', value: 'outer' }] }">
+                        <VCFormGroup :validation="{ severity: 'warning', messages: [{ key: 'w', value: 'inner' }] }">
                             <VCFormInput />
                         </VCFormGroup>
                     </VCFormGroup>

--- a/packages/forms/test/unit/components.spec.ts
+++ b/packages/forms/test/unit/components.spec.ts
@@ -398,6 +398,105 @@ describe('VCFormGroup', () => {
             expect(wrapper.text()).toBe('help');
         });
     });
+
+    describe('severity context propagation', () => {
+        // Theme with severity variants that paint a unique class on the
+        // input's root — used as a fingerprint to verify the FormGroup's
+        // severity flows down to the input.
+        const severityPreset = {
+            elements: {
+                formInput: {
+                    classes: { root: 'base-input' },
+                    variants: {
+                        severity: {
+                            error: { root: 'severity-error-class' },
+                            warning: { root: 'severity-warning-class' },
+                        },
+                    },
+                },
+            },
+        };
+
+        const buildPlugin = () => ({
+            install: (app: any) => {
+                installThemeManager(app, { themes: [severityPreset] });
+                installDefaultsManager(app);
+            },
+        });
+
+        it('should propagate error severity from FormGroup to child input', () => {
+            const wrapper = mount(VCFormGroup, {
+                props: {
+                    validation: {
+                        severity: 'error',
+                        messages: { required: 'Required' },
+                    },
+                },
+                global: { plugins: [buildPlugin()] },
+                slots: { default: () => h(VCFormInput) },
+            });
+            expect(wrapper.find('input').classes()).toContain('severity-error-class');
+        });
+
+        it('should propagate warning severity from FormGroup to child input', () => {
+            const wrapper = mount(VCFormGroup, {
+                props: {
+                    validation: {
+                        severity: 'warning',
+                        messages: { soft: 'Heads up' },
+                    },
+                },
+                global: { plugins: [buildPlugin()] },
+                slots: { default: () => h(VCFormInput) },
+            });
+            expect(wrapper.find('input').classes()).toContain('severity-warning-class');
+        });
+
+        it('should not apply any severity class when bundle severity is undefined (pristine)', () => {
+            const wrapper = mount(VCFormGroup, {
+                props: {
+                    // No severity — the FieldValidation bundle's "pristine /
+                    // success" state — explicitly `undefined` so the optional
+                    // chain in the input picks up no inherited severity.
+                    validation: { severity: undefined, messages: {} },
+                },
+                global: { plugins: [buildPlugin()] },
+                slots: { default: () => h(VCFormInput) },
+            });
+            const inputClasses = wrapper.find('input').classes();
+            expect(inputClasses).not.toContain('severity-error-class');
+            expect(inputClasses).not.toContain('severity-warning-class');
+        });
+
+        it('should not inherit severity when input is mounted outside a FormGroup', () => {
+            const wrapper = mount(VCFormInput, { global: { plugins: [buildPlugin()] } });
+            const inputClasses = wrapper.find('input').classes();
+            expect(inputClasses).toContain('base-input');
+            expect(inputClasses).not.toContain('severity-error-class');
+            expect(inputClasses).not.toContain('severity-warning-class');
+        });
+
+        it('should let per-instance themeVariant.severity override the inherited one', () => {
+            const wrapper = mount(VCFormGroup, {
+                props: {
+                    validation: {
+                        severity: 'error',
+                        messages: { e: 'parent says error' },
+                    },
+                },
+                global: { plugins: [buildPlugin()] },
+                slots: {
+                    // Per-instance forces 'warning' — should win over the
+                    // FormGroup's 'error' context per the documented
+                    // "per-instance wins" contract.
+                    default: () => h(VCFormInput, { themeVariant: { severity: 'warning' } }),
+                },
+            });
+            const inputClasses = wrapper.find('input').classes();
+            expect(inputClasses).toContain('severity-warning-class');
+            expect(inputClasses).not.toContain('severity-error-class');
+        });
+    });
 });
 
 describe('VCFormInput', () => {

--- a/packages/forms/test/unit/components.spec.ts
+++ b/packages/forms/test/unit/components.spec.ts
@@ -7,7 +7,7 @@ import {
     it,
     vi,
 } from 'vitest';
-import { h, nextTick } from 'vue';
+import { h, nextTick, ref } from 'vue';
 import { mount } from '@vue/test-utils';
 import { installDefaultsManager, installThemeManager } from '@vuecs/core';
 import { default as VCFormCheckbox } from '../../src/components/form-checkbox/FormCheckbox.vue';
@@ -495,6 +495,102 @@ describe('VCFormGroup', () => {
             const inputClasses = wrapper.find('input').classes();
             expect(inputClasses).toContain('severity-warning-class');
             expect(inputClasses).not.toContain('severity-error-class');
+        });
+
+        it('should propagate severity from the legacy :validation-severity prop', () => {
+            // Consumers still on the deprecated pre-bundle API should
+            // see the same context-driven input border colouring as
+            // bundle consumers — the context's getter falls through to
+            // `validationSeverity` when `:validation` is not set.
+            const wrapper = mount(VCFormGroup, {
+                props: {
+                    validationSeverity: 'error',
+                    validationMessages: { required: 'Required' },
+                },
+                global: { plugins: [buildPlugin()] },
+                slots: { default: () => h(VCFormInput) },
+            });
+            expect(wrapper.find('input').classes()).toContain('severity-error-class');
+        });
+
+        it('should forward-compat \'success\' severity even though shipping themes have no class for it today', () => {
+            // The context union includes 'success'. Themes can declare
+            // a `severity.success` variant; the helper plumbs it through.
+            // Light up a custom green class to verify the wiring.
+            const successPreset = {
+                elements: {
+                    formInput: {
+                        classes: { root: 'base-input' },
+                        variants: { severity: { success: { root: 'severity-success-class' } } },
+                    },
+                },
+            };
+            const wrapper = mount(VCFormGroup, {
+                props: { validation: { severity: 'success', messages: { ok: 'looks good' } } },
+                global: {
+                    plugins: [{
+                        install: (app: any) => {
+                            installThemeManager(app, { themes: [successPreset] });
+                            installDefaultsManager(app);
+                        },
+                    }],
+                },
+                slots: { default: () => h(VCFormInput) },
+            });
+            expect(wrapper.find('input').classes()).toContain('severity-success-class');
+        });
+
+        it('should react to FormGroup :validation changes after mount', async () => {
+            // Mounting with a pristine bundle, then mutating the bundle's
+            // severity, should re-render the child input with the new
+            // class — the context's function-valued severity getter
+            // tracks Vue's reactive deps through `useComponentTheme`.
+            const validation = ref<{ severity: 'error' | 'warning' | 'success' | undefined; messages: any } | null>({
+                severity: undefined,
+                messages: {},
+            });
+            const wrapper = mount(VCFormGroup, {
+                props: { validation: validation.value },
+                global: { plugins: [buildPlugin()] },
+                slots: { default: () => h(VCFormInput) },
+            });
+            // Initial state — pristine, no severity class.
+            expect(wrapper.find('input').classes()).not.toContain('severity-error-class');
+            expect(wrapper.find('input').classes()).not.toContain('severity-warning-class');
+
+            // Mutate the bundle in place (the underlying reactive that
+            // `useFieldValidation` produces does this on every $errors
+            // change — verifying the reactive chain).
+            validation.value = { severity: 'error', messages: { f: 'failed' } };
+            await wrapper.setProps({ validation: validation.value });
+            await nextTick();
+            expect(wrapper.find('input').classes()).toContain('severity-error-class');
+
+            // And again — error → warning.
+            validation.value = { severity: 'warning', messages: { p: 'pending' } };
+            await wrapper.setProps({ validation: validation.value });
+            await nextTick();
+            expect(wrapper.find('input').classes()).toContain('severity-warning-class');
+            expect(wrapper.find('input').classes()).not.toContain('severity-error-class');
+        });
+
+        it('should let an inner FormGroup override an outer one (nested groups)', () => {
+            // Stacked `<VCFormGroup>`s — the inner provider wins because
+            // Vue's `provide` shadows the outer key. Unusual layout but
+            // worth nailing down behaviour.
+            const Outer = {
+                template: `
+                    <VCFormGroup :validation="{ severity: 'error', messages: { e: 'outer' } }">
+                        <VCFormGroup :validation="{ severity: 'warning', messages: { w: 'inner' } }">
+                            <VCFormInput />
+                        </VCFormGroup>
+                    </VCFormGroup>
+                `,
+                components: { VCFormGroup, VCFormInput },
+            };
+            const wrapper = mount(Outer, { global: { plugins: [buildPlugin()] } });
+            expect(wrapper.find('input').classes()).toContain('severity-warning-class');
+            expect(wrapper.find('input').classes()).not.toContain('severity-error-class');
         });
     });
 });

--- a/themes/bootstrap/src/index.ts
+++ b/themes/bootstrap/src/index.ts
@@ -21,11 +21,22 @@ export default function bootstrapTheme(): Theme {
                 // Bootstrap's `.form-control-{sm,lg}` modifies padding +
                 // font-size on top of `.form-control`. There's no `-md`
                 // class — md IS the default.
+                //
+                // Severity uses Bootstrap's native `.is-invalid` /
+                // `.is-warning`-style helpers — but Bootstrap 5 only
+                // ships `.is-invalid` + `.is-valid`. We map `warning` →
+                // `.is-invalid` (close-enough red) and leave a comment;
+                // BS doesn't really have a soft-severity slot. Consumers
+                // wanting a true amber state can override.
                 variants: {
                     size: {
                         sm: { root: 'form-control-sm', group: 'input-group-sm' },
                         md: { root: '' },
                         lg: { root: 'form-control-lg', group: 'input-group-lg' },
+                    },
+                    severity: {
+                        error: { root: 'is-invalid' },
+                        warning: { root: 'is-invalid' },
                     },
                 },
                 defaultVariants: { size: 'md' },
@@ -99,6 +110,10 @@ export default function bootstrapTheme(): Theme {
                         md: { trigger: '' },
                         lg: { trigger: 'form-control-lg' },
                     },
+                    severity: {
+                        error: { trigger: 'is-invalid' },
+                        warning: { trigger: 'is-invalid' },
+                    },
                 },
                 defaultVariants: { size: 'md' },
             },
@@ -119,6 +134,12 @@ export default function bootstrapTheme(): Theme {
                     selected: 'd-flex flex-wrap gap-1 mt-2',
                     selectedItem: 'badge bg-secondary-subtle text-body border d-inline-flex align-items-center gap-1',
                     selectedItemRemove: 'fw-bold',
+                },
+                variants: {
+                    severity: {
+                        error: { input: 'is-invalid' },
+                        warning: { input: 'is-invalid' },
+                    },
                 },
             },
             formRadio: {
@@ -173,18 +194,22 @@ export default function bootstrapTheme(): Theme {
                 variants: {
                     size: {
                         sm: {
-                            root: 'input-group-sm', 
-                            input: 'form-control-sm', 
-                            decrement: 'btn-sm', 
-                            increment: 'btn-sm', 
+                            root: 'input-group-sm',
+                            input: 'form-control-sm',
+                            decrement: 'btn-sm',
+                            increment: 'btn-sm',
                         },
                         md: { root: '' },
                         lg: {
-                            root: 'input-group-lg', 
-                            input: 'form-control-lg', 
-                            decrement: 'btn-lg', 
-                            increment: 'btn-lg', 
+                            root: 'input-group-lg',
+                            input: 'form-control-lg',
+                            decrement: 'btn-lg',
+                            increment: 'btn-lg',
                         },
+                    },
+                    severity: {
+                        error: { input: 'is-invalid' },
+                        warning: { input: 'is-invalid' },
                     },
                 },
                 defaultVariants: { size: 'md' },
@@ -206,6 +231,10 @@ export default function bootstrapTheme(): Theme {
                         sm: { root: 'form-control-sm p-1', item: 'small' },
                         md: { root: '' },
                         lg: { root: 'form-control-lg p-3', item: 'fs-6' },
+                    },
+                    severity: {
+                        error: { root: 'is-invalid' },
+                        warning: { root: 'is-invalid' },
                     },
                 },
                 defaultVariants: { size: 'md' },
@@ -282,6 +311,10 @@ export default function bootstrapTheme(): Theme {
                         sm: { root: 'form-control-sm' },
                         md: { root: '' },
                         lg: { root: 'form-control-lg' },
+                    },
+                    severity: {
+                        error: { root: 'is-invalid' },
+                        warning: { root: 'is-invalid' },
                     },
                 },
                 defaultVariants: { size: 'md' },

--- a/themes/bootstrap/src/index.ts
+++ b/themes/bootstrap/src/index.ts
@@ -319,6 +319,20 @@ export default function bootstrapTheme(): Theme {
                 },
                 defaultVariants: { size: 'md' },
             },
+            // Severity-aware per-message colour. Bootstrap's `.text-danger`
+            // / `.text-warning` / `.text-success` utilities are `!important`,
+            // so a single class wins cleanly — no need for a default
+            // colour on `item` (messages stay neutral when no severity).
+            validationGroup: {
+                classes: { item: 'small' },
+                variants: {
+                    severity: {
+                        error: { item: 'text-danger' },
+                        warning: { item: 'text-warning' },
+                        success: { item: 'text-success' },
+                    },
+                },
+            },
             list: {
                 classes: {
                     // `position-relative` anchors `<VCListLoading :overlay>`'s

--- a/themes/bulma/src/index.ts
+++ b/themes/bulma/src/index.ts
@@ -68,11 +68,21 @@ export default function bulmaTheme(): Theme {
                 },
                 // Bulma's `.input` size modifiers are `is-small` / `is-medium` /
                 // `is-large`. `md` is the unmodified default.
+                //
+                // Severity uses Bulma's native `.is-danger` / `.is-warning`
+                // input states — both paint the border + focus shadow in
+                // the matching variant color (`error` → red, `warning` →
+                // amber). Bulma already styles these as a closed set, no
+                // gap-fill needed.
                 variants: {
                     size: {
                         sm: { root: 'is-small' },
                         md: { root: '' },
                         lg: { root: 'is-large' },
+                    },
+                    severity: {
+                        error: { root: 'is-danger' },
+                        warning: { root: 'is-warning' },
                     },
                 },
                 defaultVariants: { size: 'md' },
@@ -84,6 +94,10 @@ export default function bulmaTheme(): Theme {
                         sm: { root: 'is-small' },
                         md: { root: '' },
                         lg: { root: 'is-large' },
+                    },
+                    severity: {
+                        error: { root: 'is-danger' },
+                        warning: { root: 'is-warning' },
                     },
                 },
                 defaultVariants: { size: 'md' },
@@ -176,6 +190,10 @@ export default function bulmaTheme(): Theme {
                         md: { trigger: '' },
                         lg: { trigger: 'is-large' },
                     },
+                    severity: {
+                        error: { trigger: 'is-danger' },
+                        warning: { trigger: 'is-warning' },
+                    },
                 },
                 defaultVariants: { size: 'md' },
             },
@@ -193,6 +211,12 @@ export default function bulmaTheme(): Theme {
                     selected: 'is-flex is-flex-wrap-wrap mt-2',
                     selectedItem: 'tag is-light is-rounded',
                     selectedItemRemove: 'has-text-weight-bold',
+                },
+                variants: {
+                    severity: {
+                        error: { input: 'is-danger' },
+                        warning: { input: 'is-warning' },
+                    },
                 },
             },
             // PinInputInput renders a real `<input>`; `.input` would give it
@@ -238,6 +262,10 @@ export default function bulmaTheme(): Theme {
                             increment: 'is-large',
                         },
                     },
+                    severity: {
+                        error: { input: 'is-danger' },
+                        warning: { input: 'is-warning' },
+                    },
                 },
                 defaultVariants: { size: 'md' },
             },
@@ -257,6 +285,10 @@ export default function bulmaTheme(): Theme {
                         sm: { root: 'is-small', item: 'is-size-7' },
                         md: { root: '' },
                         lg: { root: 'is-large', item: 'is-size-6' },
+                    },
+                    severity: {
+                        error: { root: 'is-danger' },
+                        warning: { root: 'is-warning' },
                     },
                 },
                 defaultVariants: { size: 'md' },

--- a/themes/bulma/src/index.ts
+++ b/themes/bulma/src/index.ts
@@ -355,6 +355,20 @@ export default function bulmaTheme(): Theme {
                     size: 'md',
                 },
             },
+            // Severity-aware per-message colour. Bulma's `.has-text-*`
+            // helpers paint the text colour via HSL channel vars; one
+            // wins cleanly per message, so the base item carries no
+            // colour (messages stay default when no severity is set).
+            validationGroup: {
+                classes: { item: 'is-size-7' },
+                variants: {
+                    severity: {
+                        error: { item: 'has-text-danger' },
+                        warning: { item: 'has-text-warning' },
+                        success: { item: 'has-text-success' },
+                    },
+                },
+            },
             list: {
                 classes: {
                     // `is-relative` anchors `<VCListLoading :overlay>`'s

--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -387,7 +387,23 @@ export default function tailwindTheme(): Theme {
                 },
                 defaultVariants: { size: 'md' },
             },
-            validationGroup: { classes: { item: 'text-xs text-error-600' } },
+            validationGroup: {
+                classes: { item: 'text-xs text-error-600' },
+                // Severity-aware per-message colour. The base class
+                // sets `text-error-600` as the no-severity default
+                // (back-compat with consumers who used legacy
+                // `validationMessages` without a severity). The
+                // variant overrides per active severity — `tailwind-merge`
+                // dedupes the conflicting `text-*-600` classes (last
+                // colour wins).
+                variants: {
+                    severity: {
+                        error: { item: 'text-error-600' },
+                        warning: { item: 'text-warning-600' },
+                        success: { item: 'text-success-600' },
+                    },
+                },
+            },
             list: {
                 classes: {
                     // `relative` anchors `<VCListLoading :overlay>`'s

--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -92,6 +92,12 @@ export default function tailwindTheme(): Theme {
                 // + font-size for dense forms, `lg` scales up for primary
                 // call-to-action inputs. tailwind-merge dedupes the
                 // overlap with the default `px-3 py-2 text-sm` chrome.
+                //
+                // Severity axis is folded in from the surrounding
+                // `<VCFormGroup>`'s validation bundle (see
+                // `useFormInputThemeProps` in @vuecs/forms). `error` /
+                // `warning` repaint the border + focus ring; the default
+                // primary-focus chrome is overridden via tailwind-merge.
                 variants: {
                     size: {
                         sm: {
@@ -105,6 +111,10 @@ export default function tailwindTheme(): Theme {
                             groupAppend: 'px-4 text-base',
                             groupPrepend: 'px-4 text-base',
                         },
+                    },
+                    severity: {
+                        error: { root: 'border-error-500 focus:border-error-500 focus:ring-error-500' },
+                        warning: { root: 'border-warning-500 focus:border-warning-500 focus:ring-warning-500' },
                     },
                 },
                 defaultVariants: { size: 'md' },
@@ -172,6 +182,10 @@ export default function tailwindTheme(): Theme {
                         md: { trigger: '' },
                         lg: { trigger: 'vc-form-select-trigger-lg', item: 'py-2 pl-8 text-base!' },
                     },
+                    severity: {
+                        error: { trigger: 'border-error-500 focus:border-error-500 focus:ring-error-500' },
+                        warning: { trigger: 'border-warning-500 focus:border-warning-500 focus:ring-warning-500' },
+                    },
                 },
                 defaultVariants: { size: 'md' },
             },
@@ -187,6 +201,12 @@ export default function tailwindTheme(): Theme {
                     selected: 'mt-2 flex flex-wrap gap-1',
                     selectedItem: 'inline-flex items-center gap-1 rounded-sm border border-border bg-bg-muted px-2 py-0.5 text-xs text-fg hover:bg-bg-elevated',
                     selectedItemRemove: 'font-semibold leading-none text-fg-muted',
+                },
+                variants: {
+                    severity: {
+                        error: { input: 'border-error-500 focus:border-error-500 focus:ring-error-500' },
+                        warning: { input: 'border-warning-500 focus:border-warning-500 focus:ring-warning-500' },
+                    },
                 },
             },
             formRadio: {
@@ -247,6 +267,10 @@ export default function tailwindTheme(): Theme {
                             increment: 'w-10 text-base',
                         },
                     },
+                    severity: {
+                        error: { root: 'border-error-500 focus-within:border-error-500 focus-within:ring-error-500' },
+                        warning: { root: 'border-warning-500 focus-within:border-warning-500 focus-within:ring-warning-500' },
+                    },
                 },
                 defaultVariants: { size: 'md' },
             },
@@ -271,6 +295,10 @@ export default function tailwindTheme(): Theme {
                             item: 'px-2.5! py-1! text-sm!',
                             input: 'text-base!',
                         },
+                    },
+                    severity: {
+                        error: { root: 'border-error-500 focus-within:border-error-500 focus-within:ring-error-500' },
+                        warning: { root: 'border-warning-500 focus-within:border-warning-500 focus-within:ring-warning-500' },
                     },
                 },
                 defaultVariants: { size: 'md' },
@@ -351,6 +379,10 @@ export default function tailwindTheme(): Theme {
                         sm: { root: 'px-2 py-1 text-xs' },
                         md: { root: '' },
                         lg: { root: 'px-4 py-3 text-base' },
+                    },
+                    severity: {
+                        error: { root: 'border-error-500 focus:border-error-500 focus:ring-error-500' },
+                        warning: { root: 'border-warning-500 focus:border-warning-500 focus:ring-warning-500' },
                     },
                 },
                 defaultVariants: { size: 'md' },


### PR DESCRIPTION
When a form field fails validation, the message text below the input turned red/orange via `formGroup.validationError` / `validationWarning` classes, but the input itself stayed neutral. Consumers wanting a matching border had to wire `themeVariant.severity` manually on every input (the validup playground pattern).

This wires it automatically through a Vue context, matching the provideCardContext / provideStepperContext pattern already used in `@vuecs/elements` / `@vuecs/navigation`.

* `<VCFormGroup>` calls `provideFormGroupContext({ severity })` exposing its resolved validation severity. Same precedence as the render-side computation (bundle wins over legacy `validationSeverity` prop).
* `useFormInputThemeProps(props)` helper folds the inherited severity into the input's `themeVariant.severity`. Per-instance values win (explicit `{ severity: undefined }` opts out of inheritance entirely; any other explicit value overrides).
* Every form-input component in `@vuecs/forms` (FormInput, FormTextarea, FormSelect, FormSelectSearch, FormNumber, FormTags, FormCheckbox, FormCheckboxGroup, FormSwitch, FormRadio, FormRadioGroup, FormPin, FormSlider — 13 components) consumes the helper. Outside a FormGroup the helper is a pass-through (no context → no severity).
* All 3 shipping themes declare `severity: { error, warning }` variants on the affected form-input entries:
    - theme-tailwind: `border-error-500 focus:ring-error-500` / matching `warning-*`.
    - theme-bootstrap: `.is-invalid` (BS5 ships no soft-severity utility; both severities map to .is-invalid — override if you need a distinct amber state).
    - theme-bulma: `.is-danger` / `.is-warning` (Bulma's native input states).
* Public API: `provideFormGroupContext` / `useFormGroupContext` / `useFormInputThemeProps` are exported from `@vuecs/forms` so downstream component libraries can build matching variants.
* 5 new unit tests in components.spec.ts (71 passing total) cover error/warning propagation, pristine = no class, standalone input = no inheritance, per-instance override.
* Docs: validation-feedback.md gets a new 'Severity flows down' section with the canonical pattern + per-theme class table + override docs.
* .agents/architecture.md variant catalog updated with the new severity axis on every form input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form inputs now inherit validation severity (error/warning/success/pristine) from parent FormGroup and allow per-instance opt-out.

* **Themes**
  * Bootstrap, Bulma, and Tailwind themes updated to style error/warning/success states for form controls and validation messages.

* **Documentation**
  * Expanded validation-severity guide and clarified nullable modelValue handling for inputs and textareas.

* **Tests**
  * Added tests covering severity propagation and message styling.

* **Examples**
  * Added Form Group (severity) demo route and example component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->