### PR TITLE
fix(forms): stabilize checkbox baseline across indicator mount

### DIFF
--- a/docs/src/components/form-checkbox.md
+++ b/docs/src/components/form-checkbox.md
@@ -77,6 +77,20 @@ Use the named `#label` slot to render the label as markup. The slot receives `cl
 </VCFormCheckbox>
 ```
 
+## Default glyph (checkmark / indeterminate dash)
+
+A checked box renders a check mark, and `'indeterminate'` renders a dash, **out of the box** — both ship as `currentColor`-painted CSS masks in the structural stylesheet, so no icon package or slot wiring is needed.
+
+::: warning Structural stylesheet required
+The glyph lives in `@vuecs/forms`' structural CSS, not in the theme class strings. If a checked checkbox shows a bare color fill with no check mark, the stylesheet import is missing:
+
+```css
+@import "@vuecs/forms"; /* → dist/style.css */
+```
+
+The same import carries the switch track/thumb structure, slider rails, and the other form structural rules — see [Installation](/getting-started/installation).
+:::
+
 ## Custom indicator (checkmark)
 
 Replace the default checkmark via the `#indicator` slot:

--- a/packages/forms/assets/form-checkbox.css
+++ b/packages/forms/assets/form-checkbox.css
@@ -17,6 +17,11 @@
     display: inline-flex;
     align-items: center;
     gap: 0.5rem;
+    /* Content-independent line-box alignment (#1628). The wrapper's exported
+       baseline derives from its first flex item — the checkbox button, whose
+       own baseline shifts when Reka mounts/unmounts the indicator. `middle`
+       decouples the surrounding line box from that internal change. */
+    vertical-align: middle;
 }
 
 .vc-form-checkbox-label {
@@ -43,6 +48,12 @@
     background-color: var(--vc-color-bg, #fff);
     cursor: pointer;
     transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out;
+    /* An inline-flex box exposes a different baseline when empty vs. when it
+       has content (empty → margin-box edge, non-empty → content baseline).
+       Reka mounts the indicator only while checked/indeterminate, so without
+       this every toggle shifted the surrounding line box by a few pixels
+       (#1628). `middle` makes the alignment content-independent. */
+    vertical-align: middle;
 }
 
 .vc-form-checkbox:hover {


### PR DESCRIPTION
## Summary

Fixes #1628, fixes #1629.

### #1628 — layout jump on toggle

`.vc-form-checkbox` and `.vc-form-checkbox-wrapper` now carry `vertical-align: middle`. An inline-flex box exposes a different baseline when it is empty vs. when it has content (empty → margin-box edge, non-empty → content baseline), and reka-ui mounts the `CheckboxIndicator` only while checked/indeterminate — so every toggle changed the root's baseline contribution and shifted the surrounding line box. `middle` makes the alignment content-independent, exactly as verified downstream in dnpm-dip/portal.

The wrapper needs it too: in labeled usage the wrapper's exported baseline derives from its first flex item (the checkbox button), so fixing only the root would leave the labeled case jumping.

`VCFormRadio` is not affected — its indicator is absolutely positioned (never in-flow), so the root's baseline can't shift. `VCFormSwitch`'s thumb is always mounted.

### #1629 — "no visible glyph"

The default check mark + indeterminate dash already ship since `@vuecs/forms` 5.2.0 as `currentColor`-painted CSS masks in the structural stylesheet (`.vc-form-checkbox-indicator::before`, added in 4f3b0532 and present in the published `dist/style.css`). A checked box that reads as a bare color fill means the consumer is loading the theme class strings but not the structural stylesheet:

```css
@import "@vuecs/forms"; /* → dist/style.css */
```

This PR makes that failure mode self-diagnosing: the FormCheckbox docs page now documents the default glyph and carries a warning callout explaining the bare-fill symptom and the required import.

## Verification

- `npm run build --workspace=packages/forms` — `vertical-align: middle` lands in `dist/style.css`
- `npm run test --workspace=packages/forms` — 82 passed
- docs build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)