### PR TITLE
fix: build declarations under strict so polymorphic `as`/`tag` prop types survive (#1649)

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -84,25 +84,39 @@ setup(props, { attrs }) {
 5. Internal-only props (e.g. `inline` for portal opt-out, `themeClass`)
    keep their concrete defaults and still get JSDoc.
 6. **`as:` / `tag:` render-target declarations widen to
-   `[String, Object, Function]`** — accept a tag name, a component
-   options object (`RouterLink` / `NuxtLink`), AND a functional
-   component (which is a plain function at runtime):
+   `[String, Object, Function]`:**
    ```ts
    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
    ```
-   Single-type `String` rejects component values at prop validation,
-   silently coercing them to the default. Omitting `Function` lets the
-   common object-component case through but emits a Vue prop-type
-   warning when a *functional* component is passed — `Component`
-   includes functional components, so the runtime constructor array
-   must list `Function` to match the declared type (#1644). This
-   diverges deliberately from upstream Reka's `Primitive` (which uses
-   `[String, Object]`) — vuecs prefers warning-free functional-component
-   support. The wider declaration is what the
-   `/guide/build-themable-component` page teaches; first-party
-   components mirror it. (Applies only to render-target props — route
-   props like `<VCLink>`'s `to`, typed `string | Record<string, any>`,
-   stay `[String, Object]`.)
+   The `[String, Object, Function]` runtime array accepts a tag name, a
+   component options object (`RouterLink` / `NuxtLink`), AND a functional
+   component (a plain function at runtime). Single-type `String` rejects
+   component values at prop validation, silently coercing them to the
+   default. Omitting `Function` lets the common object-component case
+   through but emits a Vue prop-type warning when a *functional*
+   component is passed — `Component` includes functional components, so
+   the runtime constructor array must list `Function` to match the
+   declared type (#1644). This diverges deliberately from upstream Reka's
+   `Primitive` (which uses `[String, Object]`) — vuecs prefers
+   warning-free functional-component support.
+
+   **No cast is needed on the prop entry — but the declaration build must
+   stay strict (#1649).** A polymorphic render-target prop that carries a
+   Vue `default` becomes a key of the generated `DefineComponent`'s
+   `Defaults` type parameter, and `vue-tsc` bakes that `Defaults` literal
+   when emitting declarations. Under **`strict: false`** the bake is lossy
+   — a string-literal default collapses `$props.as` to `string` (dropping
+   the `Component` arm), breaking `<VCButton :as="RouterLink">` in a
+   consumer's `vue-tsc` / `nuxi typecheck` build. Under **`strict: true`**
+   (where `tsconfig.build.json` now sits — it inherits the base
+   `@tada5hi/tsconfig` strictness the dev `tsconfig.json` already uses) the
+   bake keeps the full union: `props.as` types as `string | Component`
+   internally (the default applied) and `$props.as` as
+   `string | Component | undefined` externally. So the plain `{ type, default }`
+   pattern is correct *as long as the build stays strict* — do not flip
+   `tsconfig.build.json` back to `strict: false`. (Applies only to
+   render-target props — route props like `<VCLink>`'s `to`, typed
+   `string | Record<string, any>`, stay `[String, Object]`.)
 
 This convention applies to every Reka-wrapping component across
 `@vuecs/overlays`, `@vuecs/forms`, `@vuecs/elements`, `@vuecs/navigation`

--- a/docs/src/guide/build-themable-component.md
+++ b/docs/src/guide/build-themable-component.md
@@ -269,7 +269,7 @@ const myDataTableProps = {
     density: { type: String as PropType<MyDataTableDensity>, default: undefined },
 
     /** HTML tag (e.g. `'section'`) or component (e.g. `RouterLink`) to render. */
-    as: { type: [String, Object] as PropType<string | Component>, default: 'div' },
+    as: { type: [String, Object, Function] as PropType<string | Component>, default: 'div' },
     /** Render the consumer's slot child as the root (asChild pattern). */
     asChild: { type: Boolean, default: false },
 
@@ -335,7 +335,11 @@ Now the consumer can:
 </template>
 ```
 
-The third form passes a Vue component to `as`. `<VCPrimitive>` then renders `h(RouterLink, mergedAttrs, { default: () => <the table chrome> })` — the entire table is wrapped in a `<RouterLink>`, making it clickable. Component-form `as` requires the prop type to accept both strings and components (`type: [String, Object] as PropType<string | Component>`).
+The third form passes a Vue component to `as`. `<VCPrimitive>` then renders `h(RouterLink, mergedAttrs, { default: () => <the table chrome> })` — the entire table is wrapped in a `<RouterLink>`, making it clickable. Component-form `as` requires the prop type to accept both strings and components (`type: [String, Object, Function] as PropType<string | Component>`).
+
+::: tip Build your declarations with `strict: true`
+A polymorphic `as` prop that also declares a Vue `default` becomes a key of the generated component's internal `Defaults` type, and `vue-tsc` bakes that type when emitting `.d.ts`. Under `strict: false` the bake is lossy — `$props.as` collapses to plain `string`, dropping the component arm, so `<MyDataTable :as="RouterLink">` fails to type-check in a consumer's `vue-tsc` / `nuxi typecheck` build. Building declarations with `strict: true` (vuecs's `tsconfig.build.json` does) keeps the full union: `$props.as` stays `string | Component | undefined` and no per-prop cast is needed. See [issue #1649](https://github.com/tada5hi/vuecs/issues/1649).
+:::
 
 `<VCPrimitive>` also accepts an `asChild` prop: instead of rendering its own element, it falls through to the consumer's slot child and merges the wrapper's class + attrs onto it. Two things to know before reaching for it:
 

--- a/packages/core/src/utils/composables/use-emit-as-props.ts
+++ b/packages/core/src/utils/composables/use-emit-as-props.ts
@@ -1,6 +1,10 @@
 import { camelize, getCurrentInstance, toHandlerKey } from 'vue';
 
-type EmitFn = (event: string, ...args: any[]) => void;
+// `(...args: any[]) => void` rather than `(event: string, ...)` so a typed
+// `emit` whose event is a literal union (e.g. `(event: 'update:open', …) => void`,
+// as Vue infers from `emits: ['update:open']`) still satisfies the constraint.
+// A `string` event param would reject it under strict (parameter contravariance).
+type EmitFn = (...args: any[]) => void;
 
 /**
  * Converts a component's declared `emits` array into a map of `onEventName`

--- a/packages/core/src/utils/composables/use-forward-expose.ts
+++ b/packages/core/src/utils/composables/use-forward-expose.ts
@@ -106,7 +106,10 @@ export function useForwardExpose() {
                     get: () => childExposed[key],
                 });
             }
-            instance.exposed = merged;
+            // `instance` is non-null (guarded with a throw at the top of
+            // `useForwardExpose`); the `!` restores that narrowing, which TS
+            // drops inside this closure.
+            instance!.exposed = merged;
         }
     }
 

--- a/packages/core/src/utils/composables/use-forward-props-emits.ts
+++ b/packages/core/src/utils/composables/use-forward-props-emits.ts
@@ -3,7 +3,10 @@ import type { ComputedRef } from 'vue';
 import { useEmitAsProps } from './use-emit-as-props';
 import { useForwardProps } from './use-forward-props';
 
-type EmitFn = (event: string, ...args: any[]) => void;
+// See `use-emit-as-props.ts` — a literal-union event param (Vue's inferred
+// `emit` type) must satisfy this constraint under strict, which `event: string`
+// rejects via parameter contravariance.
+type EmitFn = (...args: any[]) => void;
 
 /**
  * Combines `useForwardProps` and `useEmitAsProps` into one ComputedRef

--- a/packages/elements/src/components/avatar/Avatar.vue
+++ b/packages/elements/src/components/avatar/Avatar.vue
@@ -1,6 +1,11 @@
 <script lang="ts">
 import { defineComponent, h, mergeProps } from 'vue';
-import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
+import type { 
+    ExtractPublicPropTypes, 
+    PropType, 
+    SlotsType, 
+    VNode, 
+} from 'vue';
 import { AvatarFallback, AvatarImage, AvatarRoot } from 'reka-ui';
 import { useComponentTheme } from '@vuecs/core';
 import type {
@@ -74,7 +79,7 @@ export default defineComponent({
         const theme = useComponentTheme('avatar', themeProps, avatarThemeDefaults);
         return () => {
             const resolved = theme.value;
-            const children = [];
+            const children: VNode[] = [];
             if (props.src) {
                 children.push(h(AvatarImage, {
                     src: props.src,

--- a/packages/forms/src/components/form-select-search/FormSelectSearchEntry.vue
+++ b/packages/forms/src/components/form-select-search/FormSelectSearchEntry.vue
@@ -18,9 +18,11 @@ export type FormSelectSearchEntryProps = ExtractPublicPropTypes<typeof formSelec
 export default defineComponent({
     props: formSelectSearchEntryProps,
     setup(props) {
+        // `entry` is `required: true`; the `!` counters the separate-const
+        // props widening to `| undefined` under strict.
         const active = computed(
             () => props.selected &&
-                props.selected.findIndex((el) => el.value === props.entry.value) !== -1,
+                props.selected.findIndex((el) => el.value === props.entry!.value) !== -1,
         );
 
         return { active };
@@ -33,6 +35,6 @@ export default defineComponent({
         :entry="entry"
         :active="active"
     >
-        {{ entry.label }}
+        {{ entry?.label }}
     </slot>
 </template>

--- a/packages/forms/src/components/form-select/FormSelect.vue
+++ b/packages/forms/src/components/form-select/FormSelect.vue
@@ -164,7 +164,9 @@ export default defineComponent({
         const renderItems = (): VNodeChild[] => {
             const classes = theme.value;
             const items: VNodeChild[] = [];
-            for (const item of props.options) {
+            // `options` is `required: true`; the `!` counters the separate-const
+            // props widening to `| undefined` under strict.
+            for (const item of props.options!) {
                 if (isFormOptionGroup(item)) {
                     items.push(renderGroup(item, classes));
                 } else {

--- a/packages/navigation/src/components/item/module.ts
+++ b/packages/navigation/src/components/item/module.ts
@@ -17,7 +17,6 @@ import {
     provide,
     ref,
     resolveComponent,
-    toRef,
     watch,
 } from 'vue';
 import {
@@ -127,7 +126,13 @@ export const VCNavItem = defineComponent({
 
         const theme = useComponentTheme('navigation', themeProps, navigationThemeDefaults);
 
-        const data = toRef(props, 'data');
+        // `data` is `required: true`, so it's always present at runtime. The
+        // non-null assertion is needed because `defineComponent` widens
+        // required props declared via a separate `const` props object to
+        // `| undefined` in `setup` under strict (a Vue/TS inference quirk —
+        // inline prop objects don't exhibit it). Asserting here keeps every
+        // downstream `data.value` read clean instead of scattering `!`.
+        const data = computed(() => props.data!);
         const hasChildren = computed(() => data.value.children &&
             data.value.children.length > 0);
 

--- a/packages/navigation/src/components/stepper/StepperItem.vue
+++ b/packages/navigation/src/components/stepper/StepperItem.vue
@@ -54,7 +54,9 @@ export default defineComponent({
             // child indicators / titles can react to the parent step's
             // state without explicit attribute wiring on every child.
             {
-                step: props.step,
+                // `step` is `required: true`; the `!` counters the
+                // separate-const props widening to `| undefined` under strict.
+                step: props.step!,
                 disabled: props.disabled,
                 completed: props.completed,
                 ...mergeProps(attrs, { class: ['group', theme.value.item || undefined] }),

--- a/packages/overlays/src/components/context-menu/ContextMenuRadioItem.vue
+++ b/packages/overlays/src/components/context-menu/ContextMenuRadioItem.vue
@@ -42,7 +42,9 @@ export default defineComponent({
                     onSelect: (event: Event) => emit('select', event),
                     class: theme.value.radioItem || undefined,
                 }),
-                value: props.value,
+                // `value` is `required: true`; the `!` counters the
+                // separate-const props widening to `| undefined` under strict.
+                value: props.value!,
             },
             { default: () => slots.default?.() },
         );

--- a/packages/overlays/src/components/dropdown-menu/DropdownMenuRadioItem.vue
+++ b/packages/overlays/src/components/dropdown-menu/DropdownMenuRadioItem.vue
@@ -42,7 +42,9 @@ export default defineComponent({
                     onSelect: (event: Event) => emit('select', event),
                     class: theme.value.radioItem || undefined,
                 }),
-                value: props.value,
+                // `value` is `required: true`; the `!` counters the
+                // separate-const props widening to `| undefined` under strict.
+                value: props.value!,
             },
             { default: () => slots.default?.() },
         );

--- a/packages/table/src/utils/auto-render.ts
+++ b/packages/table/src/utils/auto-render.ts
@@ -120,7 +120,7 @@ export function composeTableInner(opts: {
      * typed `defineComponent({ slots: SlotsType<{…}> })` setup
      * argument without TS rejecting the assignment.
      */
-    slots?: Record<string, ((slotProps?: unknown) => unknown) | undefined>;
+    slots?: Record<string, ((...args: any[]) => unknown) | undefined>;
     /**
      * Current sort state. Forwarded to the `#header-<key>` slot props
      * (`sort` field) so consumers can render their own indicator. Only
@@ -301,12 +301,14 @@ export function composeTableInner(opts: {
     if (autoRender && !hasBody) {
         inner.push(h(VCTableBody, null, {
             row: ({ row, index }: { row: unknown; index: number }) => {
-                const rowProps = expandable ? {
-                    row,
-                    index,
-                    expandable: true,
-                    expandableTrigger,
-                } : { row, index };
+                // Flat `Record` (not a `{…} | {…}` union) so vue-tsc's `h()`
+                // overload resolution accepts it — a union props arg trips the
+                // typed-component overload under strict.
+                const rowProps: Record<string, unknown> = { row, index };
+                if (expandable) {
+                    rowProps.expandable = true;
+                    rowProps.expandableTrigger = expandableTrigger;
+                }
                 const rowSlots: Record<string, (slotProps?: unknown) => unknown> = {
                     default: () => cols.map((col) => {
                         const cellProps = {

--- a/packages/timeago/src/component.ts
+++ b/packages/timeago/src/component.ts
@@ -57,7 +57,11 @@ export const VCTimeago = defineComponent({
     setup(props) {
         const theme = useComponentTheme('timeago', props, timeagoThemeDefaults);
 
-        const dateTimeProp = toRef(props, 'datetime');
+        // `datetime` is `required: true`; `computed(() => props.datetime!)`
+        // (not `toRef`) keeps the resolved type non-`undefined` under strict —
+        // `defineComponent` widens required props from a separate `const` props
+        // object to `| undefined` in `setup`.
+        const dateTimeProp = computed(() => props.datetime!);
         const localeProp = toRef(props, 'locale');
         const titleProp = toRef(props, 'title');
         const autoUpdateProp = toRef(props, 'autoUpdate');

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,7 +7,7 @@
         "declaration": true,
         "declarationMap": true,
         "sourceMap": true,
-        "strict": false,
+        "strict": true,
         "noUncheckedIndexedAccess": false,
         "noUnusedLocals": false,
         "noUnusedParameters": false,


### PR DESCRIPTION
## Summary

Fixes #1649. A polymorphic render-target prop (`as` / `tag` / `itemAs` / …) typed `PropType<string | Component>` with a Vue `default` becomes a key of the generated `DefineComponent`'s `Defaults` type parameter. `vue-tsc` bakes that `Defaults` literal when emitting `.d.ts`, and under the build's `strict: false` the bake was **lossy** — `$props.as` collapsed to plain `string` (dropping the `Component` arm), so `<VCButton :as="RouterLink">` failed to type-check in a consumer's `vue-tsc` / `nuxi typecheck` build (even though the public prop type and runtime were correct).

## Approach — fix the root cause

The root cause is the **non-strict declaration build**. The dev `tsconfig.json` already inherits `strict: true` from `@tada5hi/tsconfig`; only `tsconfig.build.json` opted out — so the editor already flagged ~49 latent strict errors while CI's non-strict build hid them.

This PR flips `tsconfig.build.json` to **`strict: true`** so the build matches the editor. Under strict, `vue-tsc` bakes the **full union**: `props.as` is `string | Component` internally (default applied) and `$props.as` is `string | Component | undefined` externally — **with no per-prop cast or helper**. The component prop declarations are unchanged (plain `{ type: [String, Object, Function] as PropType<string | Component>, default: … }`).

> An earlier revision of this PR worked around it per-prop with `as Prop<string | Component>` casts across ~55 components. That was superseded by the strict build — it's the proper root fix, needs no casts, keeps the `default` visible in the emitted types, and aligns build with editor.

## Genuine strict errors fixed (the cost of `strict: true`)

- **core**: loosen `useEmitAsProps` / `useForwardPropsEmits` `EmitFn` to `(...args: any[]) => void` so a typed `emit` (literal-union event) satisfies the constraint (parameter contravariance); guarded non-null assert on `instance` in `useForwardExpose`.
- **navigation / overlays / forms / timeago**: non-null assert `required: true` props that `defineComponent` widens to `| undefined` in `setup` when props are declared via a separate `const` (a Vue/TS inference quirk — inline prop objects don't exhibit it; runtime-guaranteed by `required: true`).
- **elements**: annotate `VCAvatar`'s `children` array as `VNode[]`.
- **table**: loosen `composeTableInner`'s `slots` param to accept strictly-typed slots (contravariance); de-union `rowProps` so `h()` overload resolution accepts it.

## Verification

- **Type** (consumer `strict: true`): `$props.as` / `$props.tag` resolve to `string | Component | undefined` — `Component` assignable, `string` assignable, `symbol` rejected, **not `any`** — verified across Button, Badge, Card, VCPrimitive, NavItems, ModalTrigger, Countdown, Timeago.
- **Runtime** (SSR): unchanged — `<VCButton>`→`<button type="button">`, `:as={Component}`→ component render, `<VCBadge>`→`<span>`, `<VCPrimitive as="section">`→`<section>`.
- **Strict-clean**: every package builds with `strict: true` (0 errors); the whole-repo dev typecheck is also clean (only a pre-existing `baseUrl` deprecation warning).
- Full `npm run build` (28 projects), `npm run lint` (0 errors), `npm run test` (14 projects) all green.

## Notes

- 15 files: `tsconfig.build.json` + 12 targeted source fixes + 2 docs (conventions.md, build-a-themable-component guide).
- Keep `tsconfig.build.json` strict going forward — reverting it would silently reintroduce the `$props` collapse and re-hide the latent errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)