### PR TITLE
test(forms): restore non-vacuous type-test checking under TS6 (#1659)

### DIFF
--- a/packages/forms/test/tsconfig.json
+++ b/packages/forms/test/tsconfig.json
@@ -2,7 +2,8 @@
     "extends": "../tsconfig.json",
     "compilerOptions": {
         "strictNullChecks": true,
-        "noEmit": true
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
     },
     "include": [
         "types/**/*.test-d.ts"


### PR DESCRIPTION
Fixes #1659.

## Problem
The `@vuecs/forms` vitest `typecheck` guard (`test/types/model-value.test-d.ts` — the #1613 regression guard) was **vacuous**. The root `tsconfig.json` sets `baseUrl: "."`, which raises **TS5101** under TypeScript 6. `vue-tsc` treats that config-level error as fatal and skips type-checking the program files, so the guard reported `Type Errors: no errors` even on a guaranteed-wrong assertion — it would **not** have failed CI if #1613 regressed.

## Fix
Add `"ignoreDeprecations": "6.0"` to `packages/forms/test/tsconfig.json`, mirroring the `table` / `list` test configs (the same fix landed for `@vuecs/table` in #1658).

## Verification (proof of non-vacuity)
Appended a guaranteed-wrong control to the guard and ran `npm run test --workspace=packages/forms`:

| State | Control `expectTypeOf<number>().toEqualTypeOf<string>()` |
|---|---|
| **Before** (no `ignoreDeprecations`) | passes — `Type Errors: no errors` ❌ vacuous |
| **After** (this PR) | **fails** with `TS2344` — `Type Errors: 1 failed` ✅ real checking |

The real #1613 `modelValue` null-assignability assertions **pass under the restored checking** — the vacuity was not masking a regression. The control was removed before committing.

## Audit (issue item 3)
Repo-wide sweep: `forms` / `table` / `list` are the only vitest `typecheck` guards. `table` + `list` were already fixed; `forms` was the remaining gap. No other config inherits the problem. (`tests/visual-regression` has no `*.test-d.ts` guards, so it's unaffected.)

## Deferred (issue item 4, optional)
Dropping `baseUrl` repo-wide ahead of TypeScript 7's hard removal. It's straightforward — the root `paths` entries are already `./`-prefixed, so they resolve without `baseUrl` on TS ≥4.1 — but it touches the root `tsconfig.json` the whole repo + IDE rely on, so it belongs in a separate focused change rather than this targeted guard fix.