### PR TITLE
fix(button): enforce disabled when `as` renders a non-button element

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1778,6 +1778,48 @@ installed. That trade is fine for affordance chrome; it is not fine for a
 checkbox's state indicator, which is the only thing distinguishing checked
 from indeterminate.
 
+### Disabled state on polymorphic (`as`) targets (#1699)
+
+`disabled` is a `<button>` / form-control concept. A component that renders
+polymorphically (`<VCButton :as>`) can't rely on it: an `<a>`, a
+`RouterLink` / `NuxtLink`, or an arbitrary component keeps its own
+activation behaviour, and CSS's `:disabled` pseudo-class never matches
+them. Marking the element `aria-disabled="true"` *announces* the state
+without *enforcing* it — a permission-guarded row action then looks
+clickable, is clickable, and only gets rejected by the target page.
+
+The split, mirroring the form-glyph rule above:
+
+| Layer | Owns |
+|---|---|
+| Component | *enforcement* — `aria-disabled="true"`, `tabindex="-1"` (parity with what native `disabled` does to the tab order), and a **capture-phase** `onClickCapture` guard that `preventDefault()` + `stopPropagation()` + `stopImmediatePropagation()`s |
+| Theme | the *visual* cue, keyed off `[aria-disabled="true"]` — exactly as the native path's cue comes from the theme's `disabled:` utilities |
+| Structural CSS | nothing. A theme-less consumer gets no disabled cue on either path, so the two stay consistent |
+
+**The capture phase is load-bearing, not stylistic.** At the event target
+the DOM invokes capture-phase listeners before bubble-phase ones (dispatch
+walks the path twice and skips listeners whose capture flag doesn't match
+the current phase), so the guard wins regardless of registration order.
+That matters because Vue merges fallthrough attrs *after* a component's own
+props — a bubble-phase guard on `<VCButton :as="RouterLink">` would be
+registered second and run only after RouterLink had already navigated.
+`stopPropagation()` additionally suppresses the target's own bubble
+listeners, since the stop-propagation flag is checked once per element per
+phase. `packages/button/test/unit/disabled.spec.ts` pins this with a
+component target that navigates from a plain `onClick`; flipping the guard
+to `onClick` fails that spec.
+
+Themes carry the cue as: `aria-disabled:cursor-not-allowed
+aria-disabled:opacity-60` (theme-tailwind, alongside its existing
+`disabled:` pair — same shape as `pagination.link`), and a
+`.vc-button[aria-disabled="true"]` bridge rule in theme-bootstrap /
+theme-bulma, since neither framework's class strings can carry attribute
+selectors. Both bridges reuse the framework's own disabled-opacity
+variable (`--bs-btn-disabled-opacity` / `--bulma-button-disabled-opacity`)
+rather than hard-coding a value, and deliberately omit `pointer-events:
+none` (it would suppress `cursor: not-allowed`, and activation is already
+blocked JS-side).
+
 ## Dependency Flow
 
 ```

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -8,7 +8,7 @@
 
 ## Test inventory
 
-**14 workspaces** carry tests — **102 `.spec.ts`** total (plus 4 `.test-d.ts`
+**15 workspaces** carry tests — **103 `.spec.ts`** total (plus 4 `.test-d.ts`
 type guards). This is no longer "just core + navigation"; keep this table in
 sync when adding a test dir.
 
@@ -25,6 +25,7 @@ sync when adding a test dir.
 | `@vuecs/locale` | 2 | `bindLocale` / `useLocaleManager` |
 | `@vuecs/pagination` | 2 | Pagination behaviour |
 | `@vuecs/placeholder` | 1 | Placeholder / wrapper |
+| `@vuecs/button` | 1 | Disabled enforcement across native / non-native `as` targets |
 | `@vuecs/theme-tailwind` | 2 | `auditTheme` drift + palette render |
 | `@vuecs/theme-bootstrap` | 1 | `auditTheme` drift |
 | `@vuecs/theme-bulma` | 1 | `auditTheme` drift |

--- a/docs/src/components/button.md
+++ b/docs/src/components/button.md
@@ -87,13 +87,13 @@ const submit = useSubmitButton({ isEditing: () => isEditing.value });
 | `variant` | `'solid' \| 'soft' \| 'outline' \| 'ghost' \| 'link'` | (theme default) | Visual treatment. Tailwind theme defaults to `solid`. |
 | `size` | `'xs' \| 'sm' \| 'md' \| 'lg'` | (theme default) | Padding / font-size. Tailwind theme defaults to `md`. |
 | `type` | `string` | `'button'` | Forwarded as the native `type` attribute when the rendered element is `'button'` (use `'submit'` inside `<form>`). |
-| `as` | `string \| Component` | `'button'` | Element or component to render as. Pass `'a'` to render as a link, or a component (`RouterLink` / `NuxtLink`) for a button-styled navigation link. Extra attrs (`to`, `href`, `target`, …) forward to the rendered element; native `type` / `disabled` apply only for `'button'`, other targets get `aria-disabled`. |
+| `as` | `string \| Component` | `'button'` | Element or component to render as. Pass `'a'` to render as a link, or a component (`RouterLink` / `NuxtLink`) for a button-styled navigation link. Extra attrs (`to`, `href`, `target`, …) forward to the rendered element; native `type` / `disabled` apply only for `'button'`, other targets get `aria-disabled` + `tabindex="-1"` + a click guard. |
 | `tag` | `string \| Component` | — | **Deprecated** — use `as`. Non-breaking alias; takes precedence over `as` when set. |
 | `label` | `string` | — | Inline text. Equivalent to passing the same string as the default slot. |
 | `iconLeft` | `string` | — | Iconify name for a leading icon (e.g. `'lucide:plus'`), resolved through `<VCIcon>`. Skipped when empty / undefined. |
 | `iconRight` | `string` | — | Iconify name for a trailing icon. Same skip behavior as `iconLeft`. |
 | `loading` | `boolean` | `false` | Disables the button and applies `vc-button--busy` (wait cursor + opacity pulse). Also resolves as the `loading` themeVariant. |
-| `disabled` | `boolean` | `false` | Disables without the busy state. |
+| `disabled` | `boolean` | `false` | Disables without the busy state. Enforced on every render target — see [Disabling a button-styled link](#disabling-a-button-styled-link). |
 | `themeClass` | `Partial<ButtonThemeClasses>` | — | Per-instance slot class overrides — see [Theme System](/guide/theme-system). |
 | `themeVariant` | `Record<string, string \| boolean>` | — | Lower-priority variant overrides; merged with the convenience props above. |
 
@@ -172,11 +172,37 @@ import { RouterLink } from 'vue-router';
 </template>
 ```
 
-Attributes the button doesn't own (`to`, `href`, `target`, `rel`, …) flow straight through to the rendered element. Native `type` / `disabled` attributes are only emitted when the target resolves to `'button'`; for every other target the button emits `aria-disabled` instead (see the Notes below).
+Attributes the button doesn't own (`to`, `href`, `target`, `rel`, …) flow straight through to the rendered element. Native `type` / `disabled` attributes are only emitted when the target resolves to `'button'`; every other target gets the equivalent treatment via ARIA + a click guard (see below).
+
+### Disabling a button-styled link
+
+`disabled` is enforced on every render target, not just `<button>`:
+
+```vue
+<VCButton :as="RouterLink" :to="`/users/${id}`" :disabled="!canEdit" size="sm">
+    details
+</VCButton>
+```
+
+`<a>`, `RouterLink`, `NuxtLink` and friends don't understand the native
+`disabled` attribute, so for those targets the component instead emits
+`aria-disabled="true"`, sets `tabindex="-1"` (matching what native
+`disabled` does to the tab order), and attaches a **capture-phase click
+guard** that `preventDefault()`s and stops propagation. The guard runs
+before the target's own click handler, so the link cannot navigate —
+including via keyboard, since Enter on a focused link dispatches a click.
+
+The visual cue comes from the theme, keyed off `[aria-disabled="true"]`
+— the same split as the native path, where the cue comes from the
+theme's `disabled:` utilities. All three shipping themes carry it.
+
+::: tip
+You no longer need the old workaround of withholding `:to` when disabled.
+:::
 
 ## Notes
 
-- Setting `as="a"` (or `:as="RouterLink"` / `:as="NuxtLink"`) renders the button as a link / component. The structural busy class still applies, but the native `disabled` attribute is a no-op on non-button targets — the component emits `aria-disabled="true"` instead, and you should guard navigation via your own click handler if you mount the button as a link.
+- Setting `as="a"` (or `:as="RouterLink"` / `:as="NuxtLink"`) renders the button as a link / component. The structural busy class still applies. `loading` implies `disabled`, so an in-flight button-link is guarded too — this is what stops a double-submit from a button rendered as a link.
 - The `tag` prop is **deprecated** in favour of `as` (it remains a non-breaking alias and wins over `as` when both are set).
 - The `loading` prop is also passed as a `themeVariant` (`loading: true`), so themes can target the busy state via a variant if they want a custom look beyond the structural pulse.
 - Themes ship the full color × variant matrix (six colors × five variants). Override individual cells via `app.use(vuecs, { overrides: { elements: { button: { compoundVariants: [...] } } } })` if you need a different shade.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23515,8 +23515,10 @@
             "version": "1.4.0",
             "license": "Apache-2.0",
             "devDependencies": {
+                "@vue/test-utils": "^2.4.11",
                 "@vuecs/core": "^3.5.0",
                 "@vuecs/icon": "^1.1.0",
+                "jsdom": "^29.1.1",
                 "vue": "^3.5.40"
             },
             "engines": {

--- a/packages/button/assets/index.css
+++ b/packages/button/assets/index.css
@@ -19,8 +19,11 @@
  * pointer events on `<button>`, which would normally defeat `cursor: wait`.
  * Browsers honor the cursor on disabled controls anyway when the button
  * itself is the hover target, which is what we want here. Anchors
- * (`as="a"`) ignore `disabled` — consumers rendering a button-as-link
- * must guard navigation themselves.
+ * (`as="a"`) ignore `disabled`, so the component guards their activation
+ * itself (`aria-disabled` + `tabindex="-1"` + a capture-phase click guard,
+ * #1699); the *visual* disabled cue is the theme's job, keyed off
+ * `[aria-disabled="true"]` — same split as the native path, where the cue
+ * comes from the theme's `disabled:` utilities rather than from here.
  */
 .vc-button--busy {
     cursor: wait;

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -40,11 +40,14 @@
     "scripts": {
         "build:js": "tsdown",
         "build:types": "vue-tsc --declaration --emitDeclarationOnly -p tsconfig.build.json",
-        "build": "rimraf dist && npm run build:js && npm run build:types"
+        "build": "rimraf dist && npm run build:js && npm run build:types",
+        "test": "vitest --config test/vitest.config.ts --run"
     },
     "devDependencies": {
+        "@vue/test-utils": "^2.4.11",
         "@vuecs/core": "^3.5.0",
         "@vuecs/icon": "^1.1.0",
+        "jsdom": "^29.1.1",
         "vue": "^3.5.40"
     },
     "peerDependencies": {

--- a/packages/button/src/component.ts
+++ b/packages/button/src/component.ts
@@ -51,9 +51,11 @@ const buttonProps = {
      * Element or component to render as. Pass a string tag (`'a'`, `'div'`)
      * or a component (`RouterLink` / `NuxtLink`) to render a button-styled
      * link / arbitrary element. Native `type` / `disabled` semantics apply
-     * only when this resolves to `'button'`; every other target receives
-     * `aria-disabled` instead. Extra attrs (`to`, `href`, `target`, …)
-     * forward to the rendered element.
+     * only when this resolves to `'button'`; every other target is disabled
+     * via `aria-disabled` + `tabindex="-1"` + a capture-phase click guard
+     * that blocks activation (so a disabled button-link can't navigate).
+     * Extra attrs (`to`, `href`, `target`, …) forward to the rendered
+     * element.
      */
     as: { type: [String, Object, Function] as PropType<string | Component>, default: 'button' },
     /**
@@ -81,6 +83,34 @@ export const VCButton = defineComponent({
         trailing: ButtonSlotProps;
     }>,
     setup(props, { attrs, slots }) {
+        /*
+         * Activation guard for non-native render targets (#1699).
+         *
+         * `disabled` is a `<button>` / form-control attribute — an `<a>`,
+         * a `RouterLink` / `NuxtLink`, or any other `as` target keeps its
+         * own click behaviour, so a disabled button-link still navigated.
+         * `aria-disabled` alone announces the state without enforcing it.
+         *
+         * Registered as `onClickCapture` deliberately. At the event target
+         * the DOM runs the capture-phase listeners before the bubble-phase
+         * ones (dispatch walks the path twice — capturing, then bubbling —
+         * and skips listeners whose capture flag doesn't match the current
+         * phase), so this lands ahead of the target's own `onClick`
+         * regardless of registration order. That matters because fallthrough
+         * attrs are merged *after* a component's own props, i.e. a plain
+         * bubble-phase guard would run second — after RouterLink had
+         * already navigated.
+         *
+         * `stopPropagation()` also suppresses the target's bubble listeners:
+         * the stop-propagation flag is checked once per element per phase,
+         * so the element's own bubbling pass returns early.
+         */
+        const guardDisabledActivation = (event: Event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            event.stopImmediatePropagation();
+        };
+
         // The convenience props (color/variant/size/loading) are merged into
         // themeVariant before resolution so themes can drive slot classes off
         // them via the standard variant system. Getter properties keep this
@@ -190,7 +220,19 @@ export const VCButton = defineComponent({
                     ],
                     ...(isNativeButton ? { type: props.type } : {}),
                     ...(isNativeButton ? { disabled: isDisabled || undefined } : {}),
-                    ...(!isNativeButton && isDisabled ? { 'aria-disabled': 'true' } : {}),
+                    // Non-native targets get the full disabled treatment:
+                    // announced (`aria-disabled`), removed from the tab
+                    // order to match what native `disabled` does, and
+                    // blocked from activating. `tabindex="-1"` keeps the
+                    // element focusable programmatically, so it stays
+                    // reachable for tooltips explaining *why* it's off.
+                    // Enter on a focused link dispatches a click, so the
+                    // capture guard covers keyboard activation too.
+                    ...(!isNativeButton && isDisabled ? {
+                        'aria-disabled': 'true',
+                        tabindex: '-1',
+                        onClickCapture: guardDisabledActivation,
+                    } : {}),
                     // Distinguish loading from plain `disabled` for AT —
                     // both still set `disabled` (loading must block clicks
                     // to prevent double-submit), but `aria-busy` lets screen

--- a/packages/button/test/unit/disabled.spec.ts
+++ b/packages/button/test/unit/disabled.spec.ts
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+import { mount } from '@vue/test-utils';
+import {
+    afterEach,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { defineComponent, h } from 'vue';
+import vuecsButton, { VCButton } from '../../src';
+
+const plugins = [[vuecsButton, {}]] as const;
+const mountButton = (options: Record<string, any> = {}) => mount(VCButton, {
+    ...options,
+    global: { plugins: [...plugins], ...(options.global ?? {}) },
+});
+
+/**
+ * Stand-in for `RouterLink` / `NuxtLink` / `VCLink`: a component target that
+ * performs its own navigation from a plain (bubble-phase) click handler.
+ *
+ * It deliberately does NOT check `event.defaultPrevented` — vue-router's
+ * `guardEvent` does, but NuxtLink's external-href path and arbitrary
+ * consumer components don't. Asserting this stub never fires proves the
+ * guard actually stops the event rather than merely flagging it.
+ */
+const navigations: string[] = [];
+const LinkStub = defineComponent({
+    name: 'LinkStub',
+    props: { to: { type: String, default: '' } },
+    setup(props, { slots }) {
+        return () => h(
+            'a',
+            { href: props.to, onClick: () => { navigations.push(props.to); } },
+            slots.default?.(),
+        );
+    },
+});
+
+describe('<VCButton> disabled — native button', () => {
+    afterEach(() => { document.body.innerHTML = ''; });
+
+    it('uses the native disabled attribute, not the aria/tabindex fallback', () => {
+        const el = mountButton({ props: { disabled: true } }).element as HTMLElement;
+
+        expect(el.tagName).toBe('BUTTON');
+        expect((el as HTMLButtonElement).disabled).toBe(true);
+        // The non-native treatment must not leak onto a real <button>:
+        // `aria-disabled` alongside native `disabled` is redundant, and
+        // tabindex="-1" would be fighting the browser.
+        expect(el.hasAttribute('aria-disabled')).toBe(false);
+        expect(el.hasAttribute('tabindex')).toBe(false);
+    });
+
+    it('is not marked disabled when enabled', () => {
+        const el = mountButton().element as HTMLElement;
+        expect((el as HTMLButtonElement).disabled).toBe(false);
+        expect(el.hasAttribute('aria-disabled')).toBe(false);
+    });
+});
+
+describe('<VCButton> disabled — non-native render targets (#1699)', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+        navigations.length = 0;
+    });
+
+    it('announces and de-tabs a disabled anchor', () => {
+        const el = mountButton({
+            props: { as: 'a', disabled: true },
+            attrs: { href: '/users/1' },
+        }).element as HTMLElement;
+
+        expect(el.tagName).toBe('A');
+        expect(el.getAttribute('aria-disabled')).toBe('true');
+        expect(el.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('blocks activation of a disabled anchor', () => {
+        const el = mountButton({
+            props: { as: 'a', disabled: true },
+            attrs: { href: '/users/1' },
+        }).element as HTMLElement;
+
+        const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+        el.dispatchEvent(event);
+
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('stops the consumer click handler from firing while disabled', () => {
+        const clicks: string[] = [];
+        const el = mountButton({
+            props: { as: 'a', disabled: true },
+            attrs: { href: '/x', onClick: () => { clicks.push('consumer'); } },
+        }).element as HTMLElement;
+
+        el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+        expect(clicks).toEqual([]);
+    });
+
+    it("stops a component target's own navigation handler (RouterLink case)", () => {
+        // The regression this fixes: fallthrough attrs are merged AFTER a
+        // component's own props, so a bubble-phase guard would be registered
+        // second and run after the target had already navigated. The guard is
+        // capture-phase precisely so it wins that race.
+        const wrapper = mountButton({
+            props: { as: LinkStub, disabled: true },
+            attrs: { to: '/users/1' },
+        });
+        const el = wrapper.element as HTMLElement;
+
+        expect(el.tagName).toBe('A');
+        el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+        expect(navigations).toEqual([]);
+    });
+
+    it('lets a component target navigate when enabled', () => {
+        const wrapper = mountButton({
+            props: { as: LinkStub },
+            attrs: { to: '/users/1' },
+        });
+
+        (wrapper.element as HTMLElement)
+            .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+        expect(navigations).toEqual(['/users/1']);
+    });
+
+    it('leaves an enabled anchor untouched', () => {
+        const el = mountButton({
+            props: { as: 'a' },
+            attrs: { href: '/users/1' },
+        }).element as HTMLElement;
+
+        expect(el.hasAttribute('aria-disabled')).toBe(false);
+        expect(el.hasAttribute('tabindex')).toBe(false);
+
+        const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+        el.dispatchEvent(event);
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('guards while loading too (loading implies disabled)', () => {
+        const el = mountButton({
+            props: { as: 'a', loading: true },
+            attrs: { href: '/users/1' },
+        }).element as HTMLElement;
+
+        expect(el.getAttribute('aria-disabled')).toBe('true');
+        expect(el.getAttribute('aria-busy')).toBe('true');
+
+        const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+        el.dispatchEvent(event);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it('drops the guard reactively when disabled flips to false', async () => {
+        const wrapper = mountButton({
+            props: { as: 'a', disabled: true },
+            attrs: { href: '/users/1' },
+        });
+
+        await wrapper.setProps({ disabled: false });
+
+        const el = wrapper.element as HTMLElement;
+        expect(el.hasAttribute('aria-disabled')).toBe(false);
+        expect(el.hasAttribute('tabindex')).toBe(false);
+
+        const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+        el.dispatchEvent(event);
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it('applies to the deprecated `tag` alias as well', () => {
+        const el = mountButton({
+            props: { tag: 'a', disabled: true },
+            attrs: { href: '/users/1' },
+        }).element as HTMLElement;
+
+        expect(el.tagName).toBe('A');
+        expect(el.getAttribute('aria-disabled')).toBe('true');
+    });
+});

--- a/packages/button/test/vitest.config.ts
+++ b/packages/button/test/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'jsdom',
+        include: ['test/unit/**/*.{test,spec}.{js,ts}'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.{ts,tsx,js,jsx}'],
+            thresholds: {
+                branches: 70,
+                functions: 70,
+                lines: 70,
+                statements: 70,
+            },
+        },
+    },
+});

--- a/themes/bootstrap/assets/index.css
+++ b/themes/bootstrap/assets/index.css
@@ -497,6 +497,27 @@
 }
 
 /* ────────────────────────────────────────────────────────────────────────────
+ * @vuecs/button — disabled cue for non-native render targets (#1699).
+ *
+ * Bootstrap dims a disabled button through `.btn:disabled, .btn.disabled`.
+ * Neither matches a `<VCButton :as="…">` that rendered an `<a>` (or a
+ * RouterLink / NuxtLink): `:disabled` is form-elements-only, and `.disabled`
+ * is a class the component can't add from a static theme string. The
+ * component marks those targets with `aria-disabled="true"` instead, so
+ * bridge that attribute onto Bootstrap's own disabled treatment.
+ *
+ * Reuses `--bs-btn-disabled-opacity` rather than hard-coding `.65` so a
+ * consumer restyling the variable keeps both paths in sync. No
+ * `pointer-events: none` (unlike Bootstrap's `.btn.disabled`): it would
+ * suppress `cursor: not-allowed`, and activation is already blocked
+ * JS-side by the component's capture-phase click guard.
+ * ──────────────────────────────────────────────────────────────────────── */
+.vc-button[aria-disabled="true"] {
+    opacity: var(--bs-btn-disabled-opacity, .65);
+    cursor: not-allowed;
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
  * Size: `xs` gap-fill. Bootstrap 5 ships `-sm` / `-lg` size modifiers but
  * nothing below `sm`. The vuecs size axis adds `xs` (one notch under `sm`);
  * these helpers supply it by tightening the relevant BS CSS variables /

--- a/themes/bulma/assets/index.css
+++ b/themes/bulma/assets/index.css
@@ -682,6 +682,28 @@
 }
 
 /* ────────────────────────────────────────────────────────────────────────────
+ * @vuecs/button — disabled cue for non-native render targets (#1699).
+ *
+ * Bulma dims a disabled button via `.button[disabled]`, which only matches
+ * form elements — a `<VCButton :as="…">` that rendered an `<a>` (or a
+ * RouterLink / NuxtLink) never does. The component marks those targets with
+ * `aria-disabled="true"` instead, so bridge that attribute onto Bulma's own
+ * disabled treatment.
+ *
+ * Reuses `--bulma-button-disabled-opacity` rather than hard-coding `.5` so a
+ * consumer restyling the variable keeps both paths in sync. Deliberately
+ * only opacity + cursor: Bulma's `[disabled]` rule also repaints
+ * background / border to the neutral disabled tokens, which would erase the
+ * variant color and make a disabled `is-danger` link indistinguishable from
+ * a disabled `is-primary` one. Activation is already blocked JS-side by the
+ * component's capture-phase click guard.
+ * ──────────────────────────────────────────────────────────────────────── */
+.vc-button[aria-disabled="true"] {
+    opacity: var(--bulma-button-disabled-opacity, .5);
+    cursor: not-allowed;
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
  * Size: `xs` gap-fill. Bulma ships `is-small` / `is-medium` / `is-large` but
  * nothing below `is-small`. The vuecs size axis adds `xs`; these helpers
  * supply it. Bulma controls scale padding in `em`, so a font-size reduction

--- a/themes/tailwind/src/index.ts
+++ b/themes/tailwind/src/index.ts
@@ -331,7 +331,13 @@ export default function tailwindTheme(): Theme {
                     // active color's `-500` shade picked per variant. `gap-2`
                     // (8px) keeps the leading-icon / spinner visually
                     // separated from the label without looking spaced-out.
-                    root: 'inline-flex items-center justify-center gap-2 rounded-md font-medium shadow-sm transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-60',
+                    // The `disabled:` variant only matches the `:disabled`
+                    // pseudo-class, i.e. form elements — an `<a>` rendered
+                    // via `:as` never matches it. `aria-disabled:` mirrors
+                    // the same cue onto the attribute the component sets on
+                    // non-native targets, so a disabled button-link reads as
+                    // disabled (#1699). Same pairing as `pagination.link`.
+                    root: 'inline-flex items-center justify-center gap-2 rounded-md font-medium shadow-sm transition-colors cursor-pointer focus:outline-none focus:ring-2 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-60 aria-disabled:cursor-not-allowed aria-disabled:opacity-60',
                     leading: 'inline-flex shrink-0 items-center',
                     trailing: 'inline-flex shrink-0 items-center',
                     label: '',


### PR DESCRIPTION
Closes #1699

## Problem

`<VCButton :as="…">` rendered onto anything other than a native `button` marked the disabled state with `aria-disabled="true"` and nothing else. That announces the state without enforcing it:

1. **Activation was not blocked** — the `as` target kept its own click behaviour, so a disabled button-link still navigated.
2. **There was no visual cue** — `disabled:cursor-not-allowed disabled:opacity-60` only matches the `:disabled` pseudo-class, i.e. form elements. An `<a>` never matches.

Combined, a permission-guarded row action looked clickable, was clickable, and only got rejected by the target page.

## Changes

**`@vuecs/button`** — non-native targets now also get `tabindex="-1"` (parity with what native `disabled` does to the tab order) and a capture-phase click guard that `preventDefault()` + `stopPropagation()` + `stopImmediatePropagation()`s. Enter on a focused link dispatches a click, so keyboard activation rides the same guard. `loading` implies `disabled`, so an in-flight button-link is guarded too. Native `<button>` is untouched — it keeps the real `disabled` attribute and gets neither `aria-disabled` nor `tabindex`.

**Themes** — the visual cue, keyed off the attribute the component sets:

- `theme-tailwind`: `aria-disabled:cursor-not-allowed aria-disabled:opacity-60` alongside the existing `disabled:` pair (same shape as the existing `pagination.link` entry).
- `theme-bootstrap` / `theme-bulma`: class strings can't carry attribute selectors, so each bridges `.vc-button[aria-disabled="true"]` in `assets/index.css`, reusing the framework's own disabled-opacity variable (`--bs-btn-disabled-opacity` / `--bulma-button-disabled-opacity`) rather than hard-coding a value.

Neither bridge sets `pointer-events: none` (unlike Bootstrap's own `.btn.disabled`) — it would suppress `cursor: not-allowed`, and activation is already blocked JS-side. The Bulma rule also stops short of Bulma's background/border repaint, which would erase the variant color and make a disabled `is-danger` link indistinguishable from a disabled `is-primary` one.

Split into two commits so release-please attributes the button fix and the theme fixes to the right components.

## Why capture-phase (this is load-bearing, not stylistic)

At the event target the DOM invokes capture-phase listeners before bubble-phase ones — dispatch walks the path twice and skips listeners whose capture flag doesn't match the current phase. So the guard wins **regardless of registration order**.

That matters because Vue merges fallthrough attrs *after* a component's own props: a bubble-phase guard on `<VCButton :as="RouterLink">` would be registered second and run only after RouterLink had already navigated. `stopPropagation()` additionally suppresses the target's own bubble listeners, since the stop-propagation flag is checked once per element per phase.

I didn't take this on reasoning alone — see the mutation check below.

## Design notes

- **Rejected: forwarding `disabled` to targets that declare it** (e.g. `VCLink`). It can't cover plain `'a'` / `NuxtLink`, and the component can't know whether an arbitrary `as` target declares the prop. The guard covers all of them.
- **`tabindex="-1"` rather than staying focusable.** ARIA practice often prefers keeping `aria-disabled` controls focusable, but here the sibling native path (`<button disabled>`) is *not* focusable, and consistency between the two render paths of the same component won out. The element stays programmatically focusable, so a tooltip explaining *why* it's disabled still works.
- **No structural CSS for the cue.** A theme-less consumer gets no disabled cue on the native path either (it comes from the theme's `disabled:` utilities), so both paths stay consistent. Documented as an explicit layer split in `.agents/architecture.md`.

## Verification

New test workspace at `packages/button/test/` (the package had none) — 11 specs covering native vs. non-native, anchor + component targets, the enabled path, `loading`, reactive flips, and the deprecated `tag` alias.

- **Mutation-checked the key test.** Flipping the guard to bubble-phase `onClick` fails exactly `stops a component target's own navigation handler (RouterLink case)` (`expected [ '/users/1' ] to deeply equal []`) and nothing else — so the test genuinely pins the ordering rather than passing incidentally. Restored and re-verified green. The stub deliberately does *not* check `event.defaultPrevented` (vue-router's `guardEvent` does; NuxtLink's external-href path and arbitrary consumer components don't), so the assertion proves the event is actually stopped, not merely flagged.
- **Verified the Tailwind variant compiles** rather than assuming: `aria-disabled:cursor-not-allowed` → `.aria-disabled\:cursor-not-allowed[aria-disabled="true"]` under the locked Tailwind 4.3.3, matching the exact attribute *value* the component emits. A silently-dead utility would have reproduced the original bug.
- Full suite green: `nx run-many -t test` → 15/15 projects (the new workspace is auto-discovered by Nx), incl. the three theme `auditTheme` drift specs.
- `npm run lint` → 0 errors.

## Docs

`docs/src/components/button.md` gains a "Disabling a button-styled link" section; three stale claims are corrected, including "you should guard navigation via your own click handler", which this PR makes untrue. The structural-CSS header comment in `packages/button/assets/index.css` said the same thing and is updated. `.agents/architecture.md` documents the layer split and the capture-phase rationale next to the existing form-glyph rule.

Note for the authup side: the `:to="allowed ? … : undefined"` workaround and the local `aria-disabled:*` theme override are both no longer needed once this ships.