### PR TITLE
feat(button): render as link / arbitrary component via `as` prop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ npm run lint:fix       # Auto-fix lint issues
 
 | Package | Description | Version |
 |---------|-------------|---------|
-| `@vuecs/button` | General-purpose button (color/variant/size, loading, icon slots) | 0.0.0 |
+| `@vuecs/button` | General-purpose button (color/variant/size, loading, icon slots) + polymorphic `:as` (string tag or component — render as `RouterLink` / `NuxtLink` for button-styled links; deprecated `tag` alias) | 0.0.0 |
 | `@vuecs/core` | Theme system, global behavioral defaults, utilities, component infrastructure. Also exports `VCPrimitive` (ported `as` / `asChild` building block) + `usePrimitiveElement` so downstream component libraries don't need a direct `reka-ui` dep (plan 034). | 2.0.0 |
 | `@vuecs/countdown` | Countdown/timer component | 1.0.1 |
 | `@vuecs/design` | CSS design tokens (concrete OKLCH defaults from Tailwind v4's palette + semantic aliases) + motion primitives (vanilla-CSS port of `tw-animate-css`) + theme-agnostic `useColorMode` + theme-aware `useColorPalette` (dispatches through installed themes' `palette.handle` hooks) + canonical `ColorPaletteConfig` type + generic palette primitives (`applyColorPaletteCss`, `bindColorPalette<T>`, `COLOR_PALETTE_STYLE_ELEMENT_ID`) for any theme to compose. No Tailwind dep — works standalone with BS/Bulma/no theme. (plan 017, plan 026) | 0.0.0 |

--- a/docs/src/components/button.md
+++ b/docs/src/components/button.md
@@ -85,8 +85,9 @@ const submit = useSubmitButton({ isEditing: () => isEditing.value });
 | `color` | `'primary' \| 'neutral' \| 'success' \| 'warning' \| 'error' \| 'info'` | (theme default) | Semantic color — themes map it onto their palette. Tailwind theme defaults to `primary`. |
 | `variant` | `'solid' \| 'soft' \| 'outline' \| 'ghost' \| 'link'` | (theme default) | Visual treatment. Tailwind theme defaults to `solid`. |
 | `size` | `'sm' \| 'md' \| 'lg'` | (theme default) | Padding / font-size. Tailwind theme defaults to `md`. |
-| `type` | `string` | `'button'` | Forwarded as the native `type` attribute when `tag` is `'button'` (use `'submit'` inside `<form>`). |
-| `tag` | `string` | `'button'` | Override the rendered tag — pass `'a'` to render as a link (the component sets `aria-disabled` instead of the no-op `disabled` attribute on non-button tags). |
+| `type` | `string` | `'button'` | Forwarded as the native `type` attribute when the rendered element is `'button'` (use `'submit'` inside `<form>`). |
+| `as` | `string \| Component` | `'button'` | Element or component to render as. Pass `'a'` to render as a link, or a component (`RouterLink` / `NuxtLink`) for a button-styled navigation link. Extra attrs (`to`, `href`, `target`, …) forward to the rendered element; native `type` / `disabled` apply only for `'button'`, other targets get `aria-disabled`. |
+| `tag` | `string \| Component` | — | **Deprecated** — use `as`. Non-breaking alias; takes precedence over `as` when set. |
 | `label` | `string` | — | Inline text. Equivalent to passing the same string as the default slot. |
 | `iconLeft` | `string` | — | Iconify name for a leading icon (e.g. `'lucide:plus'`), resolved through `<VCIcon>`. Skipped when empty / undefined. |
 | `iconRight` | `string` | — | Iconify name for a trailing icon. Same skip behavior as `iconLeft`. |
@@ -148,9 +149,34 @@ app.use(vuecs, {
 The composable's option names, return shape, and defaults key may change in a future minor release. Pin a version if you depend on the exact API.
 :::
 
+## Render as a link / component
+
+Use `:as` to render the button as a different element or component while keeping its theming (color / variant / size). This is the way to build a **button-styled navigation link** without hand-rolling `.btn` classes:
+
+```vue
+<script setup lang="ts">
+import { VCButton } from '@vuecs/button';
+import { RouterLink } from 'vue-router';
+// In Nuxt: const NuxtLink = resolveComponent('NuxtLink');
+</script>
+
+<template>
+    <!-- string tag -->
+    <VCButton as="a" href="/docs" variant="ghost">Docs</VCButton>
+
+    <!-- vue-router / Nuxt link — extra attrs (:to) forward to the component -->
+    <VCButton :as="RouterLink" :to="`/clients/${id}`" color="primary" variant="outline" size="sm">
+        Edit
+    </VCButton>
+</template>
+```
+
+Attributes the button doesn't own (`to`, `href`, `target`, `rel`, …) flow straight through to the rendered element. Native `type` / `disabled` attributes are only emitted when the target resolves to `'button'`; for every other target the button emits `aria-disabled` instead (see the Notes below).
+
 ## Notes
 
-- Setting `tag="a"` renders the button as `<a>`. The structural busy class still applies, but the native `disabled` attribute is a no-op on anchors — guard navigation via your own click handler if you mount the button as a link.
+- Setting `as="a"` (or `:as="RouterLink"` / `:as="NuxtLink"`) renders the button as a link / component. The structural busy class still applies, but the native `disabled` attribute is a no-op on non-button targets — the component emits `aria-disabled="true"` instead, and you should guard navigation via your own click handler if you mount the button as a link.
+- The `tag` prop is **deprecated** in favour of `as` (it remains a non-breaking alias and wins over `as` when both are set).
 - The `loading` prop is also passed as a `themeVariant` (`loading: true`), so themes can target the busy state via a variant if they want a custom look beyond the structural pulse.
 - Themes ship the full color × variant matrix (six colors × five variants). Override individual cells via `app.use(vuecs, { overrides: { elements: { button: { compoundVariants: [...] } } } })` if you need a different shade.
 - The `loading` state replaces the leading icon with a spinner and lifts opacity above the framework-disabled value so loading reads distinctly from disabled (the busy class otherwise inherits the framework's `disabled:opacity-*` and the two states would render identically).

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -11,7 +11,7 @@
 - 🎛️ **Variant matrix** — `variant` (`solid` / `outline` / `soft` / `ghost` / `link`) × `color` (`primary` / `neutral` / `success` / `warning` / `error` / `info`) × `size` (`sm` / `md` / `lg`), resolved through the vuecs variant system.
 - ⏳ **Loading state** — `:loading` disables interaction and exposes `{ loading, disabled }` to the default slot for spinners or custom feedback.
 - 🖼️ **Icon support** — `icon-left` / `icon-right` Iconify-name props (rendered via `<VCIcon>`) plus leading/trailing slots for full control.
-- 🔗 **Polymorphic** — render as `button`, `a`, or any tag via `:tag`; native `type` forwarding for forms.
+- 🔗 **Polymorphic** — render as `button`, `a`, any tag, or a component (`RouterLink` / `NuxtLink`) via `:as`; native `type` forwarding for forms, `aria-disabled` for non-button targets.
 - 📝 **`useSubmitButton()` companion** — `@vuecs/forms` ships an experimental composable that drives create/update submit buttons (text, icon, color) from global behavioral defaults.
 
 ## 📦 Installation
@@ -28,7 +28,12 @@ npm install @vuecs/button
 </VCButton>
 
 <VCButton variant="outline" color="error" size="sm">Delete</VCButton>
-<VCButton variant="ghost" tag="a" href="/docs">Docs</VCButton>
+<VCButton variant="ghost" as="a" href="/docs">Docs</VCButton>
+
+<!-- button-styled router link -->
+<VCButton :as="RouterLink" :to="`/clients/${id}`" color="primary" variant="outline" size="sm">
+    Edit
+</VCButton>
 ```
 
 ## 📚 Documentation

--- a/packages/button/assets/index.css
+++ b/packages/button/assets/index.css
@@ -19,7 +19,7 @@
  * pointer events on `<button>`, which would normally defeat `cursor: wait`.
  * Browsers honor the cursor on disabled controls anyway when the button
  * itself is the hover target, which is what we want here. Anchors
- * (`tag="a"`) ignore `disabled` — consumers rendering a button-as-link
+ * (`as="a"`) ignore `disabled` — consumers rendering a button-as-link
  * must guard navigation themselves.
  */
 .vc-button--busy {

--- a/packages/button/src/component.ts
+++ b/packages/button/src/component.ts
@@ -8,6 +8,7 @@ import type {
 } from '@vuecs/core';
 import { VCIcon } from '@vuecs/icon';
 import type {
+    Component,
     ExtractPublicPropTypes,
     PropType,
     SlotsType,
@@ -46,7 +47,20 @@ const buttonProps = {
     variant: { type: String as PropType<ButtonVariant>, default: undefined },
     size: { type: String as PropType<ButtonSize>, default: undefined },
     type: { type: String, default: 'button' },
-    tag: { type: String, default: 'button' },
+    /**
+     * Element or component to render as. Pass a string tag (`'a'`, `'div'`)
+     * or a component (`RouterLink` / `NuxtLink`) to render a button-styled
+     * link / arbitrary element. Native `type` / `disabled` semantics apply
+     * only when this resolves to `'button'`; every other target receives
+     * `aria-disabled` instead. Extra attrs (`to`, `href`, `target`, …)
+     * forward to the rendered element.
+     */
+    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
+    /**
+     * @deprecated Use `as` instead. Retained as a non-breaking alias — when
+     * set it takes precedence over `as`.
+     */
+    tag: { type: [String, Object] as PropType<string | Component>, default: undefined },
     label: { type: String, default: undefined },
     iconLeft: { type: String, default: undefined },
     iconRight: { type: String, default: undefined },
@@ -154,10 +168,14 @@ export const VCButton = defineComponent({
                 ]));
             }
 
-            const isNativeButton = props.tag === 'button';
+            // `tag` is the deprecated alias — when explicitly set it wins
+            // over `as`; otherwise `as` (default `'button'`) drives the
+            // render target. A string tag or a component both resolve here.
+            const renderAs = props.tag ?? props.as;
+            const isNativeButton = renderAs === 'button';
 
             return h(
-                props.tag,
+                renderAs,
                 mergeProps({
                     class: [
                         resolved.root || undefined,


### PR DESCRIPTION
## Summary

Closes #1641.

`<VCButton>` could previously only render as a native intrinsic element (`tag: string`, `h(props.tag, …)`), so a component like `RouterLink` / `NuxtLink` couldn't be used — blocking button-styled navigation links.

This adds an `as` (`string | Component`) prop following the established vuecs render-as convention (`@vuecs/elements`, `@vuecs/navigation`, `@vuecs/overlays`, `@vuecs/table`):

```vue
<VCButton :as="NuxtLink" :to="`/clients/${row.id}`" color="primary" variant="outline" size="sm">
  <VCIcon name="fa6-solid:bars" />
</VCButton>
```

## Changes

- **`as`** (`string | Component`, default `'button'`) — element/component to render as. Native `type` / `disabled` are emitted only when the target resolves to `'button'`; every other target gets `aria-disabled`. Extra attrs (`to`, `href`, `target`, …) forward through `mergeProps(..., attrs)`.
- **`tag`** kept as a `@deprecated`, non-breaking alias — when explicitly set it wins over `as` (`renderAs = props.tag ?? props.as`), so existing `tag="a"` call sites keep working unchanged.
- `asChild` intentionally **not** added: `<VCButton>` builds its own multi-child internal structure (leading / label / trailing / spinner), which conflicts with `asChild`'s single-child contract. `as` is the clean fit.

## Docs

- `docs/src/components/button.md` — props table (`as` added, `tag` deprecated), new "Render as a link / component" section, updated Notes.
- `packages/button/README.md` — polymorphic bullet + router-link example.
- `packages/button/assets/index.css` — comment `tag="a"` → `as="a"`.
- `AGENTS.md` — button row notes polymorphic `:as`.

## Verification

- `npm run build --workspace=packages/button` ✅ (JS bundle + `vue-tsc` declarations; `.d.ts` exposes both `as` and deprecated `tag` as `PropType<string | Component>`)
- `eslint packages/button/src` ✅ zero errors

## Follow-up

#1642 tracks aligning the remaining `tag`-only components (countdown, badge, pagination, placeholder, table, list) onto the same `as` convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `as` prop to the button component for polymorphic rendering (supports native tags and components like RouterLink/NuxtLink).
  * Improved native attribute handling: `type` and `disabled` apply only when rendering as a button; `aria-disabled` used for other targets.

* **Documentation**
  * Updated component documentation and README with new usage examples and prop references.
  * Deprecated `tag` prop in favor of `as`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->