### PR TITLE
fix(theme-tailwind): add cursor-pointer to enabled VCButton (#1656)

### DIFF
--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -331,7 +331,7 @@ export default function tailwindTheme(): Theme {
                     // active color's `-500` shade picked per variant. `gap-2`
                     // (8px) keeps the leading-icon / spinner visually
                     // separated from the label without looking spaced-out.
-                    root: 'inline-flex items-center justify-center gap-2 rounded-md font-medium shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-60',
+                    root: 'inline-flex items-center justify-center gap-2 rounded-md font-medium shadow-sm transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-60',
                     leading: 'inline-flex shrink-0 items-center',
                     trailing: 'inline-flex shrink-0 items-center',
                     label: '',


### PR DESCRIPTION
Fixes #1656.

## Problem
`@vuecs/theme-tailwind`'s `button` element set `disabled:cursor-not-allowed` but **no base `cursor-pointer`**, so an enabled `<button>`-rendered `<VCButton>` showed the native default arrow cursor instead of a pointer. (Native `<button>` and Tailwind v4 preflight both default to `cursor: default`/`auto`.) The button was the odd one out — link, switch, dropdown item, and card already include `cursor-pointer`.

## Fix
Add `cursor-pointer` to `button.classes.root`:

```diff
- ...transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-60
+ ...transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-60
```

The existing `disabled:cursor-not-allowed` still wins for the disabled state (the `disabled:` variant is ordered after the base utility), so only enabled buttons get the pointer.

## Scope & verification
- **theme-tailwind only**; one-line change, no API/docs impact.
- ESLint clean; `themes/tailwind` unit tests pass (8/8, incl. the theme audit).