### PR TITLE
refactor: standardize polymorphic `as` render-target convention

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -343,7 +343,9 @@ const badgeProps = {
     color: { type: String as PropType<BadgeColor>, default: undefined },
     variant: { type: String as PropType<BadgeVariant>, default: undefined },
     size: { type: String as PropType<BadgeSize>, default: undefined },
-    tag: { type: String, default: 'span' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'span' },
+    // `tag` kept as a deprecated alias (wins over `as` when set) — see #1642.
+    tag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
     ...themableProps<BadgeThemeClasses>(),
 };
 
@@ -357,7 +359,7 @@ export default defineComponent({
             useThemeProps(props, 'color', 'variant', 'size'),
             badgeThemeDefaults,
         );
-        return () => h(props.tag, mergeProps(attrs, { class: theme.value.root }), slots.default?.());
+        return () => h(props.tag ?? props.as, mergeProps(attrs, { class: theme.value.root }), slots.default?.());
     },
 });
 ```

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -83,16 +83,26 @@ setup(props, { attrs }) {
    add a `Vuecs convention:` note in the JSDoc explaining why.
 5. Internal-only props (e.g. `inline` for portal opt-out, `themeClass`)
    keep their concrete defaults and still get JSDoc.
-6. **`as:` declarations widen to `[String, Object]`** — match
-   `VCPrimitive` / Reka's `Primitive`:
+6. **`as:` / `tag:` render-target declarations widen to
+   `[String, Object, Function]`** — accept a tag name, a component
+   options object (`RouterLink` / `NuxtLink`), AND a functional
+   component (which is a plain function at runtime):
    ```ts
-   as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+   as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
    ```
-   Single-type `String` rejects component values (e.g. `RouterLink`,
-   `NuxtLink`) at prop validation, silently coercing them to the
-   default. The wider declaration is what the
+   Single-type `String` rejects component values at prop validation,
+   silently coercing them to the default. Omitting `Function` lets the
+   common object-component case through but emits a Vue prop-type
+   warning when a *functional* component is passed — `Component`
+   includes functional components, so the runtime constructor array
+   must list `Function` to match the declared type (#1644). This
+   diverges deliberately from upstream Reka's `Primitive` (which uses
+   `[String, Object]`) — vuecs prefers warning-free functional-component
+   support. The wider declaration is what the
    `/guide/build-themable-component` page teaches; first-party
-   components mirror it.
+   components mirror it. (Applies only to render-target props — route
+   props like `<VCLink>`'s `to`, typed `string | Record<string, any>`,
+   stay `[String, Object]`.)
 
 This convention applies to every Reka-wrapping component across
 `@vuecs/overlays`, `@vuecs/forms`, `@vuecs/elements`, `@vuecs/navigation`

--- a/.agents/references/reka-ui.md
+++ b/.agents/references/reka-ui.md
@@ -172,14 +172,14 @@ Reka's `Slot` *mutates its rendered children array* — it replaces the first no
         :key="..."
     >
         <component
-            :is="itemTag"
+            :is="renderItemAs"
             v-if="item.type === 'page'"
             ...
         >
             <PaginationListItem ... />
         </component>
         <component
-            :is="itemTag"
+            :is="renderItemAs"
             v-else
             ...
         >
@@ -196,7 +196,7 @@ The wrapper component's vnode lineage differs between the `v-if` and `v-else` br
 ```vue
 <RekaPrimitive as-child v-slot="{ items }">
     <component
-        :is="itemTag"
+        :is="renderItemAs"
         v-for="(item, idx) in items"
         :key="..."
         ...
@@ -207,7 +207,7 @@ The wrapper component's vnode lineage differs between the `v-if` and `v-else` br
 </RekaPrimitive>
 ```
 
-One uniform `<component :is="itemTag">` per iteration; the conditional content is *inside* the wrapper. Slot always sees the same first-child shape, Vue's diff is clean.
+One uniform `<component :is="renderItemAs">` per iteration; the conditional content is *inside* the wrapper. Slot always sees the same first-child shape, Vue's diff is clean.
 
 **Rule:** when using `as-child` on a Reka primitive that exposes a multi-item slot, every iteration of your `v-for` must produce the same root vnode type. Conditional rendering belongs *inside* the iteration's root, not at the iteration root level.
 

--- a/docs/src/components/badge.md
+++ b/docs/src/components/badge.md
@@ -56,7 +56,8 @@ const variants = ['solid', 'soft', 'outline'] as const;
 | `color` | `'primary' \| 'neutral' \| 'success' \| 'warning' \| 'error' \| 'info'` | `'neutral'` (theme default) | Semantic color. |
 | `variant` | `'solid' \| 'soft' \| 'outline'` | `'soft'` (theme default) | Visual treatment. |
 | `size` | `'sm' \| 'md' \| 'lg'` | `'md'` (theme default) | Badge size. |
-| `tag` | `string` | `'span'` | HTML tag to render. |
+| `as` | `string \| Component` | `'span'` | Element or component to render as (string tag or `RouterLink` / `NuxtLink`). |
+| `tag` | `string \| Component` | — | **Deprecated** — use `as`. Non-breaking alias; takes precedence over `as` when set. |
 | `themeClass` | `Partial<BadgeThemeClasses>` | `undefined` | Per-instance theme override. |
 | `themeVariant` | `Record<string, string \| boolean>` | `undefined` | Per-instance variant values. |
 

--- a/docs/src/components/countdown.md
+++ b/docs/src/components/countdown.md
@@ -55,7 +55,8 @@ const time = 3600 * 1000;
 | `emitEvents` | `boolean` | `true` | Emit the `start` / `progress` / `abort` / `end` events (set `false` to silence them) |
 | `interval` | `number` | `1000` | Update interval in milliseconds between `progress` ticks |
 | `now` | `() => number` | `() => Date.now()` | Returns the current timestamp — used to compute the end time and to re-sync after the tab regains visibility |
-| `tag` | `string` | `'span'` | HTML tag to render |
+| `as` | `string \| Component` | `'span'` | Element or component to render as (string tag or `RouterLink` / `NuxtLink`). |
+| `tag` | `string \| Component` | — | **Deprecated** — use `as`. Non-breaking alias; takes precedence over `as` when set. |
 | `themeClass` | `Partial<CountdownThemeClasses>` | `undefined` | Per-instance theme override |
 | `themeVariant` | `Record<string, string \| boolean>` | `undefined` | Per-instance variant values |
 

--- a/docs/src/components/list.md
+++ b/docs/src/components/list.md
@@ -388,7 +388,8 @@ for this row.
 | `busy` | `boolean` | `false` | Loading flag (used when `state` is omitted). |
 | `total` | `number` | `data.length` | Server-side total (used when `state` is omitted). |
 | `meta` | `Record<string, unknown>` | — | Verbatim metadata bag (used when `state` is omitted; snapshot at setup). |
-| `tag` | `string` | `'div'` | Outer container element. |
+| `as` | `string \| Component` | `'div'` | Outer container element or component to render as. |
+| `tag` | `string \| Component` | — | **Deprecated** — use `as`. Non-breaking alias; wins over `as` when set. |
 | `selectionMode` | `'single' \| 'multi' \| undefined` | `undefined` | Opt into listbox semantics + selection. |
 | `selection` (v-model) | `SelectionKey[] \| SelectionKey \| null` | `null` | Selected keys; bound via `v-model:selection`. |
 | `themeClass` | `ThemeClassesOverride<ListThemeClasses>` | — | Slot class overrides. |
@@ -398,7 +399,8 @@ for this row.
 
 | Prop | Type | Default |
 |------|------|---------|
-| `tag` | `string` | `'ul'` |
+| `as` | `string \| Component` | `'ul'` |
+| `tag` | `string \| Component` | — (**deprecated** — use `as`; wins when set) |
 | `asChild` | `boolean` | `false` |
 | `themeClass` | `ThemeClassesOverride<ListBodyThemeClasses>` | — |
 | `themeVariant` | `VariantValues` | — |
@@ -412,7 +414,8 @@ for this row.
 | `selectable` | `boolean` | `false` | Row participates in selection. |
 | `disabled` | `boolean` | `false` | Disable interaction. |
 | `active` | `boolean \| 'page' \| 'step' \| 'location' \| 'date' \| 'time'` | `false` | Mark row as current (`aria-current`). |
-| `tag` | `string` | `'li'` | Row element. |
+| `as` | `string \| Component` | `'li'` | Row element or component to render as. |
+| `tag` | `string \| Component` | — | **Deprecated** — use `as`. Non-breaking alias; wins over `as` when set. |
 | `asChild` | `boolean` | `false` | Clone the default slot's single vnode instead of emitting a wrapper. |
 | `themeClass` | `ThemeClassesOverride<ListItemThemeClasses>` | — | |
 | `themeVariant` | `VariantValues` | — | |
@@ -421,7 +424,8 @@ for this row.
 
 | Prop | Type | Default |
 |------|------|---------|
-| `tag` | `string` | `'div'` |
+| `as` | `string \| Component` | `'div'` |
+| `tag` | `string \| Component` | — (**deprecated** — use `as`; wins when set) |
 | `asChild` | `boolean` | `false` |
 | `themeClass` | `ThemeClassesOverride<ListEmptyThemeClasses>` | — |
 | `themeVariant` | `VariantValues` | — |
@@ -430,7 +434,8 @@ for this row.
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `tag` | `string` | `'div'` | |
+| `as` | `string \| Component` | `'div'` | Wrapper element or component to render as. |
+| `tag` | `string \| Component` | — | **Deprecated** — use `as`. Non-breaking alias; wins over `as` when set. |
 | `overlay` | `boolean` | `false` | Refresh-feedback mode — shows whenever `busy`, regardless of data presence. Theme overlay variant activates. |
 | `asChild` | `boolean` | `false` | |
 | `themeClass` | `ThemeClassesOverride<ListLoadingThemeClasses>` | — | |

--- a/docs/src/components/pagination.md
+++ b/docs/src/components/pagination.md
@@ -128,8 +128,10 @@ Pass `''` to a single label prop (e.g. `:prev-label="''"`) to suppress that one 
 | `withText` | `boolean` | `false` | When `true`, forces the resolved label string (First / Previous / Next / Last) to render as visible text next to each edge button. When `false` (default), edge buttons are icon-only **if an icon resolves** for that button; otherwise the label string is rendered as a fallback so the button isn't empty. |
 | `siblingCount` | `number` | `1` | Number of sibling page items shown on either side of the current page; forwarded to Reka `siblingCount`. |
 | `showEdges` | `boolean` | `true` | Render First/Last edge buttons; forwarded to Reka `showEdges`. |
-| `tag` | `string` | `'ul'` | Root element tag |
-| `itemTag` | `string` | `'li'` | Item wrapper tag |
+| `as` | `string \| Component` | `'ul'` | Root element or component to render as. |
+| `itemAs` | `string \| Component` | `'li'` | Per-item element or component to render as. |
+| `tag` | `string \| Component` | — | **Deprecated** — use `as`. Non-breaking alias; takes precedence over `as` when set. |
+| `itemTag` | `string \| Component` | — | **Deprecated** — use `itemAs`. Non-breaking alias; takes precedence over `itemAs` when set. |
 | `firstIcon` | `string` | (preset) | Iconify name for the First-page button. `''` suppresses. |
 | `prevIcon` | `string` | (preset) | Iconify name for the Previous-page button. `''` suppresses. |
 | `nextIcon` | `string` | (preset) | Iconify name for the Next-page button. `''` suppresses. |

--- a/docs/src/components/placeholder.md
+++ b/docs/src/components/placeholder.md
@@ -64,7 +64,8 @@ Single animated bar — the building block.
 | `shape` | `'rect' \| 'pill' \| 'circle'` | theme default (`rect`) | Bar shape. `pill` rounds the ends (button / badge skeletons); `circle` forces 1:1 aspect (avatar skeletons — pair with a fixed `:width`). |
 | `animation` | `'wave' \| 'glow' \| 'none'` | `'wave'` | Shimmer animation. `none` disables the animation (e.g. for reduced-motion callers). |
 | `duration` | `string` | `undefined` | Override the shimmer duration (`'500ms'`, `'4s'`). Defaults to the theme's value (typically `2s`). |
-| `tag` | `string` | `'span'` | Element to render as. |
+| `as` | `string \| Component` | `'span'` | Element or component to render as (string tag or `RouterLink` / `NuxtLink`). |
+| `tag` | `string \| Component` | — | **Deprecated** — use `as`. Non-breaking alias; takes precedence over `as` when set. |
 
 ### `<VCPlaceholderWrapper>`
 

--- a/packages/button/src/component.ts
+++ b/packages/button/src/component.ts
@@ -55,12 +55,12 @@ const buttonProps = {
      * `aria-disabled` instead. Extra attrs (`to`, `href`, `target`, …)
      * forward to the rendered element.
      */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'button' },
     /**
      * @deprecated Use `as` instead. Retained as a non-breaking alias — when
      * set it takes precedence over `as`.
      */
-    tag: { type: [String, Object] as PropType<string | Component>, default: undefined },
+    tag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
     label: { type: String, default: undefined },
     iconLeft: { type: String, default: undefined },
     iconRight: { type: String, default: undefined },

--- a/packages/core/src/utils/primitive/Primitive.ts
+++ b/packages/core/src/utils/primitive/Primitive.ts
@@ -33,7 +33,7 @@ export const VCPrimitive = defineComponent({
             default: false,
         },
         as: {
-            type: [String, Object] as PropType<AsTag | Component>,
+            type: [String, Object, Function] as PropType<AsTag | Component>,
             default: 'div',
         },
     },

--- a/packages/countdown/README.md
+++ b/packages/countdown/README.md
@@ -12,7 +12,7 @@
 - ▶️ **Lifecycle events** — `start`, `progress`, `abort`, `end` (opt out via `:emit-events="false"`).
 - 🚀 **Auto-start** — begins on mount by default (`:auto-start`); restart by re-binding `:time`.
 - 🎚️ **Tunable tick** — `:interval` (default 1000 ms) and an injectable `:now` function for deterministic tests.
-- 🏷️ **Polymorphic + themeable** — `:tag` to change the host element; theme via the `countdown` element key.
+- 🏷️ **Polymorphic + themeable** — `:as` to change the host element / component (string tag or `RouterLink` / `NuxtLink`); theme via the `countdown` element key.
 
 ## 📦 Installation
 

--- a/packages/countdown/src/component.ts
+++ b/packages/countdown/src/component.ts
@@ -5,7 +5,12 @@ import type {
     ThemeElementDefinition,
     VariantValues,
 } from '@vuecs/core';
-import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
+import type { 
+    Component, 
+    ExtractPublicPropTypes, 
+    PropType, 
+    SlotsType, 
+} from 'vue';
 import {
     computed,
     defineComponent,
@@ -57,7 +62,16 @@ const countdownProps = {
         validator: (value: number) => value >= 0,
     },
     now: { type: Function as PropType<() => number>, default: () => Date.now() },
-    tag: { type: String, default: 'span' },
+    /**
+     * Element or component to render as. Pass a string tag (`'span'`,
+     * `'div'`) or a component (`RouterLink` / `NuxtLink`).
+     */
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'span' },
+    /**
+     * @deprecated Use `as` instead. Non-breaking alias — takes precedence
+     * over `as` when set.
+     */
+    tag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
     time: {
         type: Number,
         default: 0,
@@ -250,7 +264,7 @@ export const VCCountdown = defineComponent({
             };
 
             return h(
-                props.tag,
+                props.tag ?? props.as,
                 { class: theme.value.root || undefined },
                 slots.default ? slots.default(slotProps) : undefined,
             );

--- a/packages/elements/src/components/alert/Alert.vue
+++ b/packages/elements/src/components/alert/Alert.vue
@@ -44,7 +44,7 @@ const alertProps = {
      */
     role: { type: String, default: undefined },
     /** HTML tag to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     ...themableProps<AlertThemeClasses>(),
 };
 

--- a/packages/elements/src/components/alert/AlertClose.vue
+++ b/packages/elements/src/components/alert/AlertClose.vue
@@ -8,7 +8,7 @@ import type { AlertThemeClasses } from './types';
 
 const alertCloseProps = {
     /** HTML tag to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'button' },
     /**
      * Force the corner-X presentation (reads the theme's `closeIcon` slot).
      * When false (default), the slot-presence heuristic decides:

--- a/packages/elements/src/components/alert/AlertDescription.vue
+++ b/packages/elements/src/components/alert/AlertDescription.vue
@@ -7,7 +7,7 @@ import type { AlertDescriptionThemeClasses } from './types';
 
 const alertDescriptionProps = {
     /** HTML tag to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     ...themableProps<AlertDescriptionThemeClasses>(),
 };
 

--- a/packages/elements/src/components/alert/AlertTitle.vue
+++ b/packages/elements/src/components/alert/AlertTitle.vue
@@ -12,7 +12,7 @@ const alertTitleProps = {
      * Vuecs convention: defaults to `'h4'` (semantically-correct alert
      * heading). Override via `:as` for nested-heading hierarchies.
      */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'h4' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'h4' },
     ...themableProps<AlertTitleThemeClasses>(),
 };
 

--- a/packages/elements/src/components/badge/Badge.vue
+++ b/packages/elements/src/components/badge/Badge.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
 import { badgeThemeDefaults } from './theme';
 import type {
@@ -17,8 +17,16 @@ const badgeProps = {
     variant: { type: String as PropType<BadgeVariant>, default: undefined },
     /** Size variant key — resolved by the active theme. */
     size: { type: String as PropType<BadgeSize>, default: undefined },
-    /** HTML tag to render. */
-    tag: { type: String, default: 'span' },
+    /**
+     * Element or component to render as. Pass a string tag (`'span'`,
+     * `'div'`) or a component (`RouterLink` / `NuxtLink`).
+     */
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'span' },
+    /**
+     * @deprecated Use `as` instead. Non-breaking alias — takes precedence
+     * over `as` when set.
+     */
+    tag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
     ...themableProps<BadgeThemeClasses>(),
 };
 
@@ -35,7 +43,7 @@ export default defineComponent({
             badgeThemeDefaults,
         );
         return () => h(
-            props.tag,
+            props.tag ?? props.as,
             mergeProps(attrs, { class: theme.value.root || undefined }),
             slots.default?.(),
         );

--- a/packages/elements/src/components/card/Card.vue
+++ b/packages/elements/src/components/card/Card.vue
@@ -19,7 +19,7 @@ const cardProps = {
     /** Adds hover / focus styling — useful for link-cards. */
     interactive: { type: Boolean, default: undefined },
     /** HTML tag to render. Use `:as-child` to compose onto an existing component. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     /** Render the consumer's slot child as the card root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<CardThemeClasses>(),

--- a/packages/elements/src/components/card/CardBody.vue
+++ b/packages/elements/src/components/card/CardBody.vue
@@ -13,7 +13,7 @@ import type { CardBodyThemeClasses } from './types';
 
 const cardBodyProps = {
     /** HTML tag to render. Use `:as-child` to compose onto an existing component. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** Theme-class overrides for this component instance. */

--- a/packages/elements/src/components/card/CardDescription.vue
+++ b/packages/elements/src/components/card/CardDescription.vue
@@ -13,7 +13,7 @@ import type { CardDescriptionThemeClasses } from './types';
 
 const cardDescriptionProps = {
     /** HTML tag to render. Use `:as-child` to compose onto an existing component. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'p' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'p' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** Theme-class overrides for this component instance. */

--- a/packages/elements/src/components/card/CardFooter.vue
+++ b/packages/elements/src/components/card/CardFooter.vue
@@ -13,7 +13,7 @@ import type { CardFooterThemeClasses } from './types';
 
 const cardFooterProps = {
     /** HTML tag to render. Use `:as-child` to compose onto an existing component. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'footer' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'footer' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** Theme-class overrides for this component instance. */

--- a/packages/elements/src/components/card/CardHeader.vue
+++ b/packages/elements/src/components/card/CardHeader.vue
@@ -13,7 +13,7 @@ import type { CardHeaderThemeClasses } from './types';
 
 const cardHeaderProps = {
     /** HTML tag to render. Use `:as-child` to compose onto an existing component. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'header' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'header' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** Theme-class overrides for this component instance. */

--- a/packages/elements/src/components/card/CardTitle.vue
+++ b/packages/elements/src/components/card/CardTitle.vue
@@ -13,7 +13,7 @@ import type { CardTitleThemeClasses } from './types';
 
 const cardTitleProps = {
     /** HTML tag to render. Use `:as-child` to compose onto an existing component. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'h3' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'h3' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** Theme-class overrides for this component instance. */

--- a/packages/elements/src/components/collapse/Collapse.vue
+++ b/packages/elements/src/components/collapse/Collapse.vue
@@ -21,7 +21,7 @@ const collapseProps = {
      */
     unmountOnHide: { type: Boolean, default: true },
     /** HTML tag to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<CollapseThemeClasses>(),

--- a/packages/elements/src/components/collapse/CollapseContent.vue
+++ b/packages/elements/src/components/collapse/CollapseContent.vue
@@ -13,7 +13,7 @@ const collapseContentProps = {
      */
     forceMount: { type: Boolean, default: false },
     /** HTML tag to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     /** Render the consumer's slot child as the pane root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<CollapseContentThemeClasses>(),

--- a/packages/elements/src/components/collapse/CollapseTrigger.vue
+++ b/packages/elements/src/components/collapse/CollapseTrigger.vue
@@ -30,7 +30,7 @@ const collapseTriggerProps = {
      */
     chevron: { type: String as PropType<CollapseChevron>, default: undefined },
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'button' },
     /** Render the consumer's slot child as the trigger (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<CollapseTriggerThemeClasses>(),

--- a/packages/elements/src/components/visually-hidden/VisuallyHidden.vue
+++ b/packages/elements/src/components/visually-hidden/VisuallyHidden.vue
@@ -5,7 +5,7 @@ import { VisuallyHidden } from 'reka-ui';
 
 const visuallyHiddenProps = {
     /** HTML tag to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'span' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'span' },
 };
 
 export type VisuallyHiddenProps = ExtractPublicPropTypes<typeof visuallyHiddenProps>;

--- a/packages/list/src/components/list-item/ListItem.vue
+++ b/packages/list/src/components/list-item/ListItem.vue
@@ -10,7 +10,12 @@ import {
     ref,
     watch,
 } from 'vue';
-import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
+import type { 
+    Component, 
+    ExtractPublicPropTypes, 
+    PropType, 
+    SlotsType, 
+} from 'vue';
 import { provideListItemContext, useList } from '../../composables';
 import { applyAsChild } from '../../utils';
 import type { ListItemThemeClasses } from '../../types';
@@ -26,9 +31,15 @@ const listItemProps = {
     /**
      * Row element. Default `'li'` — emits semantic HTML inside `<ul>` /
      * `<ol>` (the `<VCListBody>` parent). Override only for non-list
-     * structural contexts.
+     * structural contexts. Accepts a string tag or a component.
      */
-    tag: { type: String, default: 'li' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'li' },
+
+    /**
+     * @deprecated Use `as` instead. Non-breaking alias — takes precedence
+     * over `as` when set.
+     */
+    tag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
 
     /**
      * Reka-style as-child: render by cloning the slot's first vnode
@@ -316,7 +327,7 @@ export default defineComponent({
                 const cloned = applyAsChild(children, mergedAttrs);
                 if (cloned) return cloned;
             }
-            return h(props.tag, mergedAttrs, children);
+            return h(props.tag ?? props.as, mergedAttrs, children);
         };
     },
 });

--- a/packages/list/src/components/list/List.vue
+++ b/packages/list/src/components/list/List.vue
@@ -9,6 +9,7 @@ import {
     triggerRef,
 } from 'vue';
 import type {
+    Component,
     ExtractPublicPropTypes,
     PropType,
     SlotsType,
@@ -37,9 +38,15 @@ const listProps = {
     /**
      * Outer container element. Default `'div'`. Set `'section'` (+
      * `aria-labelledby`) for landmark semantics; otherwise leave it as
-     * a generic container.
+     * a generic container. Accepts a string tag or a component.
      */
-    tag: { type: String, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
+
+    /**
+     * @deprecated Use `as` instead. Non-breaking alias — takes precedence
+     * over `as` when set.
+     */
+    tag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
 
     /**
      * Selection cardinality. Setting this opts into listbox ARIA
@@ -206,7 +213,7 @@ export default defineComponent({
         });
 
         return () => h(
-            props.tag,
+            props.tag ?? props.as,
             { class: theme.value.root || undefined },
             slots.default?.({ classes: theme.value }),
         );

--- a/packages/list/src/components/list/ListBody.vue
+++ b/packages/list/src/components/list/ListBody.vue
@@ -8,6 +8,7 @@ import {
     h,
 } from 'vue';
 import type {
+    Component,
     ExtractPublicPropTypes,
     PropType,
     SlotsType,
@@ -25,8 +26,14 @@ const listBodyProps = {
     /**
      * Inner list element. Default `'ul'` — emits semantic HTML so screen
      * readers announce "list, N items". Set `'ol'` for ordered lists.
+     * Accepts a string tag or a component.
      */
-    tag: { type: String, default: 'ul' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'ul' },
+    /**
+     * @deprecated Use `as` instead. Non-breaking alias — takes precedence
+     * over `as` when set.
+     */
+    tag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
     /**
      * Reka-style as-child: render by cloning the slot's single root vnode
      * instead of emitting a wrapper. Only honored in manual mode (default
@@ -103,7 +110,7 @@ export default defineComponent({
                     const cloned = applyAsChild(defaultVNodes, { class: rootClass, ...ariaAttrs });
                     if (cloned) return cloned;
                 }
-                return h(props.tag, { class: rootClass, ...ariaAttrs }, defaultVNodes);
+                return h(props.tag ?? props.as, { class: rootClass, ...ariaAttrs }, defaultVNodes);
             }
 
             // Auto-iterate mode: render each row through `#item`.
@@ -119,13 +126,13 @@ export default defineComponent({
                     }
                     return h(Fragment, { key }, result);
                 });
-                return h(props.tag, { class: rootClass, ...ariaAttrs }, rows);
+                return h(props.tag ?? props.as, { class: rootClass, ...ariaAttrs }, rows);
             }
 
             // No slot, no children — render empty wrapper so themes can
             // still target it. Edge case (consumer wrote `<VCListBody />`
             // with no slots).
-            return h(props.tag, { class: rootClass, ...ariaAttrs });
+            return h(props.tag ?? props.as, { class: rootClass, ...ariaAttrs });
         };
     },
 });

--- a/packages/list/src/components/list/ListEmpty.vue
+++ b/packages/list/src/components/list/ListEmpty.vue
@@ -2,7 +2,12 @@
 import { useComponentDefaults, useComponentTheme } from '@vuecs/core';
 import type { ComponentThemeDefinition, ThemeClassesOverride, VariantValues } from '@vuecs/core';
 import { defineComponent, h } from 'vue';
-import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
+import type { 
+    Component, 
+    ExtractPublicPropTypes, 
+    PropType, 
+    SlotsType, 
+} from 'vue';
 import { useList } from '../../composables';
 import { applyAsChild, hasMeaningfulVNodes } from '../../utils';
 import type { ListEmptyDefaults, ListEmptyThemeClasses } from '../../types';
@@ -10,9 +15,15 @@ import type { ListEmptyDefaults, ListEmptyThemeClasses } from '../../types';
 const listEmptyProps = {
     /**
      * Wrapper element. Default `'div'` with `role="status"` so screen
-     * readers announce the empty state when it appears.
+     * readers announce the empty state when it appears. Accepts a string
+     * tag or a component.
      */
-    tag: { type: String, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
+    /**
+     * @deprecated Use `as` instead. Non-breaking alias — takes precedence
+     * over `as` when set.
+     */
+    tag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
     asChild: { type: Boolean, default: false },
     themeClass: { type: Object as PropType<ThemeClassesOverride<ListEmptyThemeClasses>>, default: undefined },
     themeVariant: { type: Object as PropType<VariantValues>, default: undefined },
@@ -70,7 +81,7 @@ export default defineComponent({
                 if (cloned) return cloned;
             }
             const children = hasSlotContent ? slotChildren : [defaults.value.content];
-            return h(props.tag, attrs, children);
+            return h(props.tag ?? props.as, attrs, children);
         };
     },
 });

--- a/packages/list/src/components/list/ListLoading.vue
+++ b/packages/list/src/components/list/ListLoading.vue
@@ -2,7 +2,12 @@
 import { useComponentTheme } from '@vuecs/core';
 import type { ComponentThemeDefinition, ThemeClassesOverride, VariantValues } from '@vuecs/core';
 import { defineComponent, h } from 'vue';
-import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
+import type { 
+    Component, 
+    ExtractPublicPropTypes, 
+    PropType, 
+    SlotsType, 
+} from 'vue';
 import { useList } from '../../composables';
 import { applyAsChild } from '../../utils';
 import type { ListLoadingThemeClasses } from '../../types';
@@ -11,9 +16,14 @@ const listLoadingProps = {
     /**
      * Wrapper element. Default `'div'` with `role="status"` +
      * `aria-live="polite"` so screen readers announce the loading state
-     * when it appears.
+     * when it appears. Accepts a string tag or a component.
      */
-    tag: { type: String, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
+    /**
+     * @deprecated Use `as` instead. Non-breaking alias — takes precedence
+     * over `as` when set.
+     */
+    tag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
     asChild: { type: Boolean, default: false },
     /**
      * Refresh-feedback mode. When `false` (default), shows only on
@@ -89,7 +99,7 @@ export default defineComponent({
                 const cloned = applyAsChild(children, attrs);
                 if (cloned) return cloned;
             }
-            return h(props.tag, attrs, children);
+            return h(props.tag ?? props.as, attrs, children);
         };
     },
 });

--- a/packages/navigation/src/components/item/module.ts
+++ b/packages/navigation/src/components/item/module.ts
@@ -76,7 +76,7 @@ const navItemProps = {
      * collapse mode only.
      */
     as: {
-        type: [String, Object] as PropType<string | Component>,
+        type: [String, Object, Function] as PropType<string | Component>,
         default: 'li',
     },
     /**
@@ -85,7 +85,7 @@ const navItemProps = {
      * Honored in collapse mode only.
      */
     itemsAs: {
-        type: [String, Object] as PropType<string | Component>,
+        type: [String, Object, Function] as PropType<string | Component>,
         default: 'ul',
     },
     themeClass: {

--- a/packages/navigation/src/components/items/module.ts
+++ b/packages/navigation/src/components/items/module.ts
@@ -96,13 +96,13 @@ const navItemsProps = {
      * renders the same container tag. Honored in collapse mode only —
      * dropdown mode keeps Reka's NavigationMenu primitives.
      */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'ul' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'ul' },
     /**
      * The tag (or component) for each item wrapper. Defaults to `'li'`.
      * Forwarded unchanged to every nesting level. Honored in collapse mode
      * only — dropdown mode keeps Reka's NavigationMenu primitives.
      */
-    itemAs: { type: [String, Object] as PropType<string | Component>, default: 'li' },
+    itemAs: { type: [String, Object, Function] as PropType<string | Component>, default: 'li' },
     themeClass: { type: Object as PropType<ThemeClassesOverride<NavigationThemeClasses>>, default: undefined },
     themeVariant: { type: Object as PropType<VariantValues>, default: undefined },
 };

--- a/packages/navigation/src/components/stepper/StepperDescription.vue
+++ b/packages/navigation/src/components/stepper/StepperDescription.vue
@@ -12,7 +12,7 @@ const stepperDescriptionProps = {
     /** Render the consumer's slot child as the description root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** HTML tag to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'p' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'p' },
     /** Theme-class overrides for this component instance. */
     themeClass: { type: Object as PropType<ThemeClassesOverride<StepperThemeClasses>>, default: undefined },
     /** Theme-variant values for this component instance. */

--- a/packages/navigation/src/components/stepper/StepperIndicator.vue
+++ b/packages/navigation/src/components/stepper/StepperIndicator.vue
@@ -12,7 +12,7 @@ const stepperIndicatorProps = {
     /** Render the consumer's slot child as the indicator root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** HTML tag to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     /** Theme-class overrides for this component instance. */
     themeClass: { type: Object as PropType<ThemeClassesOverride<StepperThemeClasses>>, default: undefined },
     /** Theme-variant values for this component instance. */

--- a/packages/navigation/src/components/stepper/StepperSeparator.vue
+++ b/packages/navigation/src/components/stepper/StepperSeparator.vue
@@ -12,7 +12,7 @@ const stepperSeparatorProps = {
     /** Render the consumer's slot child as the separator root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** HTML tag to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     /** Theme-class overrides for this component instance. */
     themeClass: { type: Object as PropType<ThemeClassesOverride<StepperThemeClasses>>, default: undefined },
     /** Theme-variant values for this component instance. */

--- a/packages/navigation/src/components/stepper/StepperTitle.vue
+++ b/packages/navigation/src/components/stepper/StepperTitle.vue
@@ -12,7 +12,7 @@ const stepperTitleProps = {
     /** Render the consumer's slot child as the title root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** HTML tag to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'h4' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'h4' },
     /** Theme-class overrides for this component instance. */
     themeClass: { type: Object as PropType<ThemeClassesOverride<StepperThemeClasses>>, default: undefined },
     /** Theme-variant values for this component instance. */

--- a/packages/navigation/src/components/stepper/StepperTrigger.vue
+++ b/packages/navigation/src/components/stepper/StepperTrigger.vue
@@ -12,7 +12,7 @@ const stepperTriggerProps = {
     /** Render the consumer's slot child as the trigger root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     /** HTML tag to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'button' },
     /** Theme-class overrides for this component instance. */
     themeClass: { type: Object as PropType<ThemeClassesOverride<StepperThemeClasses>>, default: undefined },
     /** Theme-variant values for this component instance. */

--- a/packages/overlays/src/components/context-menu/ContextMenuItem.vue
+++ b/packages/overlays/src/components/context-menu/ContextMenuItem.vue
@@ -9,7 +9,7 @@ import type { ContextMenuThemeClasses } from './types';
 
 const contextMenuItemProps = {
     /** HTML tag (or component) to render as. Reka default: `'div'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** When true, prevents user interaction with the item. */

--- a/packages/overlays/src/components/context-menu/ContextMenuLabel.vue
+++ b/packages/overlays/src/components/context-menu/ContextMenuLabel.vue
@@ -9,7 +9,7 @@ import type { ContextMenuThemeClasses } from './types';
 
 const contextMenuLabelProps = {
     /** HTML tag (or component) to render as. Reka default: `'div'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** Per-instance theme override — flat slot key map. */

--- a/packages/overlays/src/components/context-menu/ContextMenuSubTrigger.vue
+++ b/packages/overlays/src/components/context-menu/ContextMenuSubTrigger.vue
@@ -9,7 +9,7 @@ import type { ContextMenuThemeClasses } from './types';
 
 const contextMenuSubTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'div'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** When true, prevents user interaction with the sub-trigger. */

--- a/packages/overlays/src/components/context-menu/ContextMenuTrigger.vue
+++ b/packages/overlays/src/components/context-menu/ContextMenuTrigger.vue
@@ -9,7 +9,7 @@ import type { ContextMenuThemeClasses } from './types';
 
 const contextMenuTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'span'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'span' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'span' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** When true, the trigger does not open the menu on right-click / press. */

--- a/packages/overlays/src/components/dropdown-menu/DropdownMenuItem.vue
+++ b/packages/overlays/src/components/dropdown-menu/DropdownMenuItem.vue
@@ -9,7 +9,7 @@ import type { DropdownMenuThemeClasses } from './types';
 
 const dropdownMenuItemProps = {
     /** HTML tag (or component) to render as. Reka default: `'div'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** When true, prevents user interaction with the item. */

--- a/packages/overlays/src/components/dropdown-menu/DropdownMenuLabel.vue
+++ b/packages/overlays/src/components/dropdown-menu/DropdownMenuLabel.vue
@@ -9,7 +9,7 @@ import type { DropdownMenuThemeClasses } from './types';
 
 const dropdownMenuLabelProps = {
     /** HTML tag (or component) to render as. Reka default: `'div'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** Per-instance theme override — flat slot key map. */

--- a/packages/overlays/src/components/dropdown-menu/DropdownMenuSubTrigger.vue
+++ b/packages/overlays/src/components/dropdown-menu/DropdownMenuSubTrigger.vue
@@ -9,7 +9,7 @@ import type { DropdownMenuThemeClasses } from './types';
 
 const dropdownMenuSubTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'div'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** When true, prevents user interaction with the sub-trigger. */

--- a/packages/overlays/src/components/dropdown-menu/DropdownMenuTrigger.vue
+++ b/packages/overlays/src/components/dropdown-menu/DropdownMenuTrigger.vue
@@ -9,7 +9,7 @@ import type { DropdownMenuThemeClasses } from './types';
 
 const dropdownMenuTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'button' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** Per-instance theme override — flat slot key map. */

--- a/packages/overlays/src/components/hover-card/HoverCardTrigger.vue
+++ b/packages/overlays/src/components/hover-card/HoverCardTrigger.vue
@@ -9,7 +9,7 @@ import type { HoverCardThemeClasses } from './types';
 
 const hoverCardTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'a'` (hover-card triggers are typically links). */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'a' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'a' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** Per-instance theme override — flat slot key map. */

--- a/packages/overlays/src/components/modal/ModalClose.vue
+++ b/packages/overlays/src/components/modal/ModalClose.vue
@@ -9,7 +9,7 @@ import type { ModalThemeClasses } from './types';
 
 const modalCloseProps = {
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'button' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /**

--- a/packages/overlays/src/components/modal/ModalTrigger.vue
+++ b/packages/overlays/src/components/modal/ModalTrigger.vue
@@ -9,7 +9,7 @@ import type { ModalThemeClasses } from './types';
 
 const modalTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'button' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** Per-instance theme override — flat slot key map. */

--- a/packages/overlays/src/components/popover/PopoverClose.vue
+++ b/packages/overlays/src/components/popover/PopoverClose.vue
@@ -9,7 +9,7 @@ import type { PopoverThemeClasses } from './types';
 
 const popoverCloseProps = {
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'button' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /**

--- a/packages/overlays/src/components/popover/PopoverTrigger.vue
+++ b/packages/overlays/src/components/popover/PopoverTrigger.vue
@@ -9,7 +9,7 @@ import type { PopoverThemeClasses } from './types';
 
 const popoverTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'button' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** Per-instance theme override — flat slot key map. */

--- a/packages/overlays/src/components/toast/Toast.vue
+++ b/packages/overlays/src/components/toast/Toast.vue
@@ -36,7 +36,7 @@ const toastProps = {
     /** Initial open state when `open` is undefined. */
     defaultOpen: { type: Boolean, default: true },
     /** HTML tag to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'li' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'li' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<ToastThemeClasses>(),

--- a/packages/overlays/src/components/toast/ToastAction.vue
+++ b/packages/overlays/src/components/toast/ToastAction.vue
@@ -14,7 +14,7 @@ const toastActionProps = {
      */
     altText: { type: String, required: true },
     /** HTML tag to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'button' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<ToastActionThemeClasses>(),

--- a/packages/overlays/src/components/toast/ToastClose.vue
+++ b/packages/overlays/src/components/toast/ToastClose.vue
@@ -9,7 +9,7 @@ import type { ToastThemeClasses } from './types';
 
 const toastCloseProps = {
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'button' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /**

--- a/packages/overlays/src/components/toast/ToastDescription.vue
+++ b/packages/overlays/src/components/toast/ToastDescription.vue
@@ -14,7 +14,7 @@ const toastDescriptionProps = {
      * `'div'`). `p` is the semantically-correct host for the toast body
      * text — overridable via `:as`.
      */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'p' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'p' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<ToastDescriptionThemeClasses>(),

--- a/packages/overlays/src/components/toast/ToastTitle.vue
+++ b/packages/overlays/src/components/toast/ToastTitle.vue
@@ -14,7 +14,7 @@ const toastTitleProps = {
      * `'div'`). `h3` is the semantically-correct host for an in-context
      * heading within a toast — overridable via `:as`.
      */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'h3' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'h3' },
     /** Render the consumer's slot child as the root (Reka `asChild` pattern). */
     asChild: { type: Boolean, default: false },
     ...themableProps<ToastTitleThemeClasses>(),

--- a/packages/overlays/src/components/toast/Toaster.vue
+++ b/packages/overlays/src/components/toast/Toaster.vue
@@ -48,7 +48,7 @@ const toasterProps = {
     /** Aria label for the viewport landmark. */
     label: { type: String, default: undefined },
     /** HTML tag to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'ol' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'ol' },
     ...themableProps<ToastViewportThemeClasses>(),
 };
 

--- a/packages/overlays/src/components/tooltip/TooltipTrigger.vue
+++ b/packages/overlays/src/components/tooltip/TooltipTrigger.vue
@@ -9,7 +9,7 @@ import type { TooltipThemeClasses } from './types';
 
 const tooltipTriggerProps = {
     /** HTML tag (or component) to render as. Reka default: `'button'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'button' },
     /** Render the slot content as the rendered element instead of wrapping it. */
     asChild: { type: Boolean, default: false },
     /** Per-instance theme override — flat slot key map. */

--- a/packages/pagination/src/component.vue
+++ b/packages/pagination/src/component.vue
@@ -13,7 +13,7 @@ import {
     PaginationRoot,
 } from 'reka-ui';
 import { computed, defineComponent } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import type { PaginationDefaults, PaginationMeta, PaginationThemeClasses } from './type';
 import {
     calculateOffset,
@@ -30,10 +30,14 @@ const paginationProps = {
     offset: { type: Number, default: 0 },
     /** Disable interaction and emission. Vuecs convention: semantic rename of Reka `disabled`. */
     busy: { type: Boolean, default: false },
-    /** Root element tag. Vuecs convention: defaults to `ul` (overrides Reka's `nav`) for list-style markup. */
-    tag: { type: String, default: 'ul' },
-    /** Per-item element tag. Vuecs internal — drives `<component :is>`; no Reka equivalent. */
-    itemTag: { type: String, default: 'li' },
+    /** Root element / component to render as. Vuecs convention: defaults to `ul` (overrides Reka's `nav`) for list-style markup. */
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'ul' },
+    /** Per-item element / component to render as. Drives `<component :is>`; no Reka equivalent. */
+    itemAs: { type: [String, Object, Function] as PropType<string | Component>, default: 'li' },
+    /** @deprecated Use `as` instead. Non-breaking alias — takes precedence over `as` when set. */
+    tag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
+    /** @deprecated Use `itemAs` instead. Non-breaking alias — takes precedence over `itemAs` when set. */
+    itemTag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
     /** Theme slot-class overrides. Vuecs theme concern, never forwarded to Reka. */
     themeClass: { type: Object as PropType<ThemeClassesOverride<PaginationThemeClasses>>, default: undefined },
     /** Theme variant values. Vuecs theme concern, never forwarded to Reka. */
@@ -153,6 +157,11 @@ export default defineComponent({
         const showStartControls = computed(() => !props.hideDisabled || currentPage.value > 1);
         const showEndControls = computed(() => !props.hideDisabled || currentPage.value < pageCount.value);
 
+        // `tag` / `itemTag` are deprecated aliases that win over `as` /
+        // `itemAs` when explicitly set (#1642).
+        const renderAs = computed(() => props.tag ?? props.as);
+        const renderItemAs = computed(() => props.itemTag ?? props.itemAs);
+
         const pageItemClass = (active: boolean): string | undefined => {
             const parts: string[] = [];
             if (theme.value.link) parts.push(theme.value.link);
@@ -188,6 +197,8 @@ export default defineComponent({
             pageItemClass,
             ellipsisClass,
             onPageUpdate,
+            renderAs,
+            renderItemAs,
         };
     },
 });
@@ -195,7 +206,7 @@ export default defineComponent({
 
 <template>
     <PaginationRoot
-        :as="tag"
+        :as="renderAs"
         :total="total"
         :items-per-page="effectiveLimit"
         :sibling-count="siblingCount"
@@ -207,7 +218,7 @@ export default defineComponent({
     >
         <template #default="{ page: rekaPage }">
             <component
-                :is="itemTag"
+                :is="renderItemAs"
                 v-if="showStartControls"
                 :class="theme.item || undefined"
             >
@@ -241,7 +252,7 @@ export default defineComponent({
                 </PaginationFirst>
             </component>
             <component
-                :is="itemTag"
+                :is="renderItemAs"
                 v-if="showStartControls"
                 :class="theme.item || undefined"
             >
@@ -280,7 +291,7 @@ export default defineComponent({
                      even when the visible window shifts); ellipses key by
                      iteration index (no stable identity). -->
                 <component
-                    :is="itemTag"
+                    :is="renderItemAs"
                     v-for="(item, idx) in items"
                     :key="item.type === 'page' ? `p${item.value}` : `e${idx}`"
                     :class="theme.item || undefined"
@@ -303,7 +314,7 @@ export default defineComponent({
                 </component>
             </PaginationList>
             <component
-                :is="itemTag"
+                :is="renderItemAs"
                 v-if="showEndControls"
                 :class="theme.item || undefined"
             >
@@ -322,7 +333,7 @@ export default defineComponent({
                 </PaginationNext>
             </component>
             <component
-                :is="itemTag"
+                :is="renderItemAs"
                 v-if="showEndControls"
                 :class="theme.item || undefined"
             >

--- a/packages/placeholder/src/components/Placeholder.ts
+++ b/packages/placeholder/src/components/Placeholder.ts
@@ -3,10 +3,10 @@ import {
     h, 
     mergeProps,
 } from 'vue';
-import type { ExtractPublicPropTypes, PropType } from 'vue';
+import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
 import {
-    themableProps, 
-    useComponentTheme, 
+    themableProps,
+    useComponentTheme,
     useThemeProps,
 } from '@vuecs/core';
 import { placeholderThemeDefaults } from '../theme';
@@ -46,8 +46,16 @@ const placeholderProps = {
      * the theme.
      */
     duration: { type: String, default: undefined },
-    /** Render-as tag. Defaults to `'span'` (inline-block placeholder bar). */
-    tag: { type: String, default: 'span' },
+    /**
+     * Element or component to render as. Defaults to `'span'` (inline-block
+     * placeholder bar). Pass a string tag or a component.
+     */
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'span' },
+    /**
+     * @deprecated Use `as` instead. Non-breaking alias — takes precedence
+     * over `as` when set.
+     */
+    tag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
     ...themableProps<PlaceholderThemeClasses>(),
 };
 
@@ -98,7 +106,7 @@ export const VCPlaceholder = defineComponent({
             const style: Record<string, string> = { width: widthStyle };
             if (props.duration !== undefined) style.animationDuration = props.duration;
             return h(
-                props.tag,
+                props.tag ?? props.as,
                 mergeProps(attrs, {
                     class: [t.root || undefined, animationClass || undefined],
                     style,

--- a/packages/placeholder/src/components/PlaceholderWrapper.ts
+++ b/packages/placeholder/src/components/PlaceholderWrapper.ts
@@ -3,7 +3,12 @@ import {
     h, 
     mergeProps,
 } from 'vue';
-import type { ExtractPublicPropTypes, SlotsType } from 'vue';
+import type { 
+    Component, 
+    ExtractPublicPropTypes, 
+    PropType, 
+    SlotsType, 
+} from 'vue';
 import {
     themableProps, 
     useComponentTheme, 
@@ -15,8 +20,16 @@ import type { PlaceholderWrapperThemeClasses } from '../types';
 const placeholderWrapperProps = {
     /** When `true`, the `#loading` slot renders; otherwise `#default`. */
     loading: { type: Boolean, default: false },
-    /** Render-as tag. Defaults to `'div'`. */
-    tag: { type: String, default: 'div' },
+    /**
+     * Element or component to render as. Defaults to `'div'`. Pass a string
+     * tag or a component (`RouterLink` / `NuxtLink`).
+     */
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
+    /**
+     * @deprecated Use `as` instead. Non-breaking alias — takes precedence
+     * over `as` when set.
+     */
+    tag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
     ...themableProps<PlaceholderWrapperThemeClasses>(),
 };
 
@@ -57,7 +70,7 @@ export const VCPlaceholderWrapper = defineComponent({
             placeholderWrapperThemeDefaults,
         );
         return () => h(
-            props.tag,
+            props.tag ?? props.as,
             mergeProps(attrs, {
                 class: theme.value.root || undefined,
                 // W3C ARIA "Loading content" pattern: while loading,

--- a/packages/table/src/components/Table.vue
+++ b/packages/table/src/components/Table.vue
@@ -11,7 +11,12 @@ import {
     triggerRef,
     watch,
 } from 'vue';
-import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
+import type { 
+    Component, 
+    ExtractPublicPropTypes, 
+    PropType, 
+    SlotsType, 
+} from 'vue';
 import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
 import {
     provideHeadCellCountContext,
@@ -195,8 +200,16 @@ const tableProps = {
     bordered: { type: Boolean, default: undefined },
     /** Row hover highlight — shorthand for `themeVariant.hover`. */
     hover: { type: Boolean, default: undefined },
-    /** HTML tag to render. */
-    tag: { type: String, default: 'table' },
+    /**
+     * Element or component to render as. Defaults to `'table'`. Pass a
+     * string tag or a component.
+     */
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'table' },
+    /**
+     * @deprecated Use `as` instead. Non-breaking alias — takes precedence
+     * over `as` when set.
+     */
+    tag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
     ...themableProps<TableThemeClasses>(),
 };
 
@@ -619,7 +632,7 @@ export default defineComponent({
                     ...(mode === 'multi' ? { 'aria-multiselectable': 'true' } : {}),
                 };
             const tableNode = h(
-                props.tag,
+                props.tag ?? props.as,
                 mergeProps(attrs, {
                     class: theme.value.root || undefined,
                     'aria-busy': props.busy ? 'true' : undefined,

--- a/packages/table/src/components/TableExpandTrigger.vue
+++ b/packages/table/src/components/TableExpandTrigger.vue
@@ -30,7 +30,7 @@ const tableExpandTriggerProps = {
      */
     chevron: { type: String as PropType<'auto' | 'none'>, default: undefined },
     /** HTML tag (or component) to render as. Default: `'button'`. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'button' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'button' },
     ...themableProps<TableExpandTriggerThemeClasses>(),
 };
 

--- a/packages/table/src/components/TableLite.vue
+++ b/packages/table/src/components/TableLite.vue
@@ -8,7 +8,12 @@ import {
     toRef,
     watch,
 } from 'vue';
-import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
+import type { 
+    Component, 
+    ExtractPublicPropTypes, 
+    PropType, 
+    SlotsType, 
+} from 'vue';
 import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
 import {
     provideHeadCellCountContext,
@@ -75,8 +80,16 @@ const tableLiteProps = {
     bordered: { type: Boolean, default: undefined },
     /** Row hover highlight — shorthand for `themeVariant.hover`. */
     hover: { type: Boolean, default: undefined },
-    /** HTML tag to render. */
-    tag: { type: String, default: 'table' },
+    /**
+     * Element or component to render as. Defaults to `'table'`. Pass a
+     * string tag or a component.
+     */
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'table' },
+    /**
+     * @deprecated Use `as` instead. Non-breaking alias — takes precedence
+     * over `as` when set.
+     */
+    tag: { type: [String, Object, Function] as PropType<string | Component>, default: undefined },
     ...themableProps<TableThemeClasses>(),
 };
 
@@ -233,7 +246,7 @@ export default defineComponent({
             });
 
             const tableNode = h(
-                props.tag,
+                props.tag ?? props.as,
                 mergeProps(attrs, {
                     class: theme.value.root || undefined,
                     'aria-busy': props.busy ? 'true' : undefined,


### PR DESCRIPTION
Closes #1642. Closes #1644.

Standardizes the polymorphic render-as convention across the whole component surface — the follow-ups to #1641's `<VCButton>` work.

## #1644 — `Function` in render-target prop types

`as` / `tag` / `itemAs` props are typed `PropType<string | Component>`, but `Component` includes **functional components** (plain functions at runtime). Under `type: [String, Object]` Vue emits a prop-type warning when a functional component is passed.

- Swept **47** declarations `[String, Object]` → `[String, Object, Function]` across `@vuecs/core` (`VCPrimitive`), `@vuecs/elements`, `@vuecs/navigation`, `@vuecs/overlays`, `@vuecs/table`, `@vuecs/button`.
- **Excluded `<VCLink>`'s `to`** — its `[String, Object]` is a route location (`string | Record<string, any>`), not a render target. (The original issue over-listed `link`; this is the correct scope.)
- Updated `.agents/conventions.md` rule 6 to mandate the wider declaration, with rationale, and noting it deliberately diverges from upstream Reka's `Primitive`.

## #1642 — migrate remaining `tag`-only components to `as`

Added `as` (`string | Component`) + kept `tag` as a `@deprecated`, non-breaking alias that wins when set (`renderAs = props.tag ?? props.as`):

- `@vuecs/countdown` — `<VCCountdown>`
- `@vuecs/elements` — `<VCBadge>`
- `@vuecs/pagination` — `<VCPagination>` (also `itemTag` → `itemAs`, see below)
- `@vuecs/placeholder` — `<VCPlaceholder>`, `<VCPlaceholderWrapper>`
- `@vuecs/table` — `<VCTable>`, `<VCTableLite>`
- `@vuecs/list` — `<VCList>`, `<VCListItem>`, `<VCListBody>`, `<VCListEmpty>`, `<VCListLoading>`

**Pagination** migrates **both** `tag` → `as` and `itemTag` → `itemAs` (deprecated aliases for both) to keep the `as` / `itemAs` family consistent — matching `@vuecs/navigation`. Renaming only `tag` would create an `as` / `itemTag` split.

`@vuecs/forms`' `ValidationGroup` (`tag` / `itemTag`) is intentionally out of scope.

## Non-breaking

Every legacy `tag` / `itemTag` prop is retained as a `@deprecated` alias that takes precedence over `as` / `itemAs` when set, so existing `tag="…"` call sites keep working unchanged.

## Verification

- **Build:** `npm run build` → 28 projects ✓ (includes `vue-tsc` declarations + Nuxt example app)
- **Lint:** `npm run lint` → 0 errors (259 pre-existing warnings only)
- **Tests:** `npm run test` → 14 projects ✓ (incl. `@vuecs/table`'s 169 tests)

Docs updated alongside: component pages (badge, countdown, placeholder, pagination, list), countdown README, and the `.agents/` architecture + reka-ui references.

**65 files, +274/−126.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `as` prop across components for customizing rendered elements and components with enhanced flexibility (supports strings, objects, and functions).
  
* **Deprecations**
  * Deprecated `tag` prop in favor of `as`; `tag` remains functional as a non-breaking alias with precedence when both are provided.

* **Documentation**
  * Updated component documentation to reflect the new `as` prop and document `tag` deprecation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->