### PR TITLE
fix(forms): render the checkbox glyph in the component, not the stylesheet

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1709,6 +1709,64 @@ Components use TypeScript render functions (not `.vue` SFCs) via `defineComponen
 
 Components emit minimal structural CSS via co-located `vc-*` default classes. Visual styling is delegated to theme packages. CSS is extracted into separate `dist/style.css` files during build, so consumers can import styles independently.
 
+### Form glyphs are rendered, not CSS masks (#1694)
+
+A glyph that carries **meaning** (the checkbox's check mark / indeterminate
+dash) is *content*, not styling — so it is rendered by the component, never
+painted from the structural stylesheet.
+
+The rule exists because neither lower layer is guaranteed at a given call
+site. `dist/style.css` is an opt-in import, and a consumer on a
+self-sufficient theme (`@vuecs/theme-tailwind` styles the whole checkbox box
+from utility classes) has no reason to add it. A CSS-mask glyph therefore
+disappeared silently on the default-theme → Tailwind-theme migration: the box
+still filled with `primary-600`, so checked and unchecked stayed
+distinguishable and nothing errored — there was just no check mark. Pushing
+the glyph into every theme's `indicator` class instead would have duplicated
+the same SVG across three theme packages and still left theme-less consumers
+bare.
+
+`<VCFormCheckbox>` renders an inline `<svg class="vc-form-checkbox-glyph">`
+stroked in `currentColor`, gated behind `isMeaningfulSlotContent(#indicator)`.
+Layer responsibilities after the split:
+
+| Layer | Owns |
+|---|---|
+| Component | the glyph's *shape* (check path vs. dash path, chosen from Reka's `state`) and its *size* — `width`/`height` are `85%`, so it scales with whatever sets the box |
+| Theme `indicator` class | its *colour* (`text-current` over the root's `text-on-primary`, `text-white`, …) |
+| Structural CSS | the box: `.vc-form-checkbox` sizing + the `vc-form-checkbox-{xs,sm,lg}` size-variant helpers. No glyph rules at all |
+
+**Size the glyph by ratio, not by length.** The box height is not the
+component's to predict — `1rem` by default, a size-variant helper under
+`themeVariant.size`, or a bespoke value when a consumer lines a checkbox up
+beside a taller input. Any fixed length (`12px`, `0.75em`, `0.75rem`) is
+correct for exactly one of those, so the glyph holds the *proportion*
+instead: `85%` is the old `0.75rem`-in-a-`1rem`-border-box glyph expressed
+against the content box a percentage resolves against (12 / 14). That removed
+three per-size glyph rules from the stylesheet and made arbitrary box sizes
+work for free.
+
+The percentage needs a definite containing block, so the component also sets
+`style="width:100%;height:100%"` on the `CheckboxIndicator` inline — the
+structural rule declares exactly the same thing, but it is an opt-in import
+and the glyph has to size correctly without it. Presentation attributes lose
+to CSS, so a theme or consumer rule still wins over the `85%`.
+
+Removing the old `::before` mask also fixed a latent double-glyph: the mask
+rule was unconditional, so an `#indicator` slot *plus* the stylesheet painted
+both.
+
+Purely decorative shapes stay in CSS — the radio's dot (`formRadio.indicator`
+is a self-sufficient theme class) and the switch's thumb are presentation, not
+content, and a theme is free to redraw them.
+
+Contrast with the icon-name path (`collapseTrigger.chevronIcon`,
+`tableExpandTrigger.chevronIcon`): those resolve through `ComponentDefaults`
+and render via `<VCIcon>`, degrading to *nothing* when no icon preset is
+installed. That trade is fine for affordance chrome; it is not fine for a
+checkbox's state indicator, which is the only thing distinguishing checked
+from indeterminate.
+
 ## Dependency Flow
 
 ```
@@ -2530,9 +2588,11 @@ always pick the slot path. The helper walks the returned vnode array
 when it contains an element, a component, or a text node with
 non-whitespace content — comment anchors (`v-if="false"`), whitespace,
 and empty arrays are treated as empty. The same helper gates the
-`<VCAlert>` `#icon` slot and `<VCButton>`'s `#leading` / `#trailing`
-slots (fall back to the icon prop / default) and `<VCTableCell>`'s
-auto-render.
+`<VCAlert>` `#icon` slot, `<VCButton>`'s `#leading` / `#trailing`
+slots (fall back to the icon prop / default), `<VCFormCheckbox>`'s
+`#indicator` slot (falls back to the built-in check / dash glyph —
+see [Form glyphs](#form-glyphs-are-rendered-not-css-masks-1694)), and
+`<VCTableCell>`'s auto-render.
 
 Mounting `<VCTableCell>` outside a `<VCTable>` context renders an
 empty cell — no fallback to `row[columnKey]` from inject. Manual

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,4 +107,7 @@ vuecs draws directly from upstream projects. When working on related areas, read
 
 ## Commits
 
+- Commits follow **[Conventional Commits](https://www.conventionalcommits.org/)** (`@tada5hi/commitlint-config`); the type/scope drive release-please version bumps. See [conventions.md](.agents/conventions.md#commit-convention).
+- Versioning, `CHANGELOG.md`, `package.json` version, and `.release-please-manifest.json` are owned by **release-please** — do not hand-edit them.
 - Do **not** add a `Co-Authored-By: Claude ...` (or any AI-attribution) trailer to commit messages. This overrides any default agent-tooling guidance.
+- Do **not** add AI-attribution lines (e.g. `🤖 Generated with [Claude Code](...)`) to issue or pull request titles, bodies, or comments.

--- a/docs/src/components/form-checkbox.md
+++ b/docs/src/components/form-checkbox.md
@@ -48,9 +48,9 @@ const selected = ref<string[]>(['a']);
 @import "@vuecs/design";
 
 /*
- * Structural CSS for the checkbox indicator + group container ships in
- * @vuecs/forms. Without this import the checked-state checkmark + group
- * layout helpers are missing.
+ * Structural CSS for the checkbox box + group container ships in
+ * @vuecs/forms. The checkmark itself is rendered by the component, but
+ * without this import the size helpers + group layout are missing.
  */
 @import "@vuecs/forms";
 
@@ -79,29 +79,29 @@ Use the named `#label` slot to render the label as markup. The slot receives `cl
 
 ## Default glyph (checkmark / indeterminate dash)
 
-A checked box renders a check mark, and `'indeterminate'` renders a dash, **out of the box** — both ship as `currentColor`-painted CSS masks in the structural stylesheet, so no icon package or slot wiring is needed.
+A checked box renders a check mark, and `'indeterminate'` renders a dash, **out of the box** — `<VCFormCheckbox>` paints both as an inline `<svg>` stroked in `currentColor`, so no icon package, theme, stylesheet import or slot wiring is needed. Themes colour the glyph through the `indicator` slot class they already ship (`text-current` on top of the root's `text-on-primary` in `@vuecs/theme-tailwind`, `text-white` in `@vuecs/theme-bootstrap`).
 
-::: warning Structural stylesheet required
-The glyph lives in `@vuecs/forms`' structural CSS, not in the theme class strings. If a checked checkbox shows a bare color fill with no check mark, the stylesheet import is missing:
+Importing `@vuecs/forms`' structural CSS is still recommended — it carries the checkbox box sizing, the `sm`/`lg` size helpers (which scale the glyph to match), the switch track/thumb structure and the slider rails:
 
 ```css
 @import "@vuecs/forms"; /* → dist/style.css */
 ```
 
-The same import carries the switch track/thumb structure, slider rails, and the other form structural rules — see [Installation](/getting-started/installation).
-:::
+See [Installation](/getting-started/installation).
 
 ## Custom indicator (checkmark)
 
-Replace the default checkmark via the `#indicator` slot:
+Replace the built-in glyph via the `#indicator` slot. It receives the resolved `indicator` theme class plus the current `state` (`true` or `'indeterminate'`), so a custom indicator can distinguish the two:
 
 ```vue
 <VCFormCheckbox v-model="accepted">
-    <template #indicator="{ class: indicatorClass }">
-        <span :class="indicatorClass">✔</span>
+    <template #indicator="{ class: indicatorClass, state }">
+        <span :class="indicatorClass">{{ state === 'indeterminate' ? '–' : '✔' }}</span>
     </template>
 </VCFormCheckbox>
 ```
+
+An empty slot (a `v-if` that renders nothing) falls back to the built-in glyph rather than blanking the box.
 
 ## Group v-model
 
@@ -154,7 +154,7 @@ The group also enables roving focus (arrow keys to move between children) by def
 | Slot | Slot props | Description |
 |------|------------|-------------|
 | `label` | `{ class, id }` | Custom label markup. `class` is the resolved `label` theme class; `id` matches the checkbox's `for` target. Replaces the default `<label>` |
-| `indicator` | `{ class }` | Custom checkmark content. `class` is the resolved `indicator` theme class |
+| `indicator` | `{ class, state }` | Custom checkmark content, replacing the built-in glyph. `class` is the resolved `indicator` theme class; `state` is `true` or `'indeterminate'`. Empty slot content falls back to the built-in glyph |
 
 ## See also
 

--- a/packages/forms/assets/form-checkbox.css
+++ b/packages/forms/assets/form-checkbox.css
@@ -84,34 +84,30 @@
 /* Size helpers — themes drive these via `formCheckbox.variants.size.{sm,lg}`.
    Tailwind v4 utilities (`h-3 w-3`) sit in `@layer utilities` and lose to
    unlayered structural CSS, so we ship dedicated structural helpers and
-   reference them from both Tailwind and Bootstrap theme entries. */
+   reference them from both Tailwind and Bootstrap theme entries.
+
+   The glyph needs no per-size rule: `<VCFormCheckbox>` sizes it as a
+   percentage of the box, so it follows these helpers — and any bespoke box
+   size a consumer sets to line the checkbox up beside a taller control. */
 .vc-form-checkbox-xs {
     width: 0.625rem;
     height: 0.625rem;
-}
-.vc-form-checkbox-xs .vc-form-checkbox-indicator::before {
-    width: 0.375rem;
-    height: 0.375rem;
 }
 .vc-form-checkbox-sm {
     width: 0.75rem;
     height: 0.75rem;
 }
-.vc-form-checkbox-sm .vc-form-checkbox-indicator::before {
-    width: 0.5rem;
-    height: 0.5rem;
-}
 .vc-form-checkbox-lg {
     width: 1.25rem;
     height: 1.25rem;
 }
-.vc-form-checkbox-lg .vc-form-checkbox-indicator::before {
-    width: 0.875rem;
-    height: 0.875rem;
-}
 
-/* Indicator — Reka mounts this when state ≠ unchecked. We supply a default
-   checkmark via SVG mask so consumers don't need to slot anything. */
+/* Indicator — Reka mounts this when state ≠ unchecked. The check / dash glyph
+   itself is rendered by `<VCFormCheckbox>` as an inline `<svg>` (#1694), not by
+   a CSS mask here: a mask would only paint for consumers who import this
+   stylesheet, and every theme's `formCheckbox.indicator` class is layout +
+   colour only. Painting it in the component keeps a checked box readable with
+   no theme, no stylesheet import and no `#indicator` slot. */
 .vc-form-checkbox-indicator {
     display: inline-flex;
     align-items: center;
@@ -119,29 +115,4 @@
     width: 100%;
     height: 100%;
     color: var(--vc-color-on-primary, #fff);
-}
-
-.vc-form-checkbox[data-state="checked"] .vc-form-checkbox-indicator::before,
-.vc-form-checkbox[data-state="indeterminate"] .vc-form-checkbox-indicator::before {
-    content: "";
-    display: block;
-    width: 0.75rem;
-    height: 0.75rem;
-    background-color: currentColor;
-    -webkit-mask-position: center;
-    mask-position: center;
-    -webkit-mask-repeat: no-repeat;
-    mask-repeat: no-repeat;
-    -webkit-mask-size: contain;
-    mask-size: contain;
-}
-
-.vc-form-checkbox[data-state="checked"] .vc-form-checkbox-indicator::before {
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round' d='M3.5 8.5l3 3 6-7'/%3E%3C/svg%3E");
-    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='none' stroke='black' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round' d='M3.5 8.5l3 3 6-7'/%3E%3C/svg%3E");
-}
-
-.vc-form-checkbox[data-state="indeterminate"] .vc-form-checkbox-indicator::before {
-    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect x='3' y='7' width='10' height='2' rx='1' fill='black'/%3E%3C/svg%3E");
-    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect x='3' y='7' width='10' height='2' rx='1' fill='black'/%3E%3C/svg%3E");
 }

--- a/packages/forms/src/components/form-checkbox/FormCheckbox.vue
+++ b/packages/forms/src/components/form-checkbox/FormCheckbox.vue
@@ -1,5 +1,10 @@
 <script lang="ts">
-import { useComponentDefaults, useComponentTheme, useId } from '@vuecs/core';
+import { 
+    isMeaningfulSlotContent, 
+    useComponentDefaults, 
+    useComponentTheme, 
+    useId, 
+} from '@vuecs/core';
 import { useFormInputThemeProps } from '../form-group/context';
 import type {
     ComponentDefaultValues,
@@ -9,7 +14,12 @@ import type {
     VariantValues,
 } from '@vuecs/core';
 import { CheckboxIndicator, CheckboxRoot } from 'reka-ui';
-import type { ExtractPublicPropTypes, PropType, SlotsType } from 'vue';
+import type { 
+    ExtractPublicPropTypes, 
+    PropType, 
+    SlotsType, 
+    VNode, 
+} from 'vue';
 import {
     defineComponent,
     h,
@@ -54,11 +64,63 @@ export type FormCheckboxLabelSlotProps = {
     id: string;
 };
 
+export type FormCheckboxModelValue = boolean | 'indeterminate' | null;
+
+/** Resolved state while the indicator is mounted — Reka only renders it when the box isn't unchecked. */
+export type FormCheckboxState = Exclude<FormCheckboxModelValue, false | null>;
+
 export type FormCheckboxIndicatorSlotProps = {
     class: string;
+    /** `true` while checked, `'indeterminate'` for the tri-state. */
+    state: FormCheckboxState;
 };
 
-export type FormCheckboxModelValue = boolean | 'indeterminate' | null;
+/**
+ * Built-in glyph for the checked / indeterminate states.
+ *
+ * Rendered here (rather than as a CSS mask in the structural stylesheet) so a
+ * checked box shows a check mark with **no** prerequisites — no theme, no
+ * `@import "@vuecs/forms"`, no icon package, no `#indicator` slot (#1694).
+ * `stroke="currentColor"` picks up the colour every theme already puts on the
+ * `indicator` slot class.
+ *
+ * Sized as a **percentage of the box**, not a fixed length. The box height is
+ * not ours to predict — it is `1rem` by default, `vc-form-checkbox-{xs,sm,lg}`
+ * under a size variant, and whatever a consumer writes when they line a
+ * checkbox up beside an input / text box of a different height. A hard `12px`
+ * (or `0.75em`, or `0.75rem`) would only be correct for one of those.
+ *
+ * `85%` is the previous `0.75rem` glyph in a `1rem` border-box box carrying a
+ * `1px` border, expressed against the content box the percentage resolves
+ * against (12 / 14). Holding the *ratio* instead of the length reproduces the
+ * old rendering at every size tier and drops the need for per-size glyph rules
+ * in the stylesheet entirely.
+ *
+ * The percentage resolves against the indicator, which `<VCFormCheckbox>`
+ * stretches to fill the box inline — the structural stylesheet declares the
+ * same `width/height: 100%`, but it is an opt-in import and the glyph has to
+ * size correctly without it (that is the whole point of #1694).
+ */
+function renderCheckboxGlyph(state: FormCheckboxState): VNode {
+    return h(
+        'svg',
+        {
+            'class': 'vc-form-checkbox-glyph',
+            'xmlns': 'http://www.w3.org/2000/svg',
+            'viewBox': '0 0 16 16',
+            'width': '85%',
+            'height': '85%',
+            'fill': 'none',
+            'stroke': 'currentColor',
+            'stroke-width': '2.5',
+            'stroke-linecap': 'round',
+            'stroke-linejoin': 'round',
+            'aria-hidden': 'true',
+            'focusable': 'false',
+        },
+        [h('path', { d: state === 'indeterminate' ? 'M4 8h8' : 'M3.5 8.5l3 3 6-7' })],
+    );
+}
 
 const formCheckboxProps = {
     /** Controlled checked state. `null` is accepted as the documented "unset" value. */
@@ -127,10 +189,25 @@ export default defineComponent({
                     class: resolved.root || undefined,
                 }),
                 {
-                    default: () => h(
+                    default: ({ state }: { state: FormCheckboxState }) => h(
                         CheckboxIndicator,
-                        { class: resolved.indicator || undefined },
-                        { default: () => slots.indicator?.({ class: resolved.indicator }) ?? '' },
+                        {
+                            class: resolved.indicator || undefined,
+                            // Mirrors the structural `.vc-form-checkbox-indicator`
+                            // rule inline so the glyph's percentage sizing has a
+                            // definite box to resolve against even when the
+                            // stylesheet isn't imported (#1694). No shipping theme
+                            // sizes this slot — they contribute colour + centering.
+                            style: { width: '100%', height: '100%' },
+                        },
+                        {
+                            default: () => {
+                                const content = slots.indicator?.({ class: resolved.indicator, state });
+                                return isMeaningfulSlotContent(content) ?
+                                    content :
+                                    renderCheckboxGlyph(state);
+                            },
+                        },
                     ),
                 },
             );

--- a/packages/forms/src/components/form-checkbox/index.ts
+++ b/packages/forms/src/components/form-checkbox/index.ts
@@ -9,4 +9,5 @@ export type {
     FormCheckboxLabelSlotProps,
     FormCheckboxIndicatorSlotProps,
     FormCheckboxModelValue,
+    FormCheckboxState,
 } from './FormCheckbox.vue';

--- a/packages/forms/test/unit/components.spec.ts
+++ b/packages/forms/test/unit/components.spec.ts
@@ -761,6 +761,68 @@ describe('VCFormCheckbox', () => {
         const btn = wrapper.find('button[role="checkbox"]');
         expect(btn.attributes('disabled')).toBeDefined();
     });
+
+    // #1694 — the glyph must not depend on the structural stylesheet, which
+    // theme-driven consumers have no reason to import.
+    it('should render a built-in check glyph when checked without an indicator slot', () => {
+        const wrapper = mount(VCFormCheckbox, {
+            props: { modelValue: true },
+            global: { plugins: [themePlugin] },
+        });
+        const glyph = wrapper.find('.vc-form-checkbox-indicator svg.vc-form-checkbox-glyph');
+        expect(glyph.exists()).toBe(true);
+        expect(glyph.find('path').attributes('d')).toBe('M3.5 8.5l3 3 6-7');
+    });
+
+    it('should render a dash glyph while indeterminate', () => {
+        const wrapper = mount(VCFormCheckbox, {
+            props: { modelValue: 'indeterminate' as const },
+            global: { plugins: [themePlugin] },
+        });
+        expect(wrapper.find('svg.vc-form-checkbox-glyph path').attributes('d')).toBe('M4 8h8');
+    });
+
+    it('should not render the built-in glyph while unchecked', () => {
+        const wrapper = mount(VCFormCheckbox, {
+            props: { modelValue: false },
+            global: { plugins: [themePlugin] },
+        });
+        expect(wrapper.find('svg.vc-form-checkbox-glyph').exists()).toBe(false);
+    });
+
+    it('should let an indicator slot replace the built-in glyph', () => {
+        const wrapper = mount(VCFormCheckbox, {
+            props: { modelValue: true },
+            global: { plugins: [themePlugin] },
+            slots: { indicator: () => h('i', { class: 'custom-glyph' }) },
+        });
+        expect(wrapper.find('.custom-glyph').exists()).toBe(true);
+        expect(wrapper.find('svg.vc-form-checkbox-glyph').exists()).toBe(false);
+    });
+
+    it('should fall back to the built-in glyph when the indicator slot renders nothing', () => {
+        const wrapper = mount(VCFormCheckbox, {
+            props: { modelValue: true },
+            global: { plugins: [themePlugin] },
+            slots: { indicator: () => null },
+        });
+        expect(wrapper.find('svg.vc-form-checkbox-glyph').exists()).toBe(true);
+    });
+
+    it('should expose the resolved state on the indicator slot', () => {
+        const states: unknown[] = [];
+        mount(VCFormCheckbox, {
+            props: { modelValue: 'indeterminate' as const },
+            global: { plugins: [themePlugin] },
+            slots: {
+                indicator: (props: { state: unknown }) => {
+                    states.push(props.state);
+                    return h('i');
+                },
+            },
+        });
+        expect(states).toContain('indeterminate');
+    });
 });
 
 describe('VCFormCheckboxGroup', () => {


### PR DESCRIPTION
Closes #1694.

## Problem

The check mark / indeterminate dash shipped as a CSS mask in `@vuecs/forms`' structural stylesheet. That stylesheet is an **opt-in import**, and a consumer on a self-sufficient theme has no reason to add it — `@vuecs/theme-tailwind` styles the whole box from utility classes and contributes layout + colour only on `formCheckbox.indicator`:

```js
formCheckbox: { classes: { indicator: 'inline-flex items-center justify-center text-current' } }  // centers nothing
formRadio:    { classes: { indicator: 'block h-2 w-2 rounded-full bg-primary-600' } }             // self-sufficient
```

So a checked box rendered as a bare `primary-600` fill with nothing in it. Nothing errored — the box still filled, so checked and unchecked stayed distinguishable — which is what made the default-theme → Tailwind-theme migration silent.

## Fix

`<VCFormCheckbox>` paints an inline `<svg>` stroked in `currentColor`, gated behind `isMeaningfulSlotContent(#indicator)` (the same helper that gates `<VCAlert>`'s `#icon` and `<VCButton>`'s `#leading`). A checked box is now readable with **no theme, no stylesheet import, no icon preset and no slot**.

Putting the glyph in the theme's `indicator` class instead — the fix the issue suggests — would have duplicated the same SVG across three theme packages (`bootstrap` / `bulma` lean on the structural CSS just as hard) and still left theme-less consumers bare. Layers after the split:

| Layer | Owns |
|---|---|
| Component | the glyph's shape + size |
| Theme `indicator` class | its colour (`text-current` over the root's `text-on-primary`, `text-white`, …) |
| Structural CSS | the box, and the `vc-form-checkbox-{xs,sm,lg}` size helpers. No glyph rules at all |

## Sized by ratio, not by length

`width`/`height` are `85%`, not `12px`. The box height is not the component's to predict — `1rem` by default, a size-variant helper under `themeVariant.size`, or a bespoke value when a consumer lines a checkbox up beside a taller input. Any fixed length is correct for exactly one of those. `85%` is the old `0.75rem`-in-a-`1rem`-border-box glyph expressed against the content box a percentage resolves against (12 / 14), so it reproduces the previous rendering at every size tier — and drops **three** per-size glyph rules from the stylesheet.

Measured in headless Chromium against the theme-tailwind class strings with **no structural CSS loaded**:

| Box | Glyph | Previously |
|---|---|---|
| `1rem` (default) | 11.89px | 12px |
| `1.25rem` (`lg`) | 15.30px | 14px |
| `2.5rem` (consumer-sized) | 32.30px | 12px |

The percentage needs a definite containing block, so the component also sets `style="width:100%;height:100%"` on the `CheckboxIndicator` inline — the structural rule declares exactly the same thing, but it can't be relied on. Presentation attributes lose to CSS, so a theme or consumer rule still wins over the `85%`.

## Also

- **Latent double-glyph fixed.** The old `::before` mask was unconditional, so the `#indicator` workaround the issue describes rendered the custom icon *and* the mask for anyone who did import the stylesheet.
- **`#indicator` gains `state`** (`true` | `'indeterminate'`) so a custom indicator can distinguish the two — previously impossible. Empty slot content falls back to the built-in glyph instead of blanking the box.
- New `FormCheckboxState` export.

## Verification

- 6 new unit tests (default check / dash glyph, unchecked renders none, slot replaces, empty slot falls back, `state` slot prop). `npm run test` green across all 14 projects; `npm run lint` 0 errors.
- Real-browser layout check above (jsdom computes no layout, so the percentage chain was verified in Chromium).
- Docs: the "Structural stylesheet required" warning on `docs/src/components/form-checkbox.md` is obsolete and replaced; `.agents/architecture.md` gains a *Form glyphs are rendered, not CSS masks* section under CSS Strategy, and `<VCFormCheckbox>` joins the `isMeaningfulSlotContent` call-site list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checkboxes now display built-in checkmark and indeterminate glyphs directly.
  * Custom indicator slots can receive the checkbox state and replace the default glyph.
  * Empty custom indicator slots automatically fall back to the built-in glyph.

* **Bug Fixes**
  * Improved checkbox glyph sizing, centering, and theme color handling.
  * Prevented missing or duplicated glyphs during theme migrations.

* **Documentation**
  * Updated checkbox styling, glyph, and indicator slot guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
