### PR TITLE
fix: restore @vuecs/table type build and drop redundant vue override

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,5 @@
         "lint": "eslint",
         "lint:fix": "npm run lint -- --fix",
         "prepare": "husky"
-    },
-    "overrides": {
-        "vue": "^3.5.38"
     }
 }

--- a/packages/table/src/components/Table.vue
+++ b/packages/table/src/components/Table.vue
@@ -481,7 +481,7 @@ export default defineComponent({
             if (!currentIsEmpty) return;
             let finalSeed = seeds;
             if (props.expansionMode === 'single' && seeds.length > 1) {
-                if (process.env.NODE_ENV !== 'production') {
+                if ((globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env?.NODE_ENV !== 'production') {
                     // eslint-disable-next-line no-console
                     console.warn(
                         '[VCTable] :expansion-mode="single" but multiple rows carry _expanded: true — using the first.',

--- a/packages/table/src/components/TableExpandTrigger.vue
+++ b/packages/table/src/components/TableExpandTrigger.vue
@@ -62,7 +62,7 @@ export default defineComponent({
         const expansion = rowCtx?.expansion ?? null;
 
         if (!expansion) {
-            if (process.env.NODE_ENV !== 'production') {
+            if ((globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env?.NODE_ENV !== 'production') {
                 // eslint-disable-next-line no-console
                 console.warn('[VCTableExpandTrigger] mounted outside an expandable <VCTableRow>. Set `expandable` on the row (or `:expandable` on <VCTable>).');
             }

--- a/packages/table/src/utils/auto-render.ts
+++ b/packages/table/src/utils/auto-render.ts
@@ -190,7 +190,7 @@ export function composeTableInner(opts: {
     // is visible — fixing it requires either consumer-side
     // `<VCTableHeadCell aria-hidden>` or switching to auto-header.
     if (
-        process.env.NODE_ENV !== 'production' &&
+        (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env?.NODE_ENV !== 'production' &&
         autoRender && hasHeader && !hasBody && injectTrigger
     ) {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
The table package guarded three dev-warns with bare `process.env.NODE_ENV`, which fails `vue-tsc` (TS2591: Cannot find name 'process') because the build tsconfig surfaces no Node types — and would throw a ReferenceError in browser ESM builds where `process` is not a global. Switch them to the `globalThis`-cast lookup already used in TableSortIndicators.vue / List.vue.

Also remove the root `overrides: { vue: "^3.5.38" }`: 3.5.38 is already vue@latest so the caret pins nothing, and it was committed without regenerating the lockfile, leaving package.json and package-lock.json out of sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential runtime errors in table components when running in environments where `process` is not defined, improving cross-environment compatibility.

* **Chores**
  * Removed Vue dependency override configuration from package dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->