### PR TITLE
fix(theme-tailwind): surface-aware soft dark fill for alert + list-empty (#1662)

### DIFF
--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -482,7 +482,10 @@ export default function tailwindTheme(): Theme {
                 classes: { root: 'py-2 text-center text-sm text-fg-muted' },
                 variants: { overlay: { true: { root: 'absolute inset-0 z-10 flex items-center justify-center bg-bg/75 backdrop-blur-sm' } } },
             },
-            listEmpty: { classes: { root: 'rounded-md border border-warning-200 bg-warning-50 p-2 text-sm text-warning-800' } },
+            // Soft warning "empty / no-more" marker. Dark fill is a low-opacity
+            // tint of the mid shade so it harmonizes with any customized dark
+            // `--vc-color-bg` rather than staying a glaring light panel (#1662).
+            listEmpty: { classes: { root: 'rounded-md border border-warning-200 bg-warning-50 p-2 text-sm text-warning-800 dark:border-warning-800 dark:bg-warning-500/12 dark:text-warning-200' } },
             navigation: {
                 classes: {
                     group: 'm-0 flex list-none flex-col p-0',
@@ -843,13 +846,16 @@ export default function tailwindTheme(): Theme {
                     { variants: { variant: 'solid', color: 'warning' }, class: { root: 'bg-warning-600 text-on-warning border-warning-700' } },
                     { variants: { variant: 'solid', color: 'error' }, class: { root: 'bg-error-600 text-on-error border-error-700' } },
                     { variants: { variant: 'solid', color: 'info' }, class: { root: 'bg-info-600 text-on-info border-info-700' } },
-                    // soft
-                    { variants: { variant: 'soft', color: 'primary' }, class: { root: 'bg-primary-50 text-primary-800 border-primary-200 dark:bg-primary-950 dark:text-primary-200 dark:border-primary-800' } },
-                    { variants: { variant: 'soft', color: 'neutral' }, class: { root: 'bg-neutral-50 text-fg border-border dark:bg-neutral-900' } },
-                    { variants: { variant: 'soft', color: 'success' }, class: { root: 'bg-success-50 text-success-800 border-success-200 dark:bg-success-950 dark:text-success-200 dark:border-success-800' } },
-                    { variants: { variant: 'soft', color: 'warning' }, class: { root: 'bg-warning-50 text-warning-800 border-warning-200 dark:bg-warning-950 dark:text-warning-200 dark:border-warning-800' } },
-                    { variants: { variant: 'soft', color: 'error' }, class: { root: 'bg-error-50 text-error-800 border-error-200 dark:bg-error-950 dark:text-error-200 dark:border-error-800' } },
-                    { variants: { variant: 'soft', color: 'info' }, class: { root: 'bg-info-50 text-info-800 border-info-200 dark:bg-info-950 dark:text-info-200 dark:border-info-800' } },
+                    // soft — surface-aware dark fill: a low-opacity tint of the
+                    // mid shade (not the opaque deep `-950`) so the actual
+                    // `--vc-color-bg` shows through and the panel harmonizes with
+                    // any customized dark surface instead of reading muddy (#1662).
+                    { variants: { variant: 'soft', color: 'primary' }, class: { root: 'bg-primary-50 text-primary-800 border-primary-200 dark:bg-primary-500/12 dark:text-primary-200 dark:border-primary-800' } },
+                    { variants: { variant: 'soft', color: 'neutral' }, class: { root: 'bg-neutral-50 text-fg border-border dark:bg-neutral-500/12' } },
+                    { variants: { variant: 'soft', color: 'success' }, class: { root: 'bg-success-50 text-success-800 border-success-200 dark:bg-success-500/12 dark:text-success-200 dark:border-success-800' } },
+                    { variants: { variant: 'soft', color: 'warning' }, class: { root: 'bg-warning-50 text-warning-800 border-warning-200 dark:bg-warning-500/12 dark:text-warning-200 dark:border-warning-800' } },
+                    { variants: { variant: 'soft', color: 'error' }, class: { root: 'bg-error-50 text-error-800 border-error-200 dark:bg-error-500/12 dark:text-error-200 dark:border-error-800' } },
+                    { variants: { variant: 'soft', color: 'info' }, class: { root: 'bg-info-50 text-info-800 border-info-200 dark:bg-info-500/12 dark:text-info-200 dark:border-info-800' } },
                     // outline
                     { variants: { variant: 'outline', color: 'primary' }, class: { root: 'border-primary-600 text-primary-700 bg-transparent dark:text-primary-200' } },
                     { variants: { variant: 'outline', color: 'neutral' }, class: { root: 'border-border text-fg bg-transparent' } },


### PR DESCRIPTION
Fixes #1662.

## Problem
Soft tinted panels in `@vuecs/theme-tailwind` used the opaque deepest shade `{c}-950` as their dark-mode background. On any customized dark `--vc-color-bg` other than the default near-black neutral (e.g. Nord `#2E3440`), the opaque `-950` amber/red reads as a **muddy patch** instead of a tint of the surface.

## Fix
Replace the opaque fill with a low-opacity tint of the **mid** shade (`dark:bg-{c}-500/12`) so the actual surface shows through and the panel harmonizes with any dark `--vc-color-bg`.

- **`VCAlert` soft variants** (all six colors) — `dark:bg-{c}-950` → `dark:bg-{c}-500/12` (neutral: `dark:bg-neutral-900` → `dark:bg-neutral-500/12`).
- **`listEmpty`** (the "empty / no-more" marker) — was light-only (`bg-warning-50`, no dark variant → a glaring light panel in dark mode); now gains the matching surface-aware dark treatment.

Light-mode fills and the `dark:text-*` / `dark:border-*` parts are unchanged (the issue confirms those are fine). The `/opacity` modifier on semantic shades is already a shipped pattern here (table-row variants use `dark:bg-{c}-950/30`).

## Scope
- **theme-tailwind only.** The Bootstrap/Bulma bridges map onto framework runtime variables (`--bs-*` / `--bulma-*`), not opaque `-950` shades, so they're unaffected.
- Toast / table-row / button / badge soft variants already use low-opacity tints and aren't the opaque case the issue flags — left alone.
- No public API change (props/slots/events unchanged); docs don't hardcode these internal class strings.

## Verification
- `themes/tailwind` unit tests pass (8/8, including the theme audit).
- ESLint clean.
- Theme is aliased to `src` in the example apps, so the change is live in the Nuxt/Vite demos with no rebuild (Tailwind generates the new `bg-{c}-500/12` utilities on scan).