### PR TITLE
feat(overlays): first-class closePolicy on VCModalContent

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1752,11 +1752,14 @@ matching `*Portal` so consumers don't have to compose them manually
         Modal.vue           <- DialogRoot wrapper (v-model:open)
         ModalTrigger.vue    <- DialogTrigger
         ModalContent.vue    <- DialogPortal + DialogOverlay + DialogContent
+                               + `closePolicy` prop ('always' | 'no-escape' | 'no-outside' | 'never', #1630):
+                               prevents Reka's escapeKeyDown / interactOutside per policy; raw events
+                               keep firing for per-site conditional guards
         ModalTitle.vue
         ModalDescription.vue
         ModalClose.vue        <- close trigger; slotless OR `icon` prop → theme `closeIcon` (corner-X); otherwise neutral `close`
         theme.ts            <- shared modalThemeDefaults (single source for all parts)
-        types.ts            <- ModalThemeClasses + ThemeElements augmentation
+        types.ts            <- ModalClosePolicy + ModalThemeClasses + ThemeElements augmentation
         use-modal.ts        <- useModal() view-stack composable (issue #1480)
         index.ts
       popover/                <- Popover / Trigger / Content / Arrow / Close (with `icon` prop)

--- a/docs/src/components/modal.md
+++ b/docs/src/components/modal.md
@@ -214,13 +214,40 @@ const showItem = (id: number) => {
 
 `@vuecs/theme-tailwind` ships pre-built styling for every key with light/dark mode and `data-state="open|closed"` animation hooks.
 
+## Non-dismissible modals
+
+By default a modal closes on Escape and on interaction outside the panel (Reka's Dialog behavior). For busy overlays or modals holding in-progress form input, set `closePolicy` on `<VCModalContent>` instead of hand-rolling event guards:
+
+```vue
+<!-- Survives Escape AND outside clicks — only explicit triggers close -->
+<VCModalContent close-policy="never">…</VCModalContent>
+
+<!-- Outside clicks ignored; Escape still closes -->
+<VCModalContent close-policy="no-outside">…</VCModalContent>
+```
+
+| Value | Escape closes | Outside interaction closes |
+|---|---|---|
+| `'always'` (default) | ✅ | ✅ |
+| `'no-escape'` | ❌ | ✅ |
+| `'no-outside'` | ✅ | ❌ |
+| `'never'` | ❌ | ❌ |
+
+Explicit triggers always work regardless of policy — `<VCModalClose>`, the corner-X, and programmatic `v-model:open` writes. The raw Reka events (`@escape-key-down`, `@interact-outside`) keep firing alongside the policy, so per-site conditional logic (e.g. "block dismissal only while saving") remains possible:
+
+```vue
+<VCModalContent @escape-key-down="(e) => saving && e.preventDefault()">
+```
+
+The `ModalClosePolicy` type is exported from `@vuecs/overlays`.
+
 ## Accessibility
 
 The Reka Dialog primitives provide:
 
 - **Focus trap** — focus stays inside `<VCModalContent>` while open and restores to the trigger on close.
 - **Scroll lock** — body scroll is disabled while a modal is open (`modal: true` mode).
-- **Escape key** — closes the modal. Combine with `useModal()`'s `popView()` for view-stack flows by intercepting `update:open` to call `popView` while `hasHistory` is true.
+- **Escape key** — closes the modal (suppressible via [`closePolicy`](#non-dismissible-modals)). Combine with `useModal()`'s `popView()` for view-stack flows by intercepting `update:open` to call `popView` while `hasHistory` is true.
 - **ARIA** — `role="dialog"`, `aria-modal`, `aria-labelledby` (linked to `<VCModalTitle>`), `aria-describedby` (linked to `<VCModalDescription>`).
 
 ## Animations
@@ -279,6 +306,7 @@ Floating dialog panel. Bundles `DialogPortal` + `DialogOverlay` + `DialogContent
 |---|---|---|---|
 | `inline` | `boolean` | `false` | Skip the `DialogPortal` and render where the component sits in the DOM. Useful for testing or custom mounting. |
 | `hideOverlay` | `boolean` | `false` | Skip the backdrop element. |
+| `closePolicy` | `'always' \| 'no-escape' \| 'no-outside' \| 'never'` | `'always'` | Which built-in dismissal interactions are honored — see [Non-dismissible modals](#non-dismissible-modals). |
 | `themeClass` | `Partial<ModalThemeClasses>` | `undefined` | Per-instance theme override. |
 | `themeVariant` | `Record<string, string \| boolean>` | `undefined` | Per-instance variant values. |
 

--- a/packages/overlays/src/components/modal/ModalContent.vue
+++ b/packages/overlays/src/components/modal/ModalContent.vue
@@ -9,13 +9,22 @@ import {
 import { useComponentTheme } from '@vuecs/core';
 import type { ThemeClassesOverride, VariantValues } from '@vuecs/core';
 import { modalThemeDefaults } from './theme';
-import type { ModalThemeClasses } from './types';
+import type { ModalClosePolicy, ModalThemeClasses } from './types';
 
 const modalContentProps = {
     /** Skip the portal and render in-place (testing / custom mounting). Internal — never forwarded to Reka. */
     inline: { type: Boolean, default: false },
     /** Disable the overlay backdrop. Internal — controls our own render branch. */
     hideOverlay: { type: Boolean, default: false },
+    /**
+     * Which built-in dismissal interactions are honored: `'always'`
+     * (Escape + outside interaction close — Reka default), `'no-escape'`,
+     * `'no-outside'`, or `'never'`. Explicit triggers (`<VCModalClose>`,
+     * `v-model:open` writes) always work. Internal — implemented by
+     * preventing Reka's `escapeKeyDown` / `interactOutside`; the raw
+     * events keep firing for advanced per-site handling.
+     */
+    closePolicy: { type: String as PropType<ModalClosePolicy>, default: 'always' },
     /** Per-instance theme override — flat slot key map. */
     themeClass: { type: Object as PropType<ThemeClassesOverride<ModalThemeClasses>>, default: undefined },
     /** Per-instance variant values. */
@@ -36,7 +45,23 @@ export default defineComponent({
                 [h(DialogOverlay, { class: theme.value.overlay || undefined })]),
             h(
                 DialogContent,
-                mergeProps(attrs, { class: theme.value.content || undefined }),
+                mergeProps(attrs, {
+                    class: theme.value.content || undefined,
+                    // Policy handlers merge WITH consumer listeners from
+                    // attrs (mergeProps collects both into an array), so a
+                    // per-site `@escape-key-down` still fires alongside the
+                    // policy — preventDefault() is sticky either way.
+                    onEscapeKeyDown: (event: Event) => {
+                        if (props.closePolicy === 'no-escape' || props.closePolicy === 'never') {
+                            event.preventDefault();
+                        }
+                    },
+                    onInteractOutside: (event: Event) => {
+                        if (props.closePolicy === 'no-outside' || props.closePolicy === 'never') {
+                            event.preventDefault();
+                        }
+                    },
+                }),
                 { default: () => slots.default?.() },
             ),
         ];

--- a/packages/overlays/src/components/modal/types.ts
+++ b/packages/overlays/src/components/modal/types.ts
@@ -1,5 +1,18 @@
 import type { ThemeElementDefinition } from '@vuecs/core';
 
+/**
+ * Dismissal policy for `<VCModalContent>` — which built-in close
+ * interactions are honored. Explicit triggers (`<VCModalClose>`, the
+ * corner-X, programmatic `v-model:open` writes) always work.
+ *
+ * - `always` — Escape and outside interaction both close (Reka default).
+ * - `no-escape` — Escape is ignored; outside interaction still closes.
+ * - `no-outside` — outside interaction is ignored; Escape still closes.
+ * - `never` — neither closes (busy overlays, modals holding in-progress
+ *   form input).
+ */
+export type ModalClosePolicy = 'always' | 'no-escape' | 'no-outside' | 'never';
+
 export type ModalThemeClasses = {
     /** Backdrop / overlay layer behind the dialog content. */
     overlay: string;

--- a/packages/overlays/test/unit/modal.spec.ts
+++ b/packages/overlays/test/unit/modal.spec.ts
@@ -196,4 +196,60 @@ describe('<VCModalContent> closePolicy', () => {
 
         expect(open.value).toBe(false);
     });
+
+    const pointerDownOutside = async () => {
+        // Reka's DismissableLayer attaches its document-level `pointerdown`
+        // listener via setTimeout(0) after mount — wait one macrotask so the
+        // listener is actually registered before dispatching.
+        await new Promise((resolve) => { setTimeout(resolve, 1); });
+        document.body.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
+    };
+
+    it('closes on outside pointerdown with the default policy', async () => {
+        const open = ref(true);
+        buildPolicyApp(open);
+        await nextTick();
+        await nextTick();
+
+        await pointerDownOutside();
+        await nextTick();
+
+        expect(open.value).toBe(false);
+    });
+
+    it("keeps open on outside pointerdown with closePolicy 'no-outside'", async () => {
+        const open = ref(true);
+        buildPolicyApp(open, 'no-outside');
+        await nextTick();
+        await nextTick();
+
+        await pointerDownOutside();
+        await nextTick();
+
+        expect(open.value).toBe(true);
+    });
+
+    it("keeps open on outside pointerdown with closePolicy 'never'", async () => {
+        const open = ref(true);
+        buildPolicyApp(open, 'never');
+        await nextTick();
+        await nextTick();
+
+        await pointerDownOutside();
+        await nextTick();
+
+        expect(open.value).toBe(true);
+    });
+
+    it("still closes on Escape with closePolicy 'no-outside'", async () => {
+        const open = ref(true);
+        buildPolicyApp(open, 'no-outside');
+        await nextTick();
+        await nextTick();
+
+        pressEscape();
+        await nextTick();
+
+        expect(open.value).toBe(false);
+    });
 });

--- a/packages/overlays/test/unit/modal.spec.ts
+++ b/packages/overlays/test/unit/modal.spec.ts
@@ -103,3 +103,97 @@ describe('<VCModal>', () => {
         expect(open.value).toBe(true);
     });
 });
+
+describe('<VCModalContent> closePolicy', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    function buildPolicyApp(open = ref(true), closePolicy?: string) {
+        const App = defineComponent({
+            setup() {
+                return () => h(VCModal, {
+                    open: open.value,
+                    'onUpdate:open': (v: boolean) => { open.value = v; },
+                }, {
+                    default: () => [
+                        h(VCModalContent, {
+                            inline: true, 
+                            closePolicy, 
+                            'data-testid': 'content', 
+                        }, {
+                            default: () => [
+                                h(VCModalTitle, () => 'Hello'),
+                                h(VCModalDescription, () => 'Body'),
+                                h(VCModalClose, { 'data-testid': 'close' }, () => 'Close'),
+                            ],
+                        }),
+                    ],
+                });
+            },
+        });
+
+        return mount(App, {
+            global: { plugins: [[vuecsOverlays, {}]] },
+            attachTo: document.body,
+        });
+    }
+
+    const pressEscape = () => {
+        document.dispatchEvent(new KeyboardEvent('keydown', {
+            key: 'Escape',
+            bubbles: true,
+            cancelable: true,
+        }));
+    };
+
+    it('closes on Escape with the default policy', async () => {
+        const open = ref(true);
+        buildPolicyApp(open);
+        await nextTick();
+        await nextTick();
+
+        pressEscape();
+        await nextTick();
+
+        expect(open.value).toBe(false);
+    });
+
+    it("keeps open on Escape with closePolicy 'no-escape'", async () => {
+        const open = ref(true);
+        buildPolicyApp(open, 'no-escape');
+        await nextTick();
+        await nextTick();
+
+        pressEscape();
+        await nextTick();
+
+        expect(open.value).toBe(true);
+    });
+
+    it("keeps open on Escape with closePolicy 'never'", async () => {
+        const open = ref(true);
+        buildPolicyApp(open, 'never');
+        await nextTick();
+        await nextTick();
+
+        pressEscape();
+        await nextTick();
+
+        expect(open.value).toBe(true);
+    });
+
+    it("still closes via VCModalClose with closePolicy 'never'", async () => {
+        const open = ref(true);
+        buildPolicyApp(open, 'never');
+        await nextTick();
+        await nextTick();
+
+        const close = document.body.querySelector<HTMLElement>('[data-testid="close"]');
+        expect(close).not.toBeNull();
+        close!.click();
+        await nextTick();
+
+        expect(open.value).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #1630.

Adds a `closePolicy` prop to `<VCModalContent>` so non-dismissible modals no longer require forwarding raw reka-ui events at every call site:

```vue
<VCModalContent close-policy="never">…</VCModalContent>
```

| Value | Escape closes | Outside interaction closes |
|---|---|---|
| `'always'` (default) | ✅ | ✅ |
| `'no-escape'` | ❌ | ✅ |
| `'no-outside'` | ✅ | ❌ |
| `'never'` | ❌ | ❌ |

## Design notes

- Implemented by preventing Reka's `escapeKeyDown` / `interactOutside` inside the wrapper. The policy handlers are merged WITH consumer listeners via `mergeProps` (both run; `preventDefault()` is sticky), so the raw events stay available for advanced per-site guards like "block dismissal only while saving" — exactly as the issue requested.
- Explicit triggers are unaffected by policy: `<VCModalClose>`, the corner-X, and programmatic `v-model:open` writes always close.
- `ModalClosePolicy` is exported from `@vuecs/overlays` (re-exported through the modal barrel).
- Prop lives on `<VCModalContent>` (not `<VCModal>`) because that's where Reka's dismissal events surface — consistent with the existing `inline` / `hideOverlay` placement.

## Verification

- 4 new unit tests in `modal.spec.ts` (35 total passing): default policy closes on Escape (baseline, proving the suppression tests are meaningful), `no-escape` and `never` keep the modal open, and `VCModalClose` still works under `never`.
- `npm run build --workspace=packages/overlays` + lint clean (0 errors), docs build green.
- Docs: new "Non-dismissible modals" section + props-table row on the Modal page; `.agents/architecture.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `closePolicy` prop to Modal components with four control options (`'always'`, `'no-escape'`, `'no-outside'`, `'never'`) to manage Escape key and outside-click dismissal behavior.

* **Documentation**
  * Added "Non-dismissible modals" section with behavior matrix and usage examples.
  * Extended Modal API documentation with closePolicy prop details.

* **Tests**
  * Added unit tests validating closePolicy behavior across all options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->