### PR TITLE
fix(forms): keep select trigger label reactive to option label changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23651,6 +23651,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@vueuse/core": "^14.3.0",
+                "ohash": "^2.0.11",
                 "reka-ui": "^2.10.1"
             },
             "devDependencies": {

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -47,6 +47,7 @@
     },
     "dependencies": {
         "@vueuse/core": "^14.3.0",
+        "ohash": "^2.0.11",
         "reka-ui": "^2.10.1"
     },
     "devDependencies": {

--- a/packages/forms/src/components/form-select/FormSelect.vue
+++ b/packages/forms/src/components/form-select/FormSelect.vue
@@ -23,6 +23,7 @@ import {
     SelectViewport,
 } from 'reka-ui';
 import type { AcceptableValue } from 'reka-ui';
+import { isEqual } from 'ohash';
 import type {
     ExtractPublicPropTypes,
     PropType,
@@ -30,6 +31,7 @@ import type {
     VNodeChild,
 } from 'vue';
 import {
+    computed,
     defineComponent,
     h,
     mergeProps,
@@ -177,6 +179,40 @@ export default defineComponent({
             return items;
         };
 
+        // Same value semantics as Reka's `compare` (no `by` comparator is
+        // exposed): strings via `===`, everything else via ohash `isEqual`.
+        const isSelected = (value: AcceptableValue): boolean => {
+            if (props.modelValue === undefined || props.modelValue === null) {
+                return false;
+            }
+            if (typeof value === 'string') {
+                return value === props.modelValue;
+            }
+            return isEqual(value, props.modelValue);
+        };
+
+        // Reka's SelectValue derives the trigger label from SelectRoot's
+        // optionsSet — a snapshot of each item's DOM textContent taken once in
+        // SelectItemText's onMounted. A label that changes after mount (async
+        // i18n resolution, a locale switch while closed) never re-registers,
+        // so the CLOSED trigger keeps the stale text until the content
+        // remounts on open. Resolve the label from `props.options` instead and
+        // hand it to SelectValue's default slot, which bypasses the snapshot.
+        const selectedLabel = computed<string | undefined>(() => {
+            for (const item of props.options!) {
+                if (isFormOptionGroup(item)) {
+                    const match = item.options.find((option) => isSelected(option.value));
+                    if (match) {
+                        return match.label;
+                    }
+                } else if (isSelected(item.value)) {
+                    return item.label;
+                }
+            }
+
+            return undefined;
+        });
+
         return () => {
             const resolved = theme.value;
             const { placeholder } = defaults.value;
@@ -192,7 +228,11 @@ export default defineComponent({
             }, {
                 default: () => [
                     h(SelectTrigger, mergeProps({ class: resolved.trigger || undefined }, attrs), () => [
-                        h(SelectValue, { class: resolved.value || undefined, placeholder }),
+                        h(
+                            SelectValue,
+                            { class: resolved.value || undefined, placeholder },
+                            () => selectedLabel.value ?? placeholder,
+                        ),
                         h(SelectIcon, { class: resolved.icon || undefined }, () => '▾'),
                     ]),
                     h(SelectPortal, null, () => [

--- a/packages/forms/test/unit/components.spec.ts
+++ b/packages/forms/test/unit/components.spec.ts
@@ -882,15 +882,43 @@ describe('VCFormSelect', () => {
         expect(wrapper.find('button[role="combobox"]').text()).toContain('Pick one');
     });
 
-    it('should show the matching option label in the trigger when modelValue is set', async () => {
+    it('should show the matching option label in the trigger when modelValue is set', () => {
         const wrapper = mount(VCFormSelect, {
             props: { options, modelValue: '2' },
             global: { plugins: [themePlugin] },
         });
-        // SelectValue resolves the displayed label asynchronously after
-        // SelectItem registers its text — wait one tick.
-        await nextTick();
+        // The trigger label derives synchronously from `options` — it must
+        // not depend on Reka's mount-time textContent registration.
         expect(wrapper.find('button[role="combobox"]').text()).toContain('Option 2');
+    });
+
+    it('should update the trigger label when the selected option label changes after mount', async () => {
+        // Regression: labels that resolve asynchronously (i18n) previously
+        // stayed stale in the closed trigger until the dropdown was opened,
+        // because Reka snapshots each item's textContent once in onMounted.
+        const wrapper = mount(VCFormSelect, {
+            props: { options: [{ value: '1', label: 'form.key' }], modelValue: '1' },
+            global: { plugins: [themePlugin] },
+        });
+        expect(wrapper.find('button[role="combobox"]').text()).toContain('form.key');
+        await wrapper.setProps({ options: [{ value: '1', label: 'Translated' }] });
+        expect(wrapper.find('button[role="combobox"]').text()).toContain('Translated');
+    });
+
+    it('should show the label of an option nested inside a group in the trigger', () => {
+        const wrapper = mount(VCFormSelect, {
+            props: {
+                options: [
+                    {
+                        label: 'Europe',
+                        options: [{ value: 'de', label: 'Germany' }],
+                    },
+                ],
+                modelValue: 'de',
+            },
+            global: { plugins: [themePlugin] },
+        });
+        expect(wrapper.find('button[role="combobox"]').text()).toContain('Germany');
     });
 
     it('should respect the disabled prop on the trigger', () => {


### PR DESCRIPTION
## Problem

When a `VCFormSelect` option label changes **after mount**, the closed trigger keeps showing the old text until the dropdown is opened once. Downstream this surfaces in authup's client form: the "Authentication method" / "Token binding" selects display the raw i18n key (`authupClient.authMethodNone`) until clicked, because the kit's translations resolve asynchronously one tick after first render.

## Root cause

Reka's `SelectValue` derives the closed trigger's text from `SelectRoot`'s `optionsSet` — a snapshot of each item's DOM `textContent` taken **once** in `SelectItemText`'s `onMounted` (reka-ui 2.10.1, `SelectItemText.vue`). A label that changes after mount never re-registers, so the trigger goes stale until the portal content remounts on first open, which re-runs the registration with the fresh text.

## Fix

`VCFormSelect` now resolves the selected label from its own `options` prop (groups flattened) and renders it through `SelectValue`'s **default slot**, bypassing the snapshot entirely. Value matching mirrors Reka's `compare` semantics — strings via `===`, everything else via ohash `isEqual` — so the trigger label can never disagree with the item Reka marks as selected. `ohash` is declared as a direct dependency (already in the tree via reka-ui).

## Tests

- New regression: a label swap after mount must reach the closed trigger.
- New: selected label resolves for options nested inside groups.
- Tightened: the existing trigger-label test now asserts **synchronous** resolution (no `nextTick`).

All three fail against the previous implementation; full suite passes (84/84) with the fix.