### PR TITLE
feat: add xs size variant beside sm/md/lg

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -214,38 +214,73 @@ unless the variant is structural (e.g. orientation-driven layout).
 
 | Component | Axis | Values | Notes |
 |---|---|---|---|
-| Button | `variant` × `color` × `size` | solid/outline/soft/ghost/link × primary/neutral/success/warning/error/info × sm/md/lg | Full matrix via `compoundVariants` |
-| Badge | `variant` × `color` × `size` | solid/soft/outline × six semantic colors × sm/md/lg | Mirrors button |
+| Button | `variant` × `color` × `size` | solid/outline/soft/ghost/link × primary/neutral/success/warning/error/info × xs/sm/md/lg | Full matrix via `compoundVariants` |
+| Badge | `variant` × `color` × `size` | solid/soft/outline × six semantic colors × xs/sm/md/lg | Mirrors button |
 | Card | `variant` × `interactive` | outline/soft/elevated × boolean | theme-tailwind uses `border + bg-bg` / `bg-bg-muted` / `shadow-md`; theme-bootstrap composes `.card` + `shadow` / `bg-body-tertiary`; theme-bulma uses `.box` + `vc-card-outline` gap-fill |
 | CardHeader / CardBody / CardFooter | `padding` | compact/normal/spacious | Set once on `<VCCard padding="…">` and propagated to bands via `provideCardContext()`; per-band props win over the inherited value |
-| Alert | `variant` × `color` × `size` | solid/soft/outline × neutral/info/success/warning/error × sm/md/lg | 15-cell `compoundVariants` matrix; `<VCAlertClose>` reuses `closeIcon` / `close` slots on the `alert` element (no separate theme key) |
+| Alert | `variant` × `color` × `size` | solid/soft/outline × neutral/info/success/warning/error × xs/sm/md/lg | 15-cell `compoundVariants` matrix; `<VCAlertClose>` reuses `closeIcon` / `close` slots on the `alert` element (no separate theme key) |
 | CollapseTrigger | `chevron` | auto/none | Drives visibility of the auto-rendered chevron icon (Iconify name from `ComponentDefaults['collapseTrigger'].chevronIcon`) |
-| Tag | `size` | sm/md/lg | Matches badge sizing |
-| Avatar | `size` | sm/md/lg | Theme-bootstrap uses `vc-avatar-{sm,lg}` helpers |
-| Pagination | `variant` × `size` | outline/soft/ghost × sm/md/lg | |
+| Tag | `size` | xs/sm/md/lg | Matches badge sizing |
+| Avatar | `size` | xs/sm/md/lg | Theme-bootstrap uses `vc-avatar-{sm,lg}` helpers |
+| Pagination | `variant` × `size` | outline/soft/ghost × xs/sm/md/lg | |
 | Table | `density` × `striped` × `bordered` × `hover` × `stickyHeader` | compact/normal/spacious × boolean × boolean × boolean × boolean | Whole-table chrome; sortable headers driven by per-column `:sortable` |
 | TableRow | `disabled` / `selected` / `focused` / `rowVariant` | boolean × boolean × boolean × success/warning/error/info/neutral/primary | `rowVariant` resolved from `row._rowVariant` (plan 028) |
 | TableCell | `align` / `stickyColumn` / `cellVariant` | left/center/right × boolean × six semantic colors | `cellVariant` resolved from `row._cellVariants[columnKey]` |
 | TableHeadCell | `align` / `stickyColumn` / `sorted` | left/center/right × boolean × asc/desc/none | `sorted` drives the indicator span + `aria-sort` |
 | TableEmpty | `filtered` | boolean | Distinct copy / style for empty-after-filter vs empty-no-data |
 | TableLoading | `overlay` | boolean | In-table band default vs absolute overlay for refresh-feedback |
-| FormInput / FormTextarea / FormSelect / FormNumber / FormTags / FormSelectSearch | `size` × `severity` | sm/md/lg × error/warning | theme-tailwind uses padding+font utilities + `border-error/warning-500` rings; theme-bootstrap uses `form-control-{sm,lg}` (+ `is-invalid` for both severities — BS5 doesn't ship a soft variant); theme-bulma uses `is-small/large` + native `is-danger`/`is-warning`. `severity` is folded in automatically from the surrounding `<VCFormGroup>` via `provideFormGroupContext` — no per-input wiring. |
-| FormCheckbox / FormSwitch / FormRadio | `size` | sm/md/lg | theme-bootstrap uses `vc-form-{checkbox,switch,radio}-{sm,lg}` helpers from @vuecs/forms structural CSS |
-| Modal | `size` | sm/md/lg/xl | theme-tailwind uses `max-w-*`; theme-bootstrap uses `modal-{sm,lg,xl}` |
-| Popover / HoverCard | `size` | sm/md/lg | Width + padding tier |
-| Tooltip | `size` | sm/md/lg | Padding + font-size only |
-| DropdownMenu / ContextMenu | `size` | sm/md/lg | Item padding + min-width |
+| FormInput / FormTextarea / FormSelect / FormNumber / FormTags | `size` × `severity` | xs/sm/md/lg × error/warning | theme-tailwind uses padding+font utilities + `border-error/warning-500` rings; theme-bootstrap uses `form-control-{sm,lg}` (+ `is-invalid` for both severities — BS5 doesn't ship a soft variant); theme-bulma uses `is-small/large` + native `is-danger`/`is-warning`. `severity` is folded in automatically from the surrounding `<VCFormGroup>` via `provideFormGroupContext` — no per-input wiring. |
+| FormSelectSearch | `severity` only | error/warning | No `size` axis (theme entry ships `severity` only) — the search box inherits its sizing from surrounding layout, not a size variant. |
+| FormCheckbox / FormSwitch / FormRadio | `size` | xs/sm/md/lg | theme-bootstrap uses `vc-form-{checkbox,switch,radio}-{sm,lg}` helpers from @vuecs/forms structural CSS |
+| Modal | `size` | xs/sm/md/lg/xl | theme-tailwind uses `max-w-*`; theme-bootstrap uses `modal-{sm,lg,xl}` |
+| Popover / HoverCard | `size` | xs/sm/md/lg | Width + padding tier |
+| Tooltip | `size` | xs/sm/md/lg | Padding + font-size only |
+| DropdownMenu / ContextMenu | `size` | xs/sm/md/lg | Item padding + min-width |
 | Toast | `color` × `variant` | six semantic colors × solid/soft/outline | Mirrors Badge color × variant matrix |
 | ToastViewport | `position` | top-{left,right,center}/bottom-{left,right,center} | Six positions; default `top-right` |
 | List / ListItem | `density` | compact/normal/spacious | Gap + per-row padding |
 | ListItem | `disabled` / `active` / `selected` | boolean | Folded into `themeVariant` from `<VCListItem>`'s props + derived selection state |
 | ListLoading | `overlay` | boolean | Refresh-feedback mode — absolute-positioned overlay |
-| Navigation | `size` | sm/md/lg | Link padding + icon size |
-| Stepper | `size` | sm/md/lg | Indicator + title scale; theme-bootstrap uses `vc-stepper-indicator-{sm,lg}` |
+| Navigation | `size` | xs/sm/md/lg | Link padding + icon size |
+| Stepper | `size` | xs/sm/md/lg | Indicator + title scale; theme-bootstrap uses `vc-stepper-indicator-{sm,lg}` |
 
 Components with NO theme variants today: VCSeparator, VCAspectRatio,
 VCVisuallyHidden, VCFormPin, VCFormSlider, VCGravatar, VCCountdown,
 VCTimeago, VCLink (Link has no theme system at all yet).
+
+#### The `xs` size tier
+
+The `size` axis runs `xs / sm / md / lg` (Modal additionally has `xl`);
+`md` stays the default for every component. `xs` was added beneath `sm`
+as a purely additive tier — no existing call site or default changes.
+The five typed size unions carry it (`ButtonSize`, `BadgeSize`,
+`TagSize`, `AvatarSize`, `AlertSize`); every other size-axis component
+takes size via the loose `themeVariant` record, so only the theme
+entries needed touching.
+
+Because **Bootstrap 5 and Bulma ship no native size step below `sm`**
+(`btn-sm` / `is-small` are the floor), the `xs` tier is gap-fill:
+
+- **Structural helpers** (theme-agnostic, in the component packages) gain
+  an `xs` peer beside the existing `sm` / `lg`:
+  `vc-avatar-xs`, `vc-form-{checkbox,switch,radio}-xs`,
+  `vc-form-select-trigger-xs`, `vc-stepper-indicator-xs`. All three
+  themes reference these by name.
+- **theme-tailwind** needs no CSS — it emits one-notch-smaller utility
+  classes inline (e.g. button `px-2 py-0.5 text-[0.7rem]`).
+- **theme-bootstrap** / **theme-bulma** each ship a small set of bridge
+  helpers in their `assets/index.css` (`vc-fs-xs`, plus
+  `vc-btn-xs` / `vc-pagination-xs` / `vc-form-control-xs` for Bootstrap,
+  and `vc-size-xs` for Bulma's `--bulma-control-size`-driven controls).
+  Modal `xs` is a distinct narrower tier (260px) added via
+  `.vc-modal-content.vc-modal-xs`, following each bridge's existing
+  `.vc-modal-content.modal-{sm,lg,xl}` width re-implementation (Reka's
+  dialog content has no `.modal-dialog` wrapper for native BS/Bulma
+  modal sizing).
+  The Bootstrap helpers tighten the relevant `--bs-*` CSS variables;
+  the Bulma helpers reduce font-size (Bulma scales control padding in
+  `em`). Same "bridge what the framework exposes, gap-fill what it
+  doesn't" doctrine as the rest of those bridges.
 
 ### Type-Safe Theme Slots (ThemeElements)
 

--- a/docs/demos/src/alert.ts
+++ b/docs/demos/src/alert.ts
@@ -16,7 +16,7 @@ app.mount('#app');
 announceVariants(
     {
         variant: ['solid', 'soft', 'outline'],
-        size: ['sm', 'md', 'lg'],
+        size: ['xs', 'sm', 'md', 'lg'],
     },
     { variant: 'soft', size: 'md' },
 );

--- a/docs/demos/src/avatar.ts
+++ b/docs/demos/src/avatar.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(elements);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/badge.ts
+++ b/docs/demos/src/badge.ts
@@ -21,7 +21,7 @@ announceProps(
         size: {
             type: 'enum',
             default: 'md',
-            options: ['sm', 'md', 'lg'],
+            options: ['xs', 'sm', 'md', 'lg'],
             section: 'Variant',
         },
         variant: {

--- a/docs/demos/src/button.ts
+++ b/docs/demos/src/button.ts
@@ -27,6 +27,6 @@ app.mount('#app');
 // themeVariant.size at component-level merge), so toggling the toolbar
 // reskins the color / variant / state rows while the size row remains a
 // stable size reference.
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/context-menu.ts
+++ b/docs/demos/src/context-menu.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(overlays);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/dropdown-menu.ts
+++ b/docs/demos/src/dropdown-menu.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(overlays);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/form-checkbox.ts
+++ b/docs/demos/src/form-checkbox.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(formControls);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/form-input.ts
+++ b/docs/demos/src/form-input.ts
@@ -18,7 +18,7 @@ announceProps(
         'themeVariant.size': {
             type: 'enum',
             default: 'md',
-            options: ['sm', 'md', 'lg'],
+            options: ['xs', 'sm', 'md', 'lg'],
             section: 'Variant',
         },
         disabled: {

--- a/docs/demos/src/form-number.ts
+++ b/docs/demos/src/form-number.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(forms);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/form-radio.ts
+++ b/docs/demos/src/form-radio.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(forms);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/form-select.ts
+++ b/docs/demos/src/form-select.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(formControls);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/form-switch.ts
+++ b/docs/demos/src/form-switch.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(forms);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/form-tags.ts
+++ b/docs/demos/src/form-tags.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(forms);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/form-textarea.ts
+++ b/docs/demos/src/form-textarea.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(formControls);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/hover-card.ts
+++ b/docs/demos/src/hover-card.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(overlays);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/modal.ts
+++ b/docs/demos/src/modal.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(overlays);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg', 'xl'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg', 'xl'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/pagination.ts
+++ b/docs/demos/src/pagination.ts
@@ -53,7 +53,7 @@ announceProps(
         'themeVariant.size': {
             type: 'enum', 
             default: 'md', 
-            options: ['sm', 'md', 'lg'], 
+            options: ['xs', 'sm', 'md', 'lg'], 
             section: 'Variant',
         },
     },

--- a/docs/demos/src/popover.ts
+++ b/docs/demos/src/popover.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(overlays);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/stepper.ts
+++ b/docs/demos/src/stepper.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(navigation);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/tag.ts
+++ b/docs/demos/src/tag.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(elements);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/demos/src/tooltip.ts
+++ b/docs/demos/src/tooltip.ts
@@ -13,6 +13,6 @@ installVuecs(app);
 app.use(overlays);
 app.mount('#app');
 
-announceVariants({ size: ['sm', 'md', 'lg'] }, { size: 'md' });
+announceVariants({ size: ['xs', 'sm', 'md', 'lg'] }, { size: 'md' });
 
 installIframeBridge();

--- a/docs/src/components/alert.md
+++ b/docs/src/components/alert.md
@@ -192,7 +192,7 @@ Override via `<VCAlert role="log">` for custom interaction patterns (e.g. chat l
 |---|---|---|---|
 | `color` | `'primary' \| 'neutral' \| 'info' \| 'success' \| 'warning' \| 'error'` | `undefined` | Folded into `themeVariant`; auto-resolves the icon + ARIA role for `info/success/warning/error`. `primary` and `neutral` use no preset icon by default (pass `:icon` explicitly to render one). |
 | `variant` | `'solid' \| 'soft' \| 'outline'` | `undefined` | Folded into `themeVariant`. |
-| `size` | `'sm' \| 'md' \| 'lg'` | `undefined` | Folded into `themeVariant`. |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `undefined` | Folded into `themeVariant`. |
 | `icon` | `string` | `undefined` (preset default for `color`) | Iconify name. Pass `''` to suppress. |
 | `role` | `string` | derived from `color` | ARIA role override. |
 | `as` | `string` | `'div'` | HTML tag to render. |

--- a/docs/src/components/avatar.md
+++ b/docs/src/components/avatar.md
@@ -51,7 +51,7 @@ import { VCAvatar } from '@vuecs/elements';
 | `src` | `string` | `undefined` | Image source. When omitted, the fallback renders immediately. |
 | `alt` | `string` | `''` | Alt text for the image. Empty string = decorative; pass a meaningful value when the avatar conveys identity. |
 | `delayMs` | `number` | `undefined` | Delay before the fallback appears — useful to avoid a flicker on fast connections. Only strictly positive values are forwarded to Reka (its `AvatarFallback` treats `0` as "wait forever"); omit to render the fallback immediately. |
-| `size` | `'sm' \| 'md' \| 'lg'` | theme default (`md`) | Size variant. `sm` ≈ 32px, `md` ≈ 40px, `lg` ≈ 56px (theme-defined). For arbitrary pixel sizes, use `:theme-class="{ root: extend('h-12 w-12') }"` instead. Mirrors `<VCBadge>`'s size axis. |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | theme default (`md`) | Size variant. `xs` ≈ 24px, `sm` ≈ 32px, `md` ≈ 40px, `lg` ≈ 56px (theme-defined). For arbitrary pixel sizes, use `:theme-class="{ root: extend('h-12 w-12') }"` instead. Mirrors `<VCBadge>`'s size axis. |
 | `themeClass` | `Partial<AvatarThemeClasses>` | `undefined` | Per-instance theme override. |
 | `themeVariant` | `Record<string, string \| boolean>` | `undefined` | Per-instance variant values. |
 

--- a/docs/src/components/badge.md
+++ b/docs/src/components/badge.md
@@ -55,7 +55,7 @@ const variants = ['solid', 'soft', 'outline'] as const;
 |---|---|---|---|
 | `color` | `'primary' \| 'neutral' \| 'success' \| 'warning' \| 'error' \| 'info'` | `'neutral'` (theme default) | Semantic color. |
 | `variant` | `'solid' \| 'soft' \| 'outline'` | `'soft'` (theme default) | Visual treatment. |
-| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` (theme default) | Badge size. |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `'md'` (theme default) | Badge size. |
 | `as` | `string \| Component` | `'span'` | Element or component to render as (string tag or `RouterLink` / `NuxtLink`). |
 | `tag` | `string \| Component` | — | **Deprecated** — use `as`. Non-breaking alias; takes precedence over `as` when set. |
 | `themeClass` | `Partial<BadgeThemeClasses>` | `undefined` | Per-instance theme override. |

--- a/docs/src/components/button.md
+++ b/docs/src/components/button.md
@@ -43,6 +43,7 @@ const submit = useSubmitButton({ isEditing: () => isEditing.value });
 
     <!-- Size + state axes. `loading` shows the structural busy state
          (cursor: wait + opacity pulse); `disabled` is the inert sibling. -->
+    <VCButton size="xs" label="Extra small" />
     <VCButton size="sm" label="Small" />
     <VCButton size="md" label="Medium" />
     <VCButton size="lg" label="Large" />
@@ -84,7 +85,7 @@ const submit = useSubmitButton({ isEditing: () => isEditing.value });
 |------|------|---------|-------------|
 | `color` | `'primary' \| 'neutral' \| 'success' \| 'warning' \| 'error' \| 'info'` | (theme default) | Semantic color — themes map it onto their palette. Tailwind theme defaults to `primary`. |
 | `variant` | `'solid' \| 'soft' \| 'outline' \| 'ghost' \| 'link'` | (theme default) | Visual treatment. Tailwind theme defaults to `solid`. |
-| `size` | `'sm' \| 'md' \| 'lg'` | (theme default) | Padding / font-size. Tailwind theme defaults to `md`. |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | (theme default) | Padding / font-size. Tailwind theme defaults to `md`. |
 | `type` | `string` | `'button'` | Forwarded as the native `type` attribute when the rendered element is `'button'` (use `'submit'` inside `<form>`). |
 | `as` | `string \| Component` | `'button'` | Element or component to render as. Pass `'a'` to render as a link, or a component (`RouterLink` / `NuxtLink`) for a button-styled navigation link. Extra attrs (`to`, `href`, `target`, …) forward to the rendered element; native `type` / `disabled` apply only for `'button'`, other targets get `aria-disabled`. |
 | `tag` | `string \| Component` | — | **Deprecated** — use `as`. Non-breaking alias; takes precedence over `as` when set. |

--- a/docs/src/components/gravatar.md
+++ b/docs/src/components/gravatar.md
@@ -57,7 +57,7 @@ import { VCGravatar } from '@vuecs/gravatar';
 | `email` | `string` | `''` | Email address (hashed client-side via MD5) |
 | `hash` | `string` | `''` | Pre-computed MD5 hash — bypasses `email` if set |
 | `size` | `number` | `80` | Resolution served by Gravatar (URL `?s=` parameter, range 1–2048). **Does not** control rendered size — match it to your displayed dimensions (or 2× for retina) to avoid up/down-scaling. |
-| `displaySize` | `'sm' \| 'md' \| 'lg'` | `undefined` | Visual size — forwards to `<VCAvatar :size>`. `sm` ≈ 32px, `md` ≈ 40px, `lg` ≈ 56px. Omit to fall back to the structural `vc-gravatar` 5rem (80px) baseline. Pair with a matching `size` (URL resolution) for crisp rendering: `<VCGravatar :size="80" display-size="md">`. |
+| `displaySize` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `undefined` | Visual size — forwards to `<VCAvatar :size>`. `xs` ≈ 24px, `sm` ≈ 32px, `md` ≈ 40px, `lg` ≈ 56px. Omit to fall back to the structural `vc-gravatar` 5rem (80px) baseline. Pair with a matching `size` (URL resolution) for crisp rendering: `<VCGravatar :size="80" display-size="md">`. |
 | `defaultImg` | `string` | `'retro'` | Gravatar's built-in placeholder when the email has no associated avatar (`mp`, `identicon`, `monsterid`, `wavatar`, `retro`, `robohash`, `blank`) |
 | `rating` | `string` | `'g'` | Gravatar's `r=` parameter — content rating filter (`g`, `pg`, `r`, `x`) |
 | `alt` | `string` | `'Avatar'` | Alt text for the rendered image |
@@ -81,7 +81,7 @@ import { VCGravatar } from '@vuecs/gravatar';
 
 Visual size is decoupled from the served-image resolution:
 
-- **Display** — `displaySize="sm" | "md" | "lg"` forwards to `<VCAvatar :size>` and resolves to a theme-defined size (`sm` ≈ 32px, `md` ≈ 40px, `lg` ≈ 56px). Mirrors `<VCBadge>`'s size axis. For arbitrary pixel sizes, drop `displaySize` and use `:theme-class="{ root: extend('h-12 w-12') }"` (or any other size class). When neither is set, falls back to the structural `vc-gravatar` 5rem (80px) baseline so a bare `<VCGravatar>` keeps the historical default.
+- **Display** — `displaySize="xs" | "sm" | "md" | "lg"` forwards to `<VCAvatar :size>` and resolves to a theme-defined size (`xs` ≈ 24px, `sm` ≈ 32px, `md` ≈ 40px, `lg` ≈ 56px). Mirrors `<VCBadge>`'s size axis. For arbitrary pixel sizes, drop `displaySize` and use `:theme-class="{ root: extend('h-12 w-12') }"` (or any other size class). When neither is set, falls back to the structural `vc-gravatar` 5rem (80px) baseline so a bare `<VCGravatar>` keeps the historical default.
 - **Resolution** — `size` (number, default 80) drives Gravatar's `?s=` URL parameter. Match it to your display size (or 2× for retina) so Gravatar serves a crisp image without wasted bandwidth. Recommended pairings:
   - `displaySize="sm"` → `:size="64"` (32px × 2)
   - `displaySize="md"` → `:size="80"` (40px × 2)

--- a/docs/src/components/tag.md
+++ b/docs/src/components/tag.md
@@ -56,7 +56,7 @@ function remove(value: string | number | undefined) {
 | `label` | `string` | `undefined` | Display text; default slot wins if both provided. |
 | `icon` | `string` | `undefined` | Iconify-style name forwarded to the leading `icon` slot. |
 | `removable` | `boolean` | `false` | Render the trailing remove button. |
-| `size` | `'sm' \| 'md' \| 'lg'` | theme default (`md`) | Size variant — mirrors `<VCBadge>` sizes for visual consistency. |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | theme default (`md`) | Size variant — mirrors `<VCBadge>` sizes for visual consistency. |
 | `themeClass` | `Partial<TagThemeClasses>` | `undefined` | Per-instance theme override. |
 
 | Emit | Payload | Description |
@@ -73,7 +73,7 @@ type TagItem = {
     label?: string;
     icon?: string;
     /** Per-chip override; falls back to the list-level `size`. */
-    size?: 'sm' | 'md' | 'lg';
+    size?: 'xs' | 'sm' | 'md' | 'lg';
     /** Skips the remove button on this chip even when list-level `removable` is true. */
     disabled?: boolean;
 };
@@ -85,7 +85,7 @@ type TagItem = {
 |---|---|---|---|
 | `items` | `(TagItem \| string \| number)[]` | `[]` | Items to render. |
 | `removable` | `boolean` | `false` | Show remove buttons on every chip (per-item `disabled` opts out). |
-| `size` | `'sm' \| 'md' \| 'lg'` | theme default (`md`) | Default size forwarded to every chip; per-item `size` overrides. |
+| `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | theme default (`md`) | Default size forwarded to every chip; per-item `size` overrides. |
 | `themeClass` | `Partial<TagsThemeClasses>` | `undefined` | Per-instance theme override. |
 
 | Emit | Payload | Description |

--- a/examples/_shared/src/views/Badge.vue
+++ b/examples/_shared/src/views/Badge.vue
@@ -2,7 +2,7 @@
 import { VCBadge } from '@vuecs/elements';
 
 withDefaults(defineProps<{
-    size?: 'sm' | 'md' | 'lg';
+    size?: 'xs' | 'sm' | 'md' | 'lg';
     variant?: 'solid' | 'soft' | 'outline';
     color?: 'primary' | 'neutral' | 'success' | 'warning' | 'error' | 'info';
 }>(), {

--- a/examples/_shared/src/views/Button.vue
+++ b/examples/_shared/src/views/Button.vue
@@ -85,6 +85,10 @@ const submit = useSubmitButton({ isEditing: () => isEditing.value });
              themeVariant.size at the component's merge step. -->
         <div style="display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center;">
             <VCButton
+                size="xs"
+                label="Extra small"
+            />
+            <VCButton
                 size="sm"
                 label="Small"
             />

--- a/examples/_shared/src/views/Tag.vue
+++ b/examples/_shared/src/views/Tag.vue
@@ -16,7 +16,7 @@ const tags = ref([
 // pull the value from themeVariant rather than passing themeVariant
 // (themeVariant.size on Tags only scales the wrapper gap, not the
 // children's chip size).
-const tagSize = computed(() => props.themeVariant?.size as 'sm' | 'md' | 'lg' | undefined);
+const tagSize = computed(() => props.themeVariant?.size as 'xs' | 'sm' | 'md' | 'lg' | undefined);
 
 function remove(value: string | number | undefined) {
     tags.value = tags.value.filter((t) => t.value !== value);

--- a/packages/button/src/type.ts
+++ b/packages/button/src/type.ts
@@ -4,7 +4,7 @@ export type Options = CoreOptions;
 
 export type ButtonColor = 'primary' | 'neutral' | 'success' | 'warning' | 'error' | 'info';
 export type ButtonVariant = 'solid' | 'soft' | 'outline' | 'ghost' | 'link';
-export type ButtonSize = 'sm' | 'md' | 'lg';
+export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
 
 export type ButtonThemeClasses = {
     root: string;

--- a/packages/elements/assets/avatar.css
+++ b/packages/elements/assets/avatar.css
@@ -33,9 +33,10 @@
 }
 
 /*
- * Size variant classes — referenced by the `avatar.size.{sm,md,lg}` theme
+ * Size variant classes — referenced by the `avatar.size.{xs,sm,md,lg}` theme
  * variant entries.
  */
+.vc-avatar-xs { width: 1.5rem; height: 1.5rem; }
 .vc-avatar-sm { width: 2rem; height: 2rem; }
 .vc-avatar-md { width: 2.5rem; height: 2.5rem; }
 .vc-avatar-lg { width: 3.5rem; height: 3.5rem; }

--- a/packages/elements/src/components/alert/types.ts
+++ b/packages/elements/src/components/alert/types.ts
@@ -2,7 +2,7 @@ import type { ComponentDefaultValues, ThemeElementDefinition } from '@vuecs/core
 
 export type AlertColor = 'primary' | 'neutral' | 'info' | 'success' | 'warning' | 'error';
 export type AlertVariant = 'solid' | 'soft' | 'outline';
-export type AlertSize = 'sm' | 'md' | 'lg';
+export type AlertSize = 'xs' | 'sm' | 'md' | 'lg';
 
 export type AlertThemeClasses = {
     /** Outer container. */

--- a/packages/elements/src/components/avatar/types.ts
+++ b/packages/elements/src/components/avatar/types.ts
@@ -1,6 +1,6 @@
 import type { ThemeElementDefinition } from '@vuecs/core';
 
-export type AvatarSize = 'sm' | 'md' | 'lg';
+export type AvatarSize = 'xs' | 'sm' | 'md' | 'lg';
 
 export type AvatarThemeClasses = {
     /** The outer wrapper. */

--- a/packages/elements/src/components/badge/types.ts
+++ b/packages/elements/src/components/badge/types.ts
@@ -2,7 +2,7 @@ import type { ThemeElementDefinition } from '@vuecs/core';
 
 export type BadgeColor = 'primary' | 'neutral' | 'success' | 'warning' | 'error' | 'info';
 export type BadgeVariant = 'solid' | 'soft' | 'outline';
-export type BadgeSize = 'sm' | 'md' | 'lg';
+export type BadgeSize = 'xs' | 'sm' | 'md' | 'lg';
 
 export type BadgeThemeClasses = {
     /** The pill element. */

--- a/packages/elements/src/components/tag/types.ts
+++ b/packages/elements/src/components/tag/types.ts
@@ -1,6 +1,6 @@
 import type { ThemeElementDefinition } from '@vuecs/core';
 
-export type TagSize = 'sm' | 'md' | 'lg';
+export type TagSize = 'xs' | 'sm' | 'md' | 'lg';
 
 export type TagThemeClasses = {
     /** The chip's outer element. */

--- a/packages/forms/assets/form-checkbox.css
+++ b/packages/forms/assets/form-checkbox.css
@@ -85,6 +85,14 @@
    Tailwind v4 utilities (`h-3 w-3`) sit in `@layer utilities` and lose to
    unlayered structural CSS, so we ship dedicated structural helpers and
    reference them from both Tailwind and Bootstrap theme entries. */
+.vc-form-checkbox-xs {
+    width: 0.625rem;
+    height: 0.625rem;
+}
+.vc-form-checkbox-xs .vc-form-checkbox-indicator::before {
+    width: 0.375rem;
+    height: 0.375rem;
+}
 .vc-form-checkbox-sm {
     width: 0.75rem;
     height: 0.75rem;

--- a/packages/forms/assets/form-radio.css
+++ b/packages/forms/assets/form-radio.css
@@ -99,6 +99,14 @@
 }
 
 /* Size helpers — themes drive these via `formRadio.variants.size.{sm,lg}`. */
+.vc-form-radio-xs {
+    width: 0.625rem;
+    height: 0.625rem;
+}
+.vc-form-radio-xs .vc-form-radio-indicator {
+    width: 0.3125rem;
+    height: 0.3125rem;
+}
 .vc-form-radio-sm {
     width: 0.75rem;
     height: 0.75rem;

--- a/packages/forms/assets/form-select.css
+++ b/packages/forms/assets/form-select.css
@@ -136,6 +136,11 @@
    Bootstrap's `form-control-{sm,lg}` and Tailwind's per-size utilities both
    sit in CSS layers we'd lose to (Bootstrap unlayered for some rules, Tailwind
    utilities for others), so we ship dedicated structural helpers. */
+.vc-form-select-trigger-xs {
+    padding: 0.125rem 0.4rem;
+    font-size: 0.7rem;
+    line-height: 0.9rem;
+}
 .vc-form-select-trigger-sm {
     padding: 0.25rem 0.5rem;
     font-size: 0.75rem;

--- a/packages/forms/assets/form-switch.css
+++ b/packages/forms/assets/form-switch.css
@@ -84,6 +84,17 @@
 /* Size helpers — themes drive these via `formSwitch.variants.size.{sm,lg}`.
    Track and thumb scale together; the `[data-state="checked"]` translate
    distance matches the new track width minus thumb. */
+.vc-form-switch-xs {
+    width: 1.5rem;
+    height: 0.875rem;
+}
+.vc-form-switch-xs .vc-form-switch-thumb {
+    width: 0.5rem;
+    height: 0.5rem;
+}
+.vc-form-switch-xs[data-state="checked"] .vc-form-switch-thumb {
+    translate: 0.625rem 0;
+}
 .vc-form-switch-sm {
     width: 1.75rem;
     height: 1rem;

--- a/packages/navigation/assets/index.css
+++ b/packages/navigation/assets/index.css
@@ -261,6 +261,11 @@
 }
 
 /* Size helpers — themes drive these via `stepper.variants.size.{sm,lg}`. */
+.vc-stepper-indicator-xs {
+    width: 1.25rem;
+    height: 1.25rem;
+    font-size: 0.625rem;
+}
 .vc-stepper-indicator-sm {
     width: 1.5rem;
     height: 1.5rem;

--- a/themes/bootstrap/assets/index.css
+++ b/themes/bootstrap/assets/index.css
@@ -393,6 +393,7 @@
  * the theme's `position-fixed top-50 start-50 translate-middle`.
  * ──────────────────────────────────────────────────────────────────────── */
 
+.vc-modal-content.vc-modal-xs { max-width: 260px; width: calc(100% - 1rem); }
 .vc-modal-content.modal-sm { max-width: 300px; width: calc(100% - 1rem); }
 .vc-modal-content.modal-lg { max-width: 800px; width: calc(100% - 1rem); }
 .vc-modal-content.modal-xl { max-width: 1140px; width: calc(100% - 1rem); }
@@ -469,4 +470,41 @@
 
 .vc-alert-outline {
     background-color: transparent !important;
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Size: `xs` gap-fill. Bootstrap 5 ships `-sm` / `-lg` size modifiers but
+ * nothing below `sm`. The vuecs size axis adds `xs` (one notch under `sm`);
+ * these helpers supply it by tightening the relevant BS CSS variables /
+ * utilities. Referenced from the `size.xs` theme entries in
+ * `themes/bootstrap/src/index.ts`.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/* Generic font shrink for text-bearing surfaces (alert, popover, tooltip,
+   menus, nav, list, badge, tag) — BS has no font step below `.small`. */
+.vc-fs-xs { font-size: 0.7rem; }
+
+/* Button — BS5 buttons resolve sizing from these vars (set by `.btn-sm`). */
+.vc-btn-xs {
+    --bs-btn-padding-y: 0.12rem;
+    --bs-btn-padding-x: 0.4rem;
+    --bs-btn-font-size: 0.7rem;
+    --bs-btn-border-radius: 0.2rem;
+}
+
+/* Pagination — BS5 reads these vars (set by `.pagination-sm`). */
+.vc-pagination-xs {
+    --bs-pagination-padding-y: 0.05rem;
+    --bs-pagination-padding-x: 0.4rem;
+    --bs-pagination-font-size: 0.7rem;
+}
+
+/* Text inputs / selects / textareas — every BS theme slot that takes the
+   `xs` size carries the `.form-control` base class (the FormSelect trigger
+   included), and `.form-control-sm` sets padding+font directly, so override
+   both. Element-qualified (0,2,0) beats `.form-control-sm`. */
+.form-control.vc-form-control-xs {
+    padding: 0.1rem 0.4rem;
+    font-size: 0.7rem;
+    border-radius: 0.2rem;
 }

--- a/themes/bootstrap/src/index.ts
+++ b/themes/bootstrap/src/index.ts
@@ -30,6 +30,7 @@ export default function bootstrapTheme(): Theme {
                 // wanting a true amber state can override.
                 variants: {
                     size: {
+                        xs: { root: 'form-control-sm vc-form-control-xs', group: 'input-group-sm' },
                         sm: { root: 'form-control-sm', group: 'input-group-sm' },
                         md: { root: '' },
                         lg: { root: 'form-control-lg', group: 'input-group-lg' },
@@ -63,6 +64,7 @@ export default function bootstrapTheme(): Theme {
                 // helpers (defined in @vuecs/forms styles).
                 variants: {
                     size: {
+                        xs: { root: 'vc-form-checkbox-xs', label: 'vc-fs-xs' },
                         sm: { root: 'vc-form-checkbox-sm', label: 'small' },
                         md: { root: '' },
                         lg: { root: 'vc-form-checkbox-lg', label: 'fs-5' },
@@ -80,6 +82,7 @@ export default function bootstrapTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { root: 'vc-form-switch-xs', label: 'vc-fs-xs' },
                         sm: { root: 'vc-form-switch-sm', label: 'small' },
                         md: { root: '' },
                         lg: { root: 'vc-form-switch-lg', label: 'fs-5' },
@@ -106,6 +109,7 @@ export default function bootstrapTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { trigger: 'form-control-sm vc-form-control-xs' },
                         sm: { trigger: 'form-control-sm' },
                         md: { trigger: '' },
                         lg: { trigger: 'form-control-lg' },
@@ -151,6 +155,7 @@ export default function bootstrapTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { root: 'vc-form-radio-xs', label: 'vc-fs-xs' },
                         sm: { root: 'vc-form-radio-sm', label: 'small' },
                         md: { root: '' },
                         lg: { root: 'vc-form-radio-lg', label: 'fs-5' },
@@ -193,6 +198,12 @@ export default function bootstrapTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: {
+                            root: 'input-group-sm', 
+                            input: 'form-control-sm vc-form-control-xs', 
+                            decrement: 'btn-sm vc-btn-xs', 
+                            increment: 'btn-sm vc-btn-xs', 
+                        },
                         sm: {
                             root: 'input-group-sm',
                             input: 'form-control-sm',
@@ -228,6 +239,7 @@ export default function bootstrapTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { root: 'form-control-sm vc-form-control-xs p-1', item: 'vc-fs-xs' },
                         sm: { root: 'form-control-sm p-1', item: 'small' },
                         md: { root: '' },
                         lg: { root: 'form-control-lg p-3', item: 'fs-6' },
@@ -248,6 +260,7 @@ export default function bootstrapTheme(): Theme {
                 classes: { root: 'btn d-inline-flex align-items-center justify-content-center gap-2' },
                 variants: {
                     size: {
+                        xs: { root: 'btn-sm vc-btn-xs' },
                         sm: { root: 'btn-sm' },
                         md: { root: '' },
                         lg: { root: 'btn-lg' },
@@ -308,6 +321,7 @@ export default function bootstrapTheme(): Theme {
                 classes: { root: 'form-control' },
                 variants: {
                     size: {
+                        xs: { root: 'form-control-sm vc-form-control-xs' },
                         sm: { root: 'form-control-sm' },
                         md: { root: '' },
                         lg: { root: 'form-control-lg' },
@@ -389,6 +403,7 @@ export default function bootstrapTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { link: 'vc-fs-xs py-0 px-2', trigger: 'vc-fs-xs py-0 px-2' },
                         sm: { link: 'small py-1 px-2', trigger: 'small py-1 px-2' },
                         md: { link: '' },
                         lg: { link: 'fs-6 py-3 px-4', trigger: 'fs-6 py-3 px-4' },
@@ -419,6 +434,7 @@ export default function bootstrapTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { root: 'vc-fs-xs px-2 py-0' },
                         sm: { root: 'small px-2 py-1' },
                         md: { root: '' },
                         lg: { root: 'fs-6 px-3 py-2' },
@@ -433,6 +449,7 @@ export default function bootstrapTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { root: 'gap-1' },
                         sm: { root: 'gap-1' },
                         md: { root: '' },
                         lg: { root: 'gap-3' },
@@ -452,6 +469,7 @@ export default function bootstrapTheme(): Theme {
                 // shipped in @vuecs/elements/assets/avatar.css.
                 variants: {
                     size: {
+                        xs: { root: 'vc-avatar-xs' },
                         sm: { root: 'vc-avatar-sm' },
                         md: { root: '' },
                         lg: { root: 'vc-avatar-lg' },
@@ -553,6 +571,7 @@ export default function bootstrapTheme(): Theme {
                     // with `px-*` here would let text overlap the close icon
                     // because BS `.px-*` utilities clobber both sides.
                     size: {
+                        xs: { root: 'py-1 vc-fs-xs' },
                         sm: { root: 'py-2 small' },
                         md: { root: '' },
                         lg: { root: 'py-3 fs-6' },
@@ -595,6 +614,7 @@ export default function bootstrapTheme(): Theme {
                 classes: { root: 'badge rounded-pill' },
                 variants: {
                     size: {
+                        xs: { root: 'vc-fs-xs px-2 py-0' },
                         sm: { root: 'small px-2 py-1' },
                         md: { root: '' },
                         lg: { root: 'fs-6 px-3 py-2' },
@@ -774,6 +794,7 @@ export default function bootstrapTheme(): Theme {
                         ghost: { link: 'border-0 bg-transparent' },
                     },
                     size: {
+                        xs: { root: 'pagination-sm vc-pagination-xs' },
                         sm: { root: 'pagination-sm' },
                         md: { root: '' },
                         lg: { root: 'pagination-lg' },
@@ -814,6 +835,7 @@ export default function bootstrapTheme(): Theme {
                 // in for `.modal-dialog` so we apply the size class there.
                 variants: {
                     size: {
+                        xs: { content: 'vc-modal-xs' },
                         sm: { content: 'modal-sm' },
                         md: { content: '' },
                         lg: { content: 'modal-lg' },
@@ -838,6 +860,7 @@ export default function bootstrapTheme(): Theme {
                 // to consumers via per-instance themeClass.
                 variants: {
                     size: {
+                        xs: { content: 'vc-fs-xs p-2' },
                         sm: { content: 'small p-2' },
                         md: { content: '' },
                         lg: { content: 'fs-6 p-4' },
@@ -853,6 +876,7 @@ export default function bootstrapTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { content: 'vc-fs-xs p-2' },
                         sm: { content: 'small p-2' },
                         md: { content: '' },
                         lg: { content: 'fs-6 p-4' },
@@ -879,6 +903,7 @@ export default function bootstrapTheme(): Theme {
                 // @vuecs/navigation's stepper structural CSS.
                 variants: {
                     size: {
+                        xs: { indicator: 'vc-stepper-indicator-xs', title: 'vc-fs-xs' },
                         sm: { indicator: 'vc-stepper-indicator-sm', title: 'small' },
                         md: { indicator: '' },
                         lg: { indicator: 'vc-stepper-indicator-lg', title: 'fs-6' },
@@ -951,6 +976,7 @@ export default function bootstrapTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { content: 'vc-fs-xs px-2 py-0' },
                         sm: { content: 'small px-2 py-1' },
                         md: { content: '' },
                         lg: { content: 'fs-6 px-3 py-2' },
@@ -979,6 +1005,12 @@ export default function bootstrapTheme(): Theme {
                 // dropdown chrome stays untouched.
                 variants: {
                     size: {
+                        xs: {
+                            content: 'vc-fs-xs p-1', 
+                            item: 'py-0 px-2', 
+                            subTrigger: 'py-0 px-2', 
+                            subContent: 'vc-fs-xs p-1', 
+                        },
                         sm: {
                             content: 'small p-1', 
                             item: 'py-1 px-2', 
@@ -1013,6 +1045,12 @@ export default function bootstrapTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: {
+                            content: 'vc-fs-xs p-1', 
+                            item: 'py-0 px-2', 
+                            subTrigger: 'py-0 px-2', 
+                            subContent: 'vc-fs-xs p-1', 
+                        },
                         sm: {
                             content: 'small p-1', 
                             item: 'py-1 px-2', 

--- a/themes/bulma/assets/index.css
+++ b/themes/bulma/assets/index.css
@@ -368,6 +368,7 @@
     border-radius: var(--vc-radius-lg);
 }
 
+.vc-modal-content.vc-modal-xs { max-width: 260px;  width: calc(100% - 1rem); }
 .vc-modal-content.modal-sm { max-width: 300px;  width: calc(100% - 1rem); }
 .vc-modal-content.modal-lg { max-width: 800px;  width: calc(100% - 1rem); }
 .vc-modal-content.modal-xl { max-width: 1140px; width: calc(100% - 1rem); }
@@ -644,3 +645,37 @@
     border: 1px solid var(--vc-color-info-600);
     color: var(--vc-color-info-700);
 }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Size: `xs` gap-fill. Bulma ships `is-small` / `is-medium` / `is-large` but
+ * nothing below `is-small`. The vuecs size axis adds `xs`; these helpers
+ * supply it. Bulma controls scale padding in `em`, so a font-size reduction
+ * shrinks the whole control. The element-qualified control selectors (0,2,0)
+ * beat Bulma's `.is-small` (0,1,0) without `!important`; `.vc-fs-xs` carries
+ * `!important` because it stands in for Bulma's `.is-size-7`, which is itself
+ * `!important`. Referenced from the `size.xs` theme entries in
+ * `themes/bulma/src/index.ts`.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/* Generic font shrink for text-bearing surfaces (alert, popover, tooltip,
+   menus, nav, badge, tag, control labels) — one notch below `is-size-7`. */
+.vc-fs-xs { font-size: 0.65rem !important; }
+
+/* Controls whose font-size resolves from `var(--bulma-control-size)` (button,
+   input, textarea, select trigger). A direct font-size wins over the shared
+   `font-size: var(--bulma-control-size)` rule; padding is `em`-based so it
+   scales with it. */
+.button.vc-size-xs,
+.input.vc-size-xs,
+.textarea.vc-size-xs {
+    font-size: 0.65rem;
+}
+
+/* Pagination — the vuecs root is `.pagination-list`, and the size-bearing
+   `.pagination-link` children read `--bulma-control-size`, so set that var
+   (a plain font-size on the list wouldn't override the children's own rule). */
+.pagination-list.vc-size-xs { --bulma-control-size: 0.65rem; }
+
+/* `<VCTags>` container — Bulma's `.are-*` family has no step below the
+   default; shrink the child chips for the `xs` container size. */
+.tags.vc-size-xs .tag { font-size: 0.65rem; }

--- a/themes/bulma/src/index.ts
+++ b/themes/bulma/src/index.ts
@@ -76,6 +76,7 @@ export default function bulmaTheme(): Theme {
                 // gap-fill needed.
                 variants: {
                     size: {
+                        xs: { root: 'is-small vc-size-xs' },
                         sm: { root: 'is-small' },
                         md: { root: '' },
                         lg: { root: 'is-large' },
@@ -91,6 +92,7 @@ export default function bulmaTheme(): Theme {
                 classes: { root: 'textarea' },
                 variants: {
                     size: {
+                        xs: { root: 'is-small vc-size-xs' },
                         sm: { root: 'is-small' },
                         md: { root: '' },
                         lg: { root: 'is-large' },
@@ -122,6 +124,7 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { root: 'vc-form-checkbox-xs', label: 'vc-fs-xs' },
                         sm: { root: 'vc-form-checkbox-sm', label: 'is-size-7' },
                         md: { root: '' },
                         lg: { root: 'vc-form-checkbox-lg', label: 'is-size-5' },
@@ -142,6 +145,7 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { root: 'vc-form-switch-xs', label: 'vc-fs-xs' },
                         sm: { root: 'vc-form-switch-sm', label: 'is-size-7' },
                         md: { root: '' },
                         lg: { root: 'vc-form-switch-lg', label: 'is-size-5' },
@@ -158,6 +162,7 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { root: 'vc-form-radio-xs', label: 'vc-fs-xs' },
                         sm: { root: 'vc-form-radio-sm', label: 'is-size-7' },
                         md: { root: '' },
                         lg: { root: 'vc-form-radio-lg', label: 'is-size-5' },
@@ -186,6 +191,7 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { trigger: 'is-small vc-size-xs' },
                         sm: { trigger: 'is-small' },
                         md: { trigger: '' },
                         lg: { trigger: 'is-large' },
@@ -250,6 +256,11 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: {
+                            input: 'is-small vc-size-xs', 
+                            decrement: 'is-small vc-size-xs', 
+                            increment: 'is-small vc-size-xs', 
+                        },
                         sm: {
                             input: 'is-small',
                             decrement: 'is-small',
@@ -282,6 +293,7 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { root: 'is-small vc-size-xs', item: 'vc-fs-xs' },
                         sm: { root: 'is-small', item: 'is-size-7' },
                         md: { root: '' },
                         lg: { root: 'is-large', item: 'is-size-6' },
@@ -301,6 +313,7 @@ export default function bulmaTheme(): Theme {
                 classes: { root: 'button is-inline-flex is-align-items-center is-justify-content-center is-gap-2' },
                 variants: {
                     size: {
+                        xs: { root: 'is-small vc-size-xs' },
                         sm: { root: 'is-small' },
                         md: { root: '' },
                         lg: { root: 'is-large' },
@@ -425,6 +438,7 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { link: 'vc-fs-xs', trigger: 'vc-fs-xs' },
                         sm: { link: 'is-size-7', trigger: 'is-size-7' },
                         md: { link: '' },
                         lg: { link: 'is-size-6', trigger: 'is-size-6' },
@@ -451,6 +465,7 @@ export default function bulmaTheme(): Theme {
                 // `md` lifts to `is-medium` and `lg` to `is-large`.
                 variants: {
                     size: {
+                        xs: { root: 'vc-fs-xs' },
                         sm: { root: '' },
                         md: { root: 'is-medium' },
                         lg: { root: 'is-large' },
@@ -465,6 +480,7 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { root: 'vc-size-xs' },
                         sm: { root: '' },
                         md: { root: 'are-medium' },
                         lg: { root: 'are-large' },
@@ -483,6 +499,7 @@ export default function bulmaTheme(): Theme {
                 // `vc-avatar-{sm,lg}` helpers (defined in @vuecs/elements).
                 variants: {
                     size: {
+                        xs: { root: 'vc-avatar-xs' },
                         sm: { root: 'vc-avatar-sm' },
                         md: { root: '' },
                         lg: { root: 'vc-avatar-lg' },
@@ -599,6 +616,7 @@ export default function bulmaTheme(): Theme {
                     // would shrink that reserved space and let text overlap
                     // the close icon.
                     size: {
+                        xs: { root: 'vc-fs-xs' },
                         sm: { root: 'is-size-7' },
                         md: { root: '' },
                         lg: { root: 'is-size-5' },
@@ -645,6 +663,7 @@ export default function bulmaTheme(): Theme {
                 classes: { root: 'tag is-rounded vc-badge' },
                 variants: {
                     size: {
+                        xs: { root: 'vc-fs-xs' },
                         sm: { root: '' },
                         md: { root: 'is-medium' },
                         lg: { root: 'is-large' },
@@ -821,6 +840,7 @@ export default function bulmaTheme(): Theme {
                         ghost: { link: 'is-text' },
                     },
                     size: {
+                        xs: { root: 'is-small vc-size-xs' },
                         sm: { root: 'is-small' },
                         md: { root: '' },
                         lg: { root: 'is-large' },
@@ -860,6 +880,7 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { content: 'vc-modal-xs' },
                         sm: { content: 'modal-sm' },
                         md: { content: '' },
                         lg: { content: 'modal-lg' },
@@ -883,6 +904,7 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { content: 'vc-fs-xs p-2' },
                         sm: { content: 'is-size-7 p-2' },
                         md: { content: '' },
                         lg: { content: 'is-size-6 p-5' },
@@ -898,6 +920,7 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { content: 'vc-fs-xs p-2' },
                         sm: { content: 'is-size-7 p-2' },
                         md: { content: '' },
                         lg: { content: 'is-size-6 p-5' },
@@ -971,6 +994,7 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { content: 'vc-fs-xs px-2 py-0' },
                         sm: { content: 'is-size-7 px-2 py-1' },
                         md: { content: 'px-3 py-1' },
                         lg: { content: 'is-size-6 px-3 py-2' },
@@ -998,6 +1022,7 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { content: 'vc-fs-xs' },
                         sm: { content: 'is-size-7' },
                         md: { content: '' },
                         lg: { content: 'is-size-6' },
@@ -1022,6 +1047,7 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { content: 'vc-fs-xs' },
                         sm: { content: 'is-size-7' },
                         md: { content: '' },
                         lg: { content: 'is-size-6' },
@@ -1050,6 +1076,11 @@ export default function bulmaTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: {
+                            indicator: 'vc-stepper-indicator-xs', 
+                            title: 'vc-fs-xs', 
+                            description: 'vc-fs-xs', 
+                        },
                         sm: {
                             indicator: 'vc-stepper-indicator-sm', 
                             title: 'is-size-7', 

--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -102,6 +102,11 @@ export default function tailwindTheme(): Theme {
                 // primary-focus chrome is overridden via tailwind-merge.
                 variants: {
                     size: {
+                        xs: {
+                            root: 'px-1.5 py-0.5 text-[0.7rem]',
+                            groupAppend: 'px-1.5 text-[0.7rem]',
+                            groupPrepend: 'px-1.5 text-[0.7rem]',
+                        },
                         sm: {
                             root: 'px-2 py-1 text-xs',
                             groupAppend: 'px-2 text-xs',
@@ -136,6 +141,7 @@ export default function tailwindTheme(): Theme {
                 // the structural label rule.
                 variants: {
                     size: {
+                        xs: { root: 'vc-form-checkbox-xs', label: 'text-[0.7rem]!' },
                         sm: { root: 'vc-form-checkbox-sm', label: 'text-xs!' },
                         md: { root: '' },
                         lg: { root: 'vc-form-checkbox-lg', label: 'text-base!' },
@@ -156,6 +162,7 @@ export default function tailwindTheme(): Theme {
                 // selectors). See formCheckbox above for rationale.
                 variants: {
                     size: {
+                        xs: { root: 'vc-form-switch-xs', label: 'text-[0.7rem]!' },
                         sm: { root: 'vc-form-switch-sm', label: 'text-xs!' },
                         md: { root: '' },
                         lg: { root: 'vc-form-switch-lg', label: 'text-base!' },
@@ -180,6 +187,7 @@ export default function tailwindTheme(): Theme {
                 // helpers — see formCheckbox above for rationale.
                 variants: {
                     size: {
+                        xs: { trigger: 'vc-form-select-trigger-xs', item: 'py-0.5 pl-6 text-[0.7rem]!' },
                         sm: { trigger: 'vc-form-select-trigger-sm', item: 'py-1 pl-6 text-xs!' },
                         md: { trigger: '' },
                         lg: { trigger: 'vc-form-select-trigger-lg', item: 'py-2 pl-8 text-base!' },
@@ -222,6 +230,7 @@ export default function tailwindTheme(): Theme {
                 // (root + indicator scale together via descendant selectors).
                 variants: {
                     size: {
+                        xs: { root: 'vc-form-radio-xs', label: 'text-[0.7rem]!' },
                         sm: { root: 'vc-form-radio-sm', label: 'text-xs!' },
                         md: { root: '' },
                         lg: { root: 'vc-form-radio-lg', label: 'text-base!' },
@@ -257,6 +266,11 @@ export default function tailwindTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: {
+                            input: 'px-1.5 py-0.5 text-[0.7rem]',
+                            decrement: 'w-5 text-[0.7rem]',
+                            increment: 'w-5 text-[0.7rem]',
+                        },
                         sm: {
                             input: 'px-2 py-1 text-xs',
                             decrement: 'w-6 text-xs',
@@ -286,6 +300,11 @@ export default function tailwindTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: {
+                            root: 'px-1! py-0.5!',
+                            item: 'px-1! py-px! text-[0.5625rem]!',
+                            input: 'text-[0.7rem]!',
+                        },
                         sm: {
                             root: 'px-1.5! py-1!',
                             item: 'px-1.5! py-px! text-[0.625rem]!',
@@ -319,6 +338,7 @@ export default function tailwindTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { root: 'px-2 py-0.5 text-[0.7rem]' },
                         sm: { root: 'px-2.5 py-1 text-xs' },
                         md: { root: 'px-3 py-1.5 text-sm' },
                         lg: { root: 'px-4 py-2 text-base' },
@@ -378,6 +398,7 @@ export default function tailwindTheme(): Theme {
                 classes: { root: 'block w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-fg shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:bg-bg-muted' },
                 variants: {
                     size: {
+                        xs: { root: 'px-1.5 py-0.5 text-[0.7rem]' },
                         sm: { root: 'px-2 py-1 text-xs' },
                         md: { root: '' },
                         lg: { root: 'px-4 py-3 text-base' },
@@ -478,6 +499,11 @@ export default function tailwindTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: {
+                            link: 'px-1.5 py-0.5 text-[0.7rem]',
+                            linkIcon: 'h-2.5 w-2.5',
+                            trigger: 'px-1.5 py-0.5 text-[0.7rem]',
+                        },
                         sm: {
                             link: 'px-2 py-1 text-xs',
                             linkIcon: 'h-3 w-3',
@@ -635,6 +661,7 @@ export default function tailwindTheme(): Theme {
                         ghost: { link: 'border border-border bg-bg text-fg hover:bg-bg-muted' },
                     },
                     size: {
+                        xs: { link: 'h-6 min-w-6 px-1.5 text-[0.7rem]' },
                         sm: { link: 'h-7 min-w-7 px-2 text-xs' },
                         md: { link: 'h-8 min-w-8 px-3 text-sm' },
                         lg: { link: 'h-10 min-w-10 px-4 text-base' },
@@ -669,6 +696,7 @@ export default function tailwindTheme(): Theme {
                 // utility above the structural padding/font-size defaults.
                 variants: {
                     size: {
+                        xs: { root: 'px-1! py-px! text-[0.5625rem]! gap-0.5!', remove: 'h-2.5! w-2.5!' },
                         sm: { root: 'px-1.5! py-px! text-[0.625rem]! gap-0.5!', remove: 'h-3! w-3!' },
                         md: { root: 'px-2! py-0.5! text-xs!', remove: 'h-4! w-4!' },
                         lg: { root: 'px-2.5! py-1! text-sm!', remove: 'h-5! w-5!' },
@@ -687,6 +715,7 @@ export default function tailwindTheme(): Theme {
                 // also resize.
                 variants: {
                     size: {
+                        xs: { root: 'gap-0.5' },
                         sm: { root: 'gap-1' },
                         md: { root: '' },
                         lg: { root: 'gap-2' },
@@ -710,6 +739,7 @@ export default function tailwindTheme(): Theme {
                 // unlayered structural; see form-checkbox.css rationale).
                 variants: {
                     size: {
+                        xs: { root: 'vc-avatar-xs', fallback: 'text-[0.625rem]!' },
                         sm: { root: 'vc-avatar-sm', fallback: 'text-xs!' },
                         md: { fallback: 'text-sm!' },
                         lg: { root: 'vc-avatar-lg', fallback: 'text-base!' },
@@ -799,6 +829,7 @@ export default function tailwindTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { root: 'p-1.5 pr-7 text-[0.7rem]' },
                         sm: { root: 'p-2 pr-8 text-xs' },
                         md: { root: 'p-3 pr-9 text-sm' },
                         lg: { root: 'p-4 pr-10 text-sm' },
@@ -842,6 +873,7 @@ export default function tailwindTheme(): Theme {
                 // tag.size above for rationale.
                 variants: {
                     size: {
+                        xs: { root: 'px-1! py-px! text-[0.5625rem]!' },
                         sm: { root: 'px-1.5! py-px! text-[0.625rem]!' },
                         md: { root: 'px-2! py-0.5! text-xs!' },
                         lg: { root: 'px-2.5! py-1! text-sm!' },
@@ -901,6 +933,7 @@ export default function tailwindTheme(): Theme {
                 // sm fits compact confirms, lg fits forms, xl fits dashboards.
                 variants: {
                     size: {
+                        xs: { content: 'max-w-xs p-3 gap-2' },
                         sm: { content: 'max-w-sm p-4 gap-3' },
                         md: { content: '' },
                         lg: { content: 'max-w-2xl' },
@@ -921,6 +954,7 @@ export default function tailwindTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { content: 'w-48 p-2 text-[0.7rem]' },
                         sm: { content: 'w-56 p-3 text-xs' },
                         md: { content: '' },
                         lg: { content: 'w-96 p-5 text-base' },
@@ -936,6 +970,7 @@ export default function tailwindTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { content: 'w-40 p-2 text-[0.7rem]' },
                         sm: { content: 'w-48 p-3 text-xs' },
                         md: { content: '' },
                         lg: { content: 'w-80 p-5 text-base' },
@@ -973,6 +1008,11 @@ export default function tailwindTheme(): Theme {
                 // text-size defaults set on neighboring elements.
                 variants: {
                     size: {
+                        xs: {
+                            indicator: 'vc-stepper-indicator-xs',
+                            title: 'text-[0.7rem]!',
+                            description: 'text-[0.5625rem]!',
+                        },
                         sm: {
                             indicator: 'vc-stepper-indicator-sm',
                             title: 'text-xs!',
@@ -1051,6 +1091,7 @@ export default function tailwindTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: { content: 'px-1.5 py-0.5 text-[0.5625rem]' },
                         sm: { content: 'px-2 py-1 text-[0.625rem]' },
                         md: { content: '' },
                         lg: { content: 'px-4 py-2 text-sm' },
@@ -1076,6 +1117,12 @@ export default function tailwindTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: {
+                            content: 'min-w-[5rem] text-[0.7rem]',
+                            item: 'px-1 py-0.5',
+                            subTrigger: 'px-1 py-0.5',
+                            subContent: 'min-w-[5rem] text-[0.7rem]',
+                        },
                         sm: {
                             content: 'min-w-[6rem] text-xs',
                             item: 'px-1.5 py-1',
@@ -1110,6 +1157,12 @@ export default function tailwindTheme(): Theme {
                 },
                 variants: {
                     size: {
+                        xs: {
+                            content: 'min-w-[5rem] text-[0.7rem]',
+                            item: 'px-1 py-0.5',
+                            subTrigger: 'px-1 py-0.5',
+                            subContent: 'min-w-[5rem] text-[0.7rem]',
+                        },
                         sm: {
                             content: 'min-w-[6rem] text-xs',
                             item: 'px-1.5 py-1',


### PR DESCRIPTION
## Summary

Adds an **`xs` size tier** below `sm` across every size-axis component. Purely **additive** — `md` stays the default everywhere, and no existing call site or default changes.

Motivated by downstream consumers (e.g. [authup#3139](https://github.com/authup/authup/pull/3139)) that had to downgrade `xs` buttons to `sm` because vuecs's size axis stopped at `sm`. There was already precedent: `@vuecs/placeholder` ships `xs`.

## What changed

**Types (5 unions):** `ButtonSize`, `BadgeSize`, `TagSize`, `AvatarSize`, `AlertSize` → `'xs' | 'sm' | 'md' | 'lg'`. Every *other* size-axis component takes size only via the loose `themeVariant` record, so no further type edits were needed.

**Structural helpers** (theme-agnostic, in the component packages) gained `xs` peers beside the existing `sm`/`lg`: `vc-avatar-xs`, `vc-form-{checkbox,switch,radio}-xs`, `vc-form-select-trigger-xs`, `vc-stepper-indicator-xs`.

**Themes** — an `xs` entry was added to every `size` variant block in all three themes (23 keys each, identical set):
- **Tailwind** — one-notch-smaller utility classes inline; no CSS.
- **Bootstrap & Bulma ship no native step below `sm`**, so `xs` is gap-fill via bridge helpers:
  - Bootstrap: `vc-fs-xs`, `vc-btn-xs` (tightens `--bs-btn-*`), `vc-pagination-xs` (`--bs-pagination-*`), `vc-form-control-xs`.
  - Bulma: `vc-fs-xs` (matches `.is-size-7`'s `!important`), `vc-size-xs` for `--bulma-control-size`-driven controls, and a `--bulma-control-size` override on `.pagination-list` (the real size lever for pagination links).
  - Modal `xs` is a **distinct narrower tier** (260px) via `.vc-modal-content.vc-modal-xs`, following each bridge's existing `.vc-modal-content.modal-{sm,lg,xl}` width re-implementation (Reka's dialog content has no `.modal-dialog` wrapper for native sizing).

**Examples & docs** — every docs Playground size selector now offers `xs`; the affected component pages' `size` prop tables (and avatar/gravatar pixel prose, `xs ≈ 24px`) were updated; the shared Button view shows a static `xs` button in every example app; `.agents/architecture.md`'s variant catalog + a new "`xs` size tier" note document the gap-fill doctrine.

## Coverage / completeness

- All **23** size-axis theme keys got `xs` in **all three** themes (the set is identical across themes).
- `@vuecs/placeholder` already shipped `xs`; `Gravatar` inherits it via `displaySize: AvatarSize`.
- `List`/`ListItem` use a `density` axis (not `size`) and `FormSelectSearch` has a `severity`-only theme entry (no `size`) — both correctly excluded; the architecture catalog was corrected to match.
- Verified every one of the 69 `xs` values is non-empty and references a defined class.

## Verification

- ✅ `nx build` green for all touched packages + 3 themes, including the strict `build:types` declaration emit.
- ✅ `npm run lint` — 0 errors.
- ✅ No dangling `vc-*-xs` references.

A self-audit caught and fixed several real issues before/within this PR: Bulma pagination `xs` was a no-op (wrong selector + wrong size lever), Bulma `vc-fs-xs` was weaker than the `sm` tier it mirrors (`.is-size-7` is `!important`), and the Bootstrap/Bulma modal `xs` now resolves to a genuinely-narrower panel instead of aliasing `sm`; two dead selector arms were also removed.

## Note

Scope is **all** size-axis components (the requested breadth), so `xs` also exists on `modal` / `tooltip` / `pagination` etc. where it's less commonly needed — additive and harmless, but easy to trim if undesired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added extra-small (`xs`) size support across size-driven components, including buttons, forms, navigation, badges, avatars, tags, menus, and overlays (Modal also retains `xl`).
  * Introduced `xs` sizing helpers to ensure consistent layout/typography at the new smallest tier.

* **Documentation**
  * Updated component API docs, demos, and architecture documentation to include the new `xs` size option and its sizing semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->