### PR TITLE
feat(design): export a runtime ColorMode guard (COLOR_MODES / isColorMode)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1099,11 +1099,21 @@ via a `<style id="vc-color-palette">` block, leaving layers 1-2 and 4-5 untouche
                             stays unlayered (structural CSS rule); palettes.css too.
   assets/animations.css  <- Motion primitives — vanilla-CSS port of tw-animate-css (MIT, attributed in header)
   src/
-    palette.ts                   <- applyColorPaletteCss(), bindColorPalette<T>(), COLOR_PALETTE_STYLE_ELEMENT_ID
-    composables/
-      use-color-mode.ts          <- bindColorMode(ref, opts), useColorMode(opts)
-      index.ts                   <- composables barrel
-    index.ts                     <- top-level barrel (re-exports composables + palette primitives)
+    core/
+      color-mode/
+        catalog.ts               <- COLOR_MODES tuple, derived ColorMode, isColorMode() guard (#1701)
+        bind.ts                  <- bindColorMode(ref, opts)
+        composable.ts            <- useColorMode(opts) — localStorage-backed, guard-sanitized
+        types.ts                 <- UseColorModeOptions / UseColorModeReturn
+      color-palette/
+        catalog.ts               <- SEMANTIC_SCALES, COLOR_PALETTES, COLOR_PALETTE_SHADES, ColorPaletteConfig
+        apply.ts                 <- applyColorPaletteCss(), COLOR_PALETTE_STYLE_ELEMENT_ID
+        bind.ts                  <- bindColorPalette<T>()
+        composable.ts            <- useColorPalette() / useColorPaletteUnshared()
+        presets.ts render.ts types.ts
+      theme-runtime/             <- useThemeRuntimeManager(), captureColorModeAttrs(),
+                                    renderColorPaletteFromThemes() (SSR dispatch)
+    index.ts                     <- top-level barrel (re-exports every core sub-area, flat)
 
 @vuecs/theme-tailwind/
   assets/index.css       <- @theme { --color-primary-*: var(--vc-color-primary-*) }
@@ -1187,6 +1197,7 @@ data-[state=closed]:animate-out fade-out-0 zoom-out-95` composition.
 - **`useColorPaletteUnshared(options?)`** — un-shared variant. Same surface; one watcher per call. Accepts a custom `source: Ref<T>` for SSR-aware persistence (Nuxt cookie, IndexedDB, etc.). Used internally by `@vuecs/nuxt`'s cookie-backed wrapper.
 - **`useColorMode(options?)`** — reactive light/dark/system mode with localStorage persistence + `<html>` class sync. Returns `{ mode, resolved, isDark, toggle }`. Uses `usePreferredDark` from VueUse to resolve `'system'`.
 - **`bindColorMode(source: Ref<ColorMode>, options?)`** — building block; same pattern as `bindColorPalette`.
+- **`COLOR_MODES` / `ColorMode` / `isColorMode(value)`** — the color-mode vocabulary, in `core/color-mode/catalog.ts` (same tuple-is-the-source-of-truth shape as `color-palette/catalog.ts`: `ColorMode` is *derived* via `typeof COLOR_MODES[number]`, so the union and the runtime list can't drift). `isColorMode` takes `unknown` so consumers can point it straight at untrusted persisted state — the required narrowing step for any `Ref<string>`-backed source before it satisfies `bindColorMode`. `useColorMode`'s `useStorage` serializer and `@vuecs/nuxt`'s cookie-backed `useColorMode` both run it, degrading an invalid stored value to the configured initial rather than round-tripping it onto the `<html>` class (issue #1701).
 
 **`@vuecs/theme-tailwind` (Tailwind-specific palette + class strings):**
 - **`renderColorPaletteStyles(palette): string`** — pure function. Returns a `:root { … }` block that remaps `--vc-color-<scale>-*` onto `var(--color-<palette>-*)` for every scale set in `palette`. Safe on server and client.

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -8,7 +8,7 @@
 
 ## Test inventory
 
-**14 workspaces** carry tests — **101 `.spec.ts`** total (plus 4 `.test-d.ts`
+**14 workspaces** carry tests — **102 `.spec.ts`** total (plus 4 `.test-d.ts`
 type guards). This is no longer "just core + navigation"; keep this table in
 sync when adding a test dir.
 
@@ -19,7 +19,7 @@ sync when adding a test dir.
 | `@vuecs/elements` | 10 | Card / Alert / Collapse / Badge / Avatar / Tag parts |
 | `@vuecs/navigation` | 10 | Registry, resolver, breadcrumb, stepper |
 | `@vuecs/overlays` | 10 | Modal / AlertDialog / Popover / Tooltip / menus, `useToast` / `useModal` / `useAlertDialog` |
-| `@vuecs/design` | 7 | `useColorMode`, palette render/apply, standalone catalog |
+| `@vuecs/design` | 8 | `useColorMode`, color-mode catalog/guard, palette render/apply, standalone catalog |
 | `@vuecs/forms` | 2 | Components (incl. Reka `VCFormSelect`), `useSubmitButton` |
 | `@vuecs/list` | 2 | Components + list context |
 | `@vuecs/locale` | 2 | `bindLocale` / `useLocaleManager` |

--- a/docs/src/guide/composables.md
+++ b/docs/src/guide/composables.md
@@ -347,7 +347,11 @@ const { mode, resolved, isDark, toggle } = useColorMode();
 #### API
 
 ```ts
-type ColorMode = 'light' | 'dark' | 'system';
+const COLOR_MODES = ['light', 'dark', 'system'] as const;
+type ColorMode = typeof COLOR_MODES[number];
+
+/** Runtime guard over COLOR_MODES — narrows untrusted persisted values. */
+function isColorMode(value: unknown): value is ColorMode;
 
 interface UseColorModeOptions {
     /** Initial mode when no persisted value exists. Default: 'system' */
@@ -399,6 +403,34 @@ function bindColorMode(
     options?: { syncClass?: boolean },
 ): UseColorModeReturn;
 ```
+
+#### Narrowing an untrusted source
+
+A persisted backend (cookie, `localStorage`, an SSR hydration payload) is
+user-writable, so it hands you a `Ref<string>` — not a `Ref<ColorMode>`.
+Narrow it with `isColorMode()` before handing it to `bindColorMode`;
+without that step a stale or hand-edited value round-trips into `mode`
+and from there onto the `<html>` class.
+
+```ts
+import { bindColorMode, isColorMode } from '@vuecs/design';
+import type { ColorMode } from '@vuecs/design';
+
+const source = /* Ref<string> from your storage backend */;
+
+const mode = computed<ColorMode>({
+    // Reads degrade to the configured initial …
+    get: () => (isColorMode(source.value) ? source.value : 'system'),
+    // … writes always come from bindColorMode, which only emits valid modes.
+    set: (value) => { source.value = value; },
+});
+
+bindColorMode(mode);
+```
+
+`useColorMode()` (localStorage) and `@vuecs/nuxt`'s `useColorMode()`
+(cookie) both apply this guard internally — you only need it when you
+wire up your own backend.
 
 The Nuxt module pattern (`@vuecs/nuxt`'s `useColorPalette`):
 

--- a/docs/src/guide/composables.md
+++ b/docs/src/guide/composables.md
@@ -413,10 +413,14 @@ without that step a stale or hand-edited value round-trips into `mode`
 and from there onto the `<html>` class.
 
 ```ts
+import { computed, ref } from 'vue';
+import type { Ref } from 'vue';
 import { bindColorMode, isColorMode } from '@vuecs/design';
 import type { ColorMode } from '@vuecs/design';
 
-const source = /* Ref<string> from your storage backend */;
+// Whatever your storage backend hands you — a cookie ref, `useStorage()`,
+// a value read out of an SSR hydration payload …
+const source: Ref<string> = ref(localStorage.getItem('my-color-mode') ?? 'system');
 
 const mode = computed<ColorMode>({
     // Reads degrade to the configured initial …

--- a/packages/design/src/core/color-mode/bind.ts
+++ b/packages/design/src/core/color-mode/bind.ts
@@ -2,7 +2,8 @@ import { usePreferredDark } from '@vueuse/core';
 import { computed, watch } from 'vue';
 import type { Ref } from 'vue';
 import { useThemeRuntimeManager } from '../theme-runtime/composable';
-import type { ColorMode, UseColorModeOptions, UseColorModeReturn } from './types';
+import type { ColorMode } from './catalog';
+import type { UseColorModeOptions, UseColorModeReturn } from './types';
 
 /**
  * Wire any reactive `Ref<ColorMode>` into the design system: track

--- a/packages/design/src/core/color-mode/catalog.ts
+++ b/packages/design/src/core/color-mode/catalog.ts
@@ -1,0 +1,43 @@
+/**
+ * Canonical color-mode vocabulary for the vuecs design system.
+ *
+ * Mirrors the `color-palette/catalog.ts` shape: the runtime tuple is
+ * the single source of truth and the `ColorMode` union is *derived*
+ * from it, so a new mode can never be added to one without the other.
+ *
+ * Consumers that back `bindColorMode()`'s source ref with persisted
+ * state (a cookie, `localStorage`, an SSR hydration payload) hold a
+ * `Ref<string>` and must narrow it before it satisfies the signature —
+ * without narrowing, a foreign stored value would round-trip into the
+ * mode ref and from there onto the `<html>` class. `isColorMode()` is
+ * that narrowing step:
+ *
+ *     const mode = computed<ColorMode>({
+ *         get: () => (isColorMode(source.value) ? source.value : 'system'),
+ *         set: (value) => { source.value = value; },
+ *     });
+ *     bindColorMode(mode);
+ */
+
+/**
+ * The three selectable color modes. `'system'` is the sentinel that
+ * defers to the OS preference (`prefers-color-scheme`) — it is never
+ * the *resolved* value, which is always `'light'` or `'dark'`.
+ */
+export const COLOR_MODES = [
+    'light',
+    'dark',
+    'system',
+] as const;
+
+export type ColorMode = typeof COLOR_MODES[number];
+
+const COLOR_MODE_SET = new Set<string>(COLOR_MODES);
+
+/**
+ * Runtime guard over {@link COLOR_MODES}. Accepts `unknown` so it can
+ * be pointed straight at untrusted persisted state without a cast.
+ */
+export function isColorMode(value: unknown): value is ColorMode {
+    return typeof value === 'string' && COLOR_MODE_SET.has(value);
+}

--- a/packages/design/src/core/color-mode/composable.ts
+++ b/packages/design/src/core/color-mode/composable.ts
@@ -2,16 +2,14 @@ import { createSharedComposable, useStorage } from '@vueuse/core';
 import { ref } from 'vue';
 import type { Ref } from 'vue';
 import { bindColorMode } from './bind';
-import type { ColorMode, UseColorModeOptions, UseColorModeReturn } from './types';
+import { isColorMode } from './catalog';
+import type { ColorMode } from './catalog';
+import type { UseColorModeOptions, UseColorModeReturn } from './types';
 
 const DEFAULT_STORAGE_KEY = 'vc-color-mode';
-const COLOR_MODES: readonly ColorMode[] = ['light', 'dark', 'system'];
-const COLOR_MODE_SET = new Set<string>(COLOR_MODES);
 
 const sanitize = (value: unknown, fallback: ColorMode): ColorMode => (
-    typeof value === 'string' && COLOR_MODE_SET.has(value) ?
-        (value as ColorMode) :
-        fallback
+    isColorMode(value) ? value : fallback
 );
 
 /**

--- a/packages/design/src/core/color-mode/index.ts
+++ b/packages/design/src/core/color-mode/index.ts
@@ -1,3 +1,4 @@
 export * from './bind';
+export * from './catalog';
 export * from './composable';
 export * from './types';

--- a/packages/design/src/core/color-mode/types.ts
+++ b/packages/design/src/core/color-mode/types.ts
@@ -1,6 +1,5 @@
 import type { ComputedRef, WritableComputedRef } from 'vue';
-
-export type ColorMode = 'light' | 'dark' | 'system';
+import type { ColorMode } from './catalog';
 
 /**
  * Options for `useColorMode()`. Note that `useColorMode` is wrapped

--- a/packages/design/test/unit/core/color-mode/catalog.spec.ts
+++ b/packages/design/test/unit/core/color-mode/catalog.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { COLOR_MODES, isColorMode } from '../../../../src/core/color-mode/catalog';
+
+describe('COLOR_MODES', () => {
+    it('holds the canonical vocabulary', () => {
+        expect(COLOR_MODES).toEqual(['light', 'dark', 'system']);
+    });
+});
+
+describe('isColorMode', () => {
+    it('accepts every catalog entry', () => {
+        for (const mode of COLOR_MODES) {
+            expect(isColorMode(mode)).toBe(true);
+        }
+    });
+
+    it('rejects foreign strings', () => {
+        expect(isColorMode('')).toBe(false);
+        expect(isColorMode('auto')).toBe(false);
+        expect(isColorMode('Dark')).toBe(false);
+        expect(isColorMode('système')).toBe(false);
+    });
+
+    it('rejects non-string values', () => {
+        expect(isColorMode(undefined)).toBe(false);
+        expect(isColorMode(null)).toBe(false);
+        expect(isColorMode(0)).toBe(false);
+        expect(isColorMode({})).toBe(false);
+        expect(isColorMode(['dark'])).toBe(false);
+    });
+
+    it('does not report inherited Object.prototype keys as modes', () => {
+        // Guards against a plain-object lookup implementation, where
+        // `'toString'` / `'constructor'` would resolve truthy.
+        expect(isColorMode('toString')).toBe(false);
+        expect(isColorMode('constructor')).toBe(false);
+    });
+
+    it('narrows the value for downstream consumers', () => {
+        const raw: unknown = 'dark';
+        if (isColorMode(raw)) {
+            // Type-level assertion — `raw` is `ColorMode` inside this branch,
+            // so assigning it to the union compiles without a cast.
+            const mode: 'light' | 'dark' | 'system' = raw;
+            expect(mode).toBe('dark');
+        } else {
+            expect.unreachable('isColorMode should accept "dark"');
+        }
+    });
+});

--- a/packages/design/test/unit/core/color-mode/composable.spec.ts
+++ b/packages/design/test/unit/core/color-mode/composable.spec.ts
@@ -7,7 +7,7 @@ import {
 } from 'vitest';
 import { nextTick, ref } from 'vue';
 import { bindColorMode } from '../../../../src/core/color-mode/bind';
-import type { ColorMode } from '../../../../src/core/color-mode/types';
+import type { ColorMode } from '../../../../src/core/color-mode/catalog';
 
 describe('bindColorMode', () => {
     afterEach(() => {

--- a/packages/design/test/unit/core/theme-runtime/composable.spec.ts
+++ b/packages/design/test/unit/core/theme-runtime/composable.spec.ts
@@ -14,7 +14,7 @@ import {
     ref,
 } from 'vue';
 import { bindColorMode } from '../../../../src/core/color-mode/bind';
-import type { ColorMode } from '../../../../src/core/color-mode/types';
+import type { ColorMode } from '../../../../src/core/color-mode/catalog';
 import type { ThemeRuntimeEntry } from '../../../../src/core/theme-runtime/types';
 
 const THEME_MANAGER_SYMBOL = Symbol.for('VCThemeManager');

--- a/packages/nuxt/src/runtime/composables/useColorMode.ts
+++ b/packages/nuxt/src/runtime/composables/useColorMode.ts
@@ -1,5 +1,6 @@
-import { bindColorMode } from '@vuecs/design';
+import { bindColorMode, isColorMode } from '@vuecs/design';
 import type { ColorMode, UseColorModeReturn } from '@vuecs/design';
+import { computed } from 'vue';
 // @ts-expect-error resolved by Nuxt at build time
 import { useCookie, useRuntimeConfig } from '#imports';
 
@@ -37,7 +38,19 @@ export function useColorMode(): UseColorModeReturn {
         watch: true,
     });
 
-    return bindColorMode(cookie);
+    // The cookie is user-writable, so its value is untrusted: a stale
+    // or hand-edited `vc-color-mode` would otherwise round-trip an
+    // arbitrary string through `mode` and onto the `<html>` class.
+    // Reads degrade to the configured initial; writes always come from
+    // `bindColorMode`, which only ever emits a valid mode.
+    const source = computed<ColorMode>({
+        get: () => (isColorMode(cookie.value) ? cookie.value : defaultValue),
+        set: (value) => {
+            cookie.value = value;
+        },
+    });
+
+    return bindColorMode(source);
 }
 
 export type { ColorMode, UseColorModeReturn } from '@vuecs/design';


### PR DESCRIPTION
Closes #1701

## Problem

`@vuecs/design` exported the `ColorMode` type but no runtime counterpart of the vocabulary. Any consumer backing `bindColorMode()`'s source ref with persisted state (cookie, `localStorage`, an SSR hydration payload) holds a `Ref<string>` and has to hand-roll the narrowing before it satisfies the signature — authup duplicates exactly this in two apps (authup/authup#3378).

Without the narrowing, a foreign stored value either fails the types or leaks an arbitrary string into the mode ref, and from there onto the `<html>` class.

## Changes

**`@vuecs/design`** — new `core/color-mode/catalog.ts`, mirroring the existing `color-palette/catalog.ts` shape:

- `COLOR_MODES` — the canonical readonly tuple.
- `ColorMode` — now *derived* (`typeof COLOR_MODES[number]`) rather than hand-written, so the union and the runtime list can't drift. Public surface is unchanged; it just moves from `types.ts` to `catalog.ts` and is still re-exported from the package root.
- `isColorMode(value: unknown): value is ColorMode` — takes `unknown` so it can be pointed straight at untrusted state without a cast.

`useColorMode()`'s `useStorage` serializer now runs the shared guard instead of its own private copy of the vocabulary (net -5 lines there).

**`@vuecs/nuxt`** (the optional half of the issue) — `useColorMode()` cast the `vc-color-mode` cookie straight to `ColorMode`. Since the cookie is user-writable, an invalid value round-tripped unchecked. Reads now degrade to the configured initial. The server-side plugin already narrowed explicitly (`stored === 'light' || stored === 'dark'`) and is unchanged.

Split into two commits so release-please attributes the `feat` and the `fix` to the right components.

## Verification

- `packages/design/test/unit/core/color-mode/catalog.spec.ts` — vocabulary, accept/reject (incl. `Object.prototype` keys, so a plain-object lookup can't regress in), and a type-level narrowing assertion.
- Full suite green: `nx run-many -t test` → 14/14 projects, 968 tests.
- `npm run lint` → 0 errors.
- Checked the built `dist` rather than only source: `COLOR_MODES` / `isColorMode` are in the ESM export list and `catalog.d.ts` emits `COLOR_MODES: readonly ["light", "dark", "system"]` + the `value is ColorMode` predicate.

## Docs

`docs/src/guide/composables.md` gains the guard in the API block plus a "Narrowing an untrusted source" section carrying the issue's snippet. `.agents/architecture.md` documents the export (and its stale `@vuecs/design` layout tree — still showing a long-gone `src/composables/use-color-mode.ts` — is refreshed to the real `src/core/*` shape, since this change adds a file to it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared catalog of supported color modes: light, dark, and system.
  * Added runtime validation for color-mode values, including persisted settings.
  * Invalid saved color-mode values now safely fall back to the configured default.

* **Documentation**
  * Updated color-mode guidance with validation examples and API details.

* **Tests**
  * Expanded coverage for valid, invalid, and non-string color-mode values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->