### PR TITLE
feat(elements): override VCAlert leading icon via #icon slot (#1672)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2521,12 +2521,18 @@ available. Resolution order per cell:
    `{ value, key, row }` and its return value is rendered. Otherwise
    `null` / `undefined` render as `''`; everything else via `String(...)`.
 
-The slot-vs-auto branch is decided by `hasMeaningfulSlotContent()` —
-Vue passes `slots.default` as an always-present render fn when a
-`<template>` slot is declared, so a naive `slots.default?.()` truthy
-check would always pick the slot path. The helper walks the returned
-vnode array and considers a slot meaningful when it contains an
-element, a component, or a text node with non-whitespace content.
+The slot-vs-auto branch is decided by `isMeaningfulSlotContent()`
+(a shared helper exported from `@vuecs/core`) — Vue passes
+`slots.default` as an always-present render fn when a `<template>`
+slot is declared, so a naive `slots.default?.()` truthy check would
+always pick the slot path. The helper walks the returned vnode array
+(recursing into `Fragment` children) and considers a slot meaningful
+when it contains an element, a component, or a text node with
+non-whitespace content — comment anchors (`v-if="false"`), whitespace,
+and empty arrays are treated as empty. The same helper gates the
+`<VCAlert>` `#icon` slot and `<VCButton>`'s `#leading` / `#trailing`
+slots (fall back to the icon prop / default) and `<VCTableCell>`'s
+auto-render.
 
 Mounting `<VCTableCell>` outside a `<VCTable>` context renders an
 empty cell — no fallback to `row[columnKey]` from inject. Manual

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -111,7 +111,7 @@ packages/core/src/
     composable.ts     # useComponentDefaults() Vue composable
     install.ts        # installDefaultsManager() / injectDefaultsManager()
     index.ts          # Barrel exports
-  utils/              # Shared utilities (inject, provide, normalizeSlot, etc.)
+  utils/              # Shared utilities (inject, provide, normalizeSlot, isMeaningfulSlotContent, etc.)
   types.ts            # VNodeClass, VNodeProperties, PartialPick, GenericComponentShape
 ```
 

--- a/docs/src/components/alert.md
+++ b/docs/src/components/alert.md
@@ -103,6 +103,24 @@ For an animated dismiss, wrap with [`<VCCollapse>`](/components/collapse) (see t
 
 Pass an empty string (`:icon="''"`) to suppress the icon entirely.
 
+For full control over the leading visual — a custom-styled `<VCIcon>`, a
+spinner, an image, or any component — use the `#icon` slot. It renders in
+the alert's icon position and takes precedence over the `:icon` prop and
+the color-derived default:
+
+```vue
+<VCAlert color="warning">
+    <template #icon>
+        <VCIcon name="fa6-solid:upload" class="text-lg" />
+    </template>
+    Upload one or more code files…
+</VCAlert>
+```
+
+Precedence is `#icon` slot → `:icon` prop → color-derived default. An empty
+(or `v-if="false"`) slot falls back to the prop / default, so `:icon="''"`
+still suppresses when the slot renders nothing.
+
 ### Dismiss with collapse animation
 
 Compose with [`<VCCollapse>`](/components/collapse) for a height-collapse on dismiss (instead of instant unmount):
@@ -193,9 +211,16 @@ Override via `<VCAlert role="log">` for custom interaction patterns (e.g. chat l
 | `color` | `'primary' \| 'neutral' \| 'info' \| 'success' \| 'warning' \| 'error'` | `undefined` | Folded into `themeVariant`; auto-resolves the icon + ARIA role for `info/success/warning/error`. `primary` and `neutral` use no preset icon by default (pass `:icon` explicitly to render one). |
 | `variant` | `'solid' \| 'soft' \| 'outline'` | `undefined` | Folded into `themeVariant`. |
 | `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | `undefined` | Folded into `themeVariant`. |
-| `icon` | `string` | `undefined` (preset default for `color`) | Iconify name. Pass `''` to suppress. |
+| `icon` | `string` | `undefined` (preset default for `color`) | Iconify name. Pass `''` to suppress. Overridden by the `#icon` slot. |
 | `role` | `string` | derived from `color` | ARIA role override. |
 | `as` | `string` | `'div'` | HTML tag to render. |
+
+#### Slots
+
+| Slot | Props | Description |
+|---|---|---|
+| `default` | — | Alert body — title / description compound or inline text. |
+| `icon` | `{ class: string }` | Leading-icon override, rendered inside the icon wrapper in place of the `icon` prop / color-derived default. `class` is the resolved icon-wrapper theme class. An empty (or `v-if="false"`) slot falls back to the prop / default. |
 
 `<VCAlert>` is presentational — wrap with `v-if` (instant dismissal) or `<VCCollapse v-model:open>` (animated). No `v-model:open` on the alert itself.
 

--- a/docs/src/components/alert.md
+++ b/docs/src/components/alert.md
@@ -121,6 +121,13 @@ Precedence is `#icon` slot → `:icon` prop → color-derived default. An empty
 (or `v-if="false"`) slot falls back to the prop / default, so `:icon="''"`
 still suppresses when the slot renders nothing.
 
+The color-derived / `:icon` icon is decorative, so its wrapper is
+`aria-hidden` (the alert's `role` + text carry the meaning). The `#icon`
+slot wrapper is **not** `aria-hidden` — its content is yours and may be
+meaningful or interactive (a live `role="status"` spinner, a focusable
+control). If you slot a purely decorative icon, mark it `aria-hidden`
+yourself.
+
 ### Dismiss with collapse animation
 
 Compose with [`<VCCollapse>`](/components/collapse) for a height-collapse on dismiss (instead of instant unmount):
@@ -220,7 +227,7 @@ Override via `<VCAlert role="log">` for custom interaction patterns (e.g. chat l
 | Slot | Props | Description |
 |---|---|---|
 | `default` | — | Alert body — title / description compound or inline text. |
-| `icon` | `{ class: string }` | Leading-icon override, rendered inside the icon wrapper in place of the `icon` prop / color-derived default. `class` is the resolved icon-wrapper theme class. An empty (or `v-if="false"`) slot falls back to the prop / default. |
+| `icon` | `{ class: string }` | Leading-icon override, rendered inside the icon wrapper in place of the `icon` prop / color-derived default. `class` is the resolved icon-wrapper theme class. An empty (or `v-if="false"`) slot falls back to the prop / default. The slot wrapper is **not** `aria-hidden` (consumer owns slot a11y); the prop / color-derived icon wrapper is. |
 
 `<VCAlert>` is presentational — wrap with `v-if` (instant dismissal) or `<VCCollapse v-model:open>` (animated). No `v-model:open` on the alert itself.
 

--- a/packages/button/src/component.ts
+++ b/packages/button/src/component.ts
@@ -1,4 +1,4 @@
-import { useComponentTheme } from '@vuecs/core';
+import { isMeaningfulSlotContent, useComponentTheme } from '@vuecs/core';
 import type {
     ComponentThemeDefinition,
     ThemeClassesOverride,
@@ -113,10 +113,10 @@ export const VCButton = defineComponent({
 
             const children: VNodeArrayChildren = [];
 
-            // Empty slot results (`<template #leading />` returning []) used to
-            // emit a wrapper <span> with no children — functionally inert but
-            // dead markup. Coerce slot output to non-empty before pushing.
-            const isNonEmptySlot = (out: unknown): out is VNodeArrayChildren => Array.isArray(out) && out.length > 0;
+            // Empty slot results (`<template #leading />` returning [], or a
+            // `v-if="false"` comment) would otherwise emit a wrapper <span>
+            // with no visible children — functionally inert but dead markup.
+            // `isMeaningfulSlotContent` (from @vuecs/core) gates that out.
 
             // When loading, the leading slot becomes a spinner — universally
             // legible loading affordance, replaces any consumer-provided icon
@@ -138,7 +138,7 @@ export const VCButton = defineComponent({
                 ]));
             } else if (slots.leading) {
                 const leadingOut = slots.leading(slotProps);
-                if (isNonEmptySlot(leadingOut)) {
+                if (isMeaningfulSlotContent(leadingOut)) {
                     children.push(h('span', { class: resolved.leading || undefined }, leadingOut));
                 }
             } else if (props.iconLeft) {
@@ -151,7 +151,7 @@ export const VCButton = defineComponent({
             }
 
             const slotLabel = slots.default ? slots.default(slotProps) : undefined;
-            if (isNonEmptySlot(slotLabel)) {
+            if (isMeaningfulSlotContent(slotLabel)) {
                 children.push(h('span', { class: resolved.label || undefined }, slotLabel));
             } else if (typeof props.label === 'string' && props.label !== '') {
                 children.push(h('span', { class: resolved.label || undefined }, props.label));
@@ -159,7 +159,7 @@ export const VCButton = defineComponent({
 
             if (slots.trailing) {
                 const trailingOut = slots.trailing(slotProps);
-                if (isNonEmptySlot(trailingOut)) {
+                if (isMeaningfulSlotContent(trailingOut)) {
                     children.push(h('span', { class: resolved.trailing || undefined }, trailingOut));
                 }
             } else if (props.iconRight) {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from './evaluate';
 export * from './inject';
 export * from './object';
 export * from './normalize-slot';
+export * from './slot-content';
 export * from './primitive';
 export * from './promise';
 export * from './provide';

--- a/packages/core/src/utils/slot-content.ts
+++ b/packages/core/src/utils/slot-content.ts
@@ -1,0 +1,45 @@
+import {
+    Comment,
+    Fragment,
+    Text,
+} from 'vue';
+import type { VNode } from 'vue';
+
+/**
+ * Whether the given rendered slot output carries *meaningful* content —
+ * i.e. would produce visible / structural DOM rather than only comment
+ * anchors (`v-if="false"`), whitespace text, or an empty array.
+ *
+ * Vue hands a declared `<template #slot>` to a component as an
+ * always-present render function, so a naive `slots.foo?.()` truthiness
+ * check can't tell "consumer passed real content" apart from "slot
+ * declared but rendered nothing". Pass the *rendered* vnodes (invoke the
+ * slot at most once per render — slot fns can be non-trivial) and let this
+ * walk them: it recurses into `Fragment` children, so a `<template v-if>` /
+ * `<template v-for>` / multi-root slot is classified by its actual
+ * contents rather than by the wrapping Fragment.
+ *
+ * Callers use it to decide whether to render a slot's wrapper vs fall back
+ * to a prop / default (`<VCAlert #icon>`, `<VCButton #leading>`) and
+ * whether a cell should auto-render its column value (`<VCTableCell>`).
+ */
+export function isMeaningfulSlotContent(nodes: unknown): boolean {
+    if (nodes == null || nodes === false) return false;
+    if (typeof nodes === 'string') return nodes.trim().length > 0;
+    if (typeof nodes === 'number') return true;
+    if (Array.isArray(nodes)) {
+        return nodes.some((child) => isMeaningfulSlotContent(child));
+    }
+    if (typeof nodes !== 'object') return false;
+    const v = nodes as VNode;
+    if (v.type === Comment) return false;
+    if (v.type === Text) {
+        return typeof v.children === 'string' && v.children.trim().length > 0;
+    }
+    if (v.type === Fragment) {
+        return isMeaningfulSlotContent(v.children);
+    }
+    // Element or component vnode (string tag, object component, or a
+    // symbol type other than the ones handled above).
+    return true;
+}

--- a/packages/core/test/unit/utils/slot-content.spec.ts
+++ b/packages/core/test/unit/utils/slot-content.spec.ts
@@ -1,0 +1,57 @@
+import {
+    Fragment,
+    createCommentVNode,
+    createTextVNode,
+    h,
+} from 'vue';
+import {
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { isMeaningfulSlotContent } from '../../../src';
+
+describe('isMeaningfulSlotContent', () => {
+    it('treats nullish / false / empty array as empty', () => {
+        expect(isMeaningfulSlotContent(undefined)).toBe(false);
+        expect(isMeaningfulSlotContent(null)).toBe(false);
+        expect(isMeaningfulSlotContent(false)).toBe(false);
+        expect(isMeaningfulSlotContent([])).toBe(false);
+    });
+
+    it('treats a bare string by trimmed length', () => {
+        expect(isMeaningfulSlotContent('')).toBe(false);
+        expect(isMeaningfulSlotContent('   ')).toBe(false);
+        expect(isMeaningfulSlotContent('x')).toBe(true);
+    });
+
+    it('treats any number as meaningful (including 0)', () => {
+        expect(isMeaningfulSlotContent(0)).toBe(true);
+        expect(isMeaningfulSlotContent(5)).toBe(true);
+    });
+
+    it('ignores comment vnodes (v-if="false" anchors)', () => {
+        expect(isMeaningfulSlotContent([createCommentVNode('')])).toBe(false);
+        expect(isMeaningfulSlotContent(createCommentVNode('v-if'))).toBe(false);
+    });
+
+    it('classifies text vnodes by trimmed content', () => {
+        expect(isMeaningfulSlotContent([createTextVNode('   ')])).toBe(false);
+        expect(isMeaningfulSlotContent([createTextVNode('hi')])).toBe(true);
+    });
+
+    it('treats element / component vnodes as meaningful', () => {
+        expect(isMeaningfulSlotContent([h('span', 'x')])).toBe(true);
+        expect(isMeaningfulSlotContent(h('svg'))).toBe(true);
+    });
+
+    it('recurses into Fragment children', () => {
+        expect(isMeaningfulSlotContent([h(Fragment, [createCommentVNode('')])])).toBe(false);
+        expect(isMeaningfulSlotContent([h(Fragment, [createTextVNode('  '), createCommentVNode('')])])).toBe(false);
+        expect(isMeaningfulSlotContent([h(Fragment, [h('span', 'x')])])).toBe(true);
+    });
+
+    it('returns true when any array member is meaningful', () => {
+        expect(isMeaningfulSlotContent([createCommentVNode(''), h('span', 'x')])).toBe(true);
+    });
+});

--- a/packages/elements/README.md
+++ b/packages/elements/README.md
@@ -20,7 +20,7 @@
 **Compounds**
 
 - 🗂️ **Card** — `<VCCard>` + Header / Title / Description / Body / Footer. `variant` (`outline` / `soft` / `elevated`), `interactive` hover/focus ring for whole-card links (`as-child` + `<NuxtLink>`), and `padding` set once on the root and inherited by every band. Plus `<VCCardPlaceholder>`, the matching skeleton.
-- 🚨 **Alert** — `<VCAlert>` + Title / Description / Close. Persistent banner with a 15-cell `variant` × `color` matrix.
+- 🚨 **Alert** — `<VCAlert>` + Title / Description / Close. Persistent banner with a 15-cell `variant` × `color` matrix. Leading icon resolves from `color`, an `:icon` name prop, or the `#icon` slot for arbitrary content.
 - 📂 **Collapse** — `<VCCollapse>` + Trigger / Content (Reka Collapsible) with auto-chevron and height animation.
 
 ## 📦 Installation

--- a/packages/elements/src/components/alert/Alert.vue
+++ b/packages/elements/src/components/alert/Alert.vue
@@ -139,10 +139,19 @@ export default defineComponent({
             const iconSlot = slots.icon?.({ class: theme.value.icon });
             let iconNode: VNode | null = null;
             if (isMeaningfulSlotContent(iconSlot)) {
-                iconNode = h('div', { class: iconClass, 'aria-hidden': 'true' }, iconSlot);
+                // No `aria-hidden` on the slot path: `#icon` content is
+                // consumer-owned and may be meaningful or interactive (a live
+                // `role="status"` spinner, a focusable control). Forcing
+                // `aria-hidden` here would hide announced/focusable content
+                // from assistive tech — the `aria-hidden-focus` anti-pattern
+                // (WCAG 4.1.2). The consumer owns the slot's semantics; a
+                // purely decorative icon can set `aria-hidden` itself.
+                iconNode = h('div', { class: iconClass }, iconSlot);
             } else {
                 const iconValue = iconName.value;
                 if (iconValue && hasIconComponent) {
+                    // Decorative prop / color-derived icon — hidden from AT;
+                    // the alert's `role` + text content carry the semantics.
                     iconNode = h('div', { class: iconClass, 'aria-hidden': 'true' }, [
                         h(VCIcon as Component, { name: iconValue }),
                     ]);

--- a/packages/elements/src/components/alert/Alert.vue
+++ b/packages/elements/src/components/alert/Alert.vue
@@ -6,8 +6,15 @@ import {
     mergeProps,
     resolveComponent,
 } from 'vue';
-import type { Component, ExtractPublicPropTypes, PropType } from 'vue';
+import type {
+    Component,
+    ExtractPublicPropTypes,
+    PropType,
+    SlotsType,
+    VNode,
+} from 'vue';
 import {
+    isMeaningfulSlotContent,
     themableProps,
     useComponentDefaults,
     useComponentTheme,
@@ -50,6 +57,11 @@ const alertProps = {
 
 export type AlertProps = ExtractPublicPropTypes<typeof alertProps>;
 
+export type AlertIconSlotProps = {
+    /** Resolved theme class for the leading-icon wrapper. */
+    class: string;
+};
+
 const alertBehavioralDefaults: AlertDefaults = {
     primaryIcon: '',
     neutralIcon: '',
@@ -74,6 +86,16 @@ export default defineComponent({
     name: 'VCAlert',
     inheritAttrs: false,
     props: alertProps,
+    slots: Object as SlotsType<{
+        /** Alert body — title / description compound or inline text. */
+        default?: Record<string, never>;
+        /**
+         * Leading-icon override. Rendered inside the icon wrapper in place
+         * of the `icon` prop / color-derived default. An empty (or
+         * `v-if="false"`) slot falls back to the prop / default.
+         */
+        icon?: AlertIconSlotProps;
+    }>,
     setup(props, { attrs, slots }) {
         const themeProps = useThemeProps(props, 'color', 'variant', 'size');
         const theme = useComponentTheme('alert', themeProps, alertThemeDefaults);
@@ -107,8 +129,25 @@ export default defineComponent({
         const hasIconComponent = typeof VCIcon !== 'string';
 
         return () => {
-            const iconValue = iconName.value;
-            const showIcon = !!iconValue && hasIconComponent;
+            const iconClass = theme.value.icon || undefined;
+
+            // Precedence: `#icon` slot → `icon` prop → color-derived default.
+            // The wrapper is a `<div>` (flow content) rather than a `<span>`
+            // so an arbitrary `#icon` slot — including block-level content
+            // like a spinner — nests validly. `.vc-alert-icon` sets
+            // `display: inline-flex`, so the tag has no layout effect.
+            const iconSlot = slots.icon?.({ class: theme.value.icon });
+            let iconNode: VNode | null = null;
+            if (isMeaningfulSlotContent(iconSlot)) {
+                iconNode = h('div', { class: iconClass, 'aria-hidden': 'true' }, iconSlot);
+            } else {
+                const iconValue = iconName.value;
+                if (iconValue && hasIconComponent) {
+                    iconNode = h('div', { class: iconClass, 'aria-hidden': 'true' }, [
+                        h(VCIcon as Component, { name: iconValue }),
+                    ]);
+                }
+            }
 
             return h(
                 props.as,
@@ -117,9 +156,7 @@ export default defineComponent({
                     class: theme.value.root || undefined,
                 }),
                 [
-                    showIcon ? h('span', { class: theme.value.icon || undefined, 'aria-hidden': 'true' }, [
-                        h(VCIcon as Component, { name: iconValue }),
-                    ]) : null,
+                    iconNode,
                     h('div', { class: theme.value.content || undefined }, slots.default?.()),
                 ],
             );

--- a/packages/elements/src/components/alert/index.ts
+++ b/packages/elements/src/components/alert/index.ts
@@ -3,7 +3,7 @@ export { default as VCAlertTitle } from './AlertTitle.vue';
 export { default as VCAlertDescription } from './AlertDescription.vue';
 export { default as VCAlertClose } from './AlertClose.vue';
 
-export type { AlertProps } from './Alert.vue';
+export type { AlertProps, AlertIconSlotProps } from './Alert.vue';
 export type { AlertTitleProps } from './AlertTitle.vue';
 export type { AlertDescriptionProps } from './AlertDescription.vue';
 export type { AlertCloseProps } from './AlertClose.vue';

--- a/packages/elements/test/unit/alert.spec.ts
+++ b/packages/elements/test/unit/alert.spec.ts
@@ -5,7 +5,12 @@ import {
     expect,
     it,
 } from 'vitest';
-import { defineComponent, h, ref } from 'vue';
+import {
+    Comment,
+    defineComponent,
+    h,
+    ref,
+} from 'vue';
 import { mount } from '@vue/test-utils';
 import vuecsElements, {
     VCAlert,
@@ -126,6 +131,80 @@ describe('<VCAlert>', () => {
             });
             expect((wrapper.element as HTMLElement)
                 .querySelector('[data-test-icon="lucide:circle-x"]')).not.toBeNull();
+        });
+    });
+
+    describe('#icon slot', () => {
+        it('renders the #icon slot inside the icon wrapper', () => {
+            const wrapper = mount(defineComponent({
+                setup: () => () => h(VCAlert, { color: 'warning' }, {
+                    icon: () => h('svg', { 'data-test-slot-icon': '' }),
+                    default: () => 'x',
+                }),
+            }), { global: { plugins: [...plugins] } });
+            const iconWrapper = (wrapper.element as HTMLElement).querySelector('.vc-alert-icon');
+            expect(iconWrapper).not.toBeNull();
+            expect(iconWrapper!.getAttribute('aria-hidden')).toBe('true');
+            expect(iconWrapper!.querySelector('[data-test-slot-icon]')).not.toBeNull();
+        });
+
+        it('takes precedence over the :icon prop and color-derived default', () => {
+            const VCIcon = defineComponent({
+                name: 'VCIcon',
+                props: ['name'],
+                setup: (props) => () => h('span', { 'data-test-icon': props.name }),
+            });
+            const wrapper = mount(defineComponent({
+                setup: () => () => h(VCAlert, { color: 'error', icon: 'lucide:x' }, {
+                    icon: () => h('svg', { 'data-test-slot-icon': '' }),
+                    default: () => 'x',
+                }),
+            }), { global: { plugins: [...plugins], components: { VCIcon } } });
+            const root = wrapper.element as HTMLElement;
+            // Slot content is rendered; the prop-driven VCIcon is not.
+            expect(root.querySelector('[data-test-slot-icon]')).not.toBeNull();
+            expect(root.querySelector('[data-test-icon]')).toBeNull();
+        });
+
+        it('exposes the resolved icon-wrapper class as a slot prop', () => {
+            let received: string | undefined;
+            mount(defineComponent({
+                setup: () => () => h(VCAlert, { color: 'warning' }, {
+                    icon: (props: { class: string }) => {
+                        received = props.class;
+                        return h('span', 'x');
+                    },
+                    default: () => 'x',
+                }),
+            }), { global: { plugins: [...plugins] } });
+            expect(received).toBe('vc-alert-icon');
+        });
+
+        it('an empty slot falls back to the :icon prop / default (no empty wrapper)', () => {
+            const VCIcon = defineComponent({
+                name: 'VCIcon',
+                props: ['name'],
+                setup: (props) => () => h('span', { 'data-test-icon': props.name }),
+            });
+            const wrapper = mount(defineComponent({
+                setup: () => () => h(VCAlert, { color: 'error', icon: 'lucide:x' }, {
+                    icon: () => null,
+                    default: () => 'x',
+                }),
+            }), { global: { plugins: [...plugins], components: { VCIcon } } });
+            const root = wrapper.element as HTMLElement;
+            // Empty slot → fall back to the prop-driven icon.
+            expect(root.querySelector('[data-test-icon="lucide:x"]')).not.toBeNull();
+        });
+
+        it('a whitespace-only / commented slot does not render an icon wrapper when the prop is suppressed', () => {
+            const wrapper = mount(defineComponent({
+                setup: () => () => h(VCAlert, { color: 'error', icon: '' }, {
+                    icon: () => [h(Comment, ''), '   '],
+                    default: () => 'x',
+                }),
+            }), { global: { plugins: [...plugins] } });
+            expect((wrapper.element as HTMLElement).querySelector('.vc-alert-icon')).toBeNull();
         });
     });
 

--- a/packages/elements/test/unit/alert.spec.ts
+++ b/packages/elements/test/unit/alert.spec.ts
@@ -144,8 +144,33 @@ describe('<VCAlert>', () => {
             }), { global: { plugins: [...plugins] } });
             const iconWrapper = (wrapper.element as HTMLElement).querySelector('.vc-alert-icon');
             expect(iconWrapper).not.toBeNull();
-            expect(iconWrapper!.getAttribute('aria-hidden')).toBe('true');
             expect(iconWrapper!.querySelector('[data-test-slot-icon]')).not.toBeNull();
+        });
+
+        it('does NOT force aria-hidden on the consumer-owned slot wrapper', () => {
+            // Slot content may be meaningful / interactive (a live spinner, a
+            // focusable control); hiding it from AT would be the
+            // aria-hidden-focus anti-pattern. The consumer owns slot a11y.
+            const wrapper = mount(defineComponent({
+                setup: () => () => h(VCAlert, { color: 'warning' }, {
+                    icon: () => h('svg', { 'data-test-slot-icon': '' }),
+                    default: () => 'x',
+                }),
+            }), { global: { plugins: [...plugins] } });
+            const iconWrapper = (wrapper.element as HTMLElement).querySelector('.vc-alert-icon');
+            expect(iconWrapper!.getAttribute('aria-hidden')).toBeNull();
+        });
+
+        it('keeps aria-hidden on the decorative prop/color icon wrapper', () => {
+            const VCIcon = defineComponent({
+                name: 'VCIcon',
+                props: ['name'],
+                setup: (props) => () => h('span', { 'data-test-icon': props.name }),
+            });
+            const wrapper = mount(defineComponent({ setup: () => () => h(VCAlert, { color: 'error', icon: 'lucide:x' }, { default: () => 'x' }) }), { global: { plugins: [...plugins], components: { VCIcon } } });
+            const iconWrapper = (wrapper.element as HTMLElement).querySelector('.vc-alert-icon');
+            expect(iconWrapper).not.toBeNull();
+            expect(iconWrapper!.getAttribute('aria-hidden')).toBe('true');
         });
 
         it('takes precedence over the :icon prop and color-derived default', () => {

--- a/packages/table/src/components/TableCell.vue
+++ b/packages/table/src/components/TableCell.vue
@@ -1,8 +1,5 @@
 <script lang="ts">
 import {
-    Comment,
-    Fragment,
-    Text,
     defineComponent,
     h,
     mergeProps,
@@ -10,10 +7,14 @@ import {
 import type {
     ExtractPublicPropTypes,
     PropType,
-    VNode,
     VNodeArrayChildren,
 } from 'vue';
-import { themableProps, useComponentTheme, useThemeProps } from '@vuecs/core';
+import {
+    isMeaningfulSlotContent,
+    themableProps,
+    useComponentTheme,
+    useThemeProps,
+} from '@vuecs/core';
 import { useTable, useTableRow } from '../composables/context';
 import { resolveCellValue } from '../utils/render-utils';
 import type { TableCellThemeClasses } from '../types';
@@ -49,47 +50,6 @@ const tableCellProps = {
 };
 
 export type TableCellProps = ExtractPublicPropTypes<typeof tableCellProps>;
-
-/**
- * Detect whether the consumer-passed default slot's rendered vnodes
- * contain any meaningful content (vs being an empty / whitespace-only
- * / comment-only render).
- *
- * Vue passes `slots.default` as a render fn that's always present when
- * a `<template>` slot is declared (even if empty), so a naive
- * `slots.default?.()` truthy check would always pick the slot path
- * and skip the auto-render. Walk the rendered vnodes and recurse into
- * `Fragment` children — a `<template v-if>` / `<template v-for>` /
- * multi-child template renders as a Fragment whose `children` is the
- * actual content. Without recursion those would be falsely classified
- * as empty.
- *
- * Takes the pre-rendered vnodes (not the slot fn) so the caller can
- * invoke the slot at most once per render — slot fns can be
- * non-trivial and should not be called twice.
- */
-function hasMeaningfulSlotContent(nodes: unknown): boolean {
-    if (nodes == null || nodes === false) return false;
-    if (typeof nodes === 'string') return nodes.trim().length > 0;
-    if (typeof nodes === 'number') return true;
-    if (Array.isArray(nodes)) {
-        for (const child of nodes) {
-            if (hasMeaningfulSlotContent(child)) return true;
-        }
-        return false;
-    }
-    if (typeof nodes !== 'object') return false;
-    const v = nodes as VNode;
-    if (v.type === Comment) return false;
-    if (v.type === Text) {
-        return typeof v.children === 'string' && v.children.trim().length > 0;
-    }
-    if (v.type === Fragment) {
-        return hasMeaningfulSlotContent(v.children);
-    }
-    // Element or component vnode (string tag, object component, symbol other than the above).
-    return true;
-}
 
 export default defineComponent({
     name: 'VCTableCell',
@@ -164,7 +124,7 @@ export default defineComponent({
                 props.columnKey &&
                 tableCtx &&
                 rowCtx &&
-                !hasMeaningfulSlotContent(slotVNodes)
+                !isMeaningfulSlotContent(slotVNodes)
             ) {
                 const column = tableCtx.columns.value
                     .find((c) => c.key === props.columnKey);


### PR DESCRIPTION
Closes #1672.

## Summary

`<VCAlert>` previously exposed its leading icon only through the `icon`
name prop (Iconify string). This adds an **`#icon` slot** so consumers
can render arbitrary leading content — a custom-styled `<VCIcon>`, a
spinner, an image, or any component — while keeping the alert's layout
and a11y.

```vue
<VCAlert color="warning">
  <template #icon>
    <VCIcon name="fa6-solid:upload" class="text-lg" />
  </template>
  Upload one or more code files…
</VCAlert>
```

**Precedence:** `#icon` slot → `icon` prop → color-derived default. An
empty (or `v-if="false"`) slot falls back to the prop / default, so
`:icon=""` still suppresses.

The icon wrapper changed from a `<span>` to a `<div>` (flow content) so
block-level slot content nests as valid HTML. `.vc-alert-icon` sets
`display: inline-flex`, so this is layout-neutral (no theme targets it
by tag, and no visual-regression impact).

## Shared helper consolidation

The "does this slot render meaningful content?" check was duplicated —
a recursive `hasMeaningfulSlotContent` in `@vuecs/table`'s `TableCell`
and a shallow `isNonEmptySlot` in `@vuecs/button`. This PR promotes the
recursive version to a single exported `@vuecs/core` util,
**`isMeaningfulSlotContent`**, and adopts it in all three call sites
(alert `#icon`, table auto-render, button `#leading`/`#trailing`).

Side effect: `@vuecs/button` no longer emits a dead wrapper `<span>` for
a comment-only slot (`<template #leading><X v-if="false"/></template>`).

> Note: `<VCButton>` already supported arbitrary leading/trailing content
> via its existing `#leading` / `#trailing` slots — no new button slots
> were added, only the shared-helper adoption.

## Tests / verification

- New `@vuecs/core` unit test for `isMeaningfulSlotContent` (nullish,
  strings, numbers, comment/text/element vnodes, Fragment recursion).
- New `#icon` slot cases in the elements alert spec (precedence over
  prop, slot-prop `class`, empty-slot fallback, whitespace/comment slot).
- `@vuecs/core` (323), `@vuecs/elements` (61), `@vuecs/table` (174) test
  suites pass; all affected packages build clean; `npm run lint` reports
  0 errors.

## Docs

- `docs/src/components/alert.md` — custom-icon section + slots table.
- `packages/elements/README.md` — one-liner.
- `.agents/architecture.md` + `.agents/structure.md` — helper promotion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alerts now support an `#icon` slot, letting you fully customize the leading icon and its placement.
  * Slot content detection is now shared across components for more consistent rendering behavior.

* **Bug Fixes**
  * Empty or comment-only slots no longer produce blank icon or button wrappers.
  * Table cells now reliably fall back to displayed data when the default slot has no meaningful content.
  * Alert icons now follow a clearer priority: slot content, then icon setting, then default styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->